### PR TITLE
Remove typos in documentation templates

### DIFF
--- a/metaphactory/core/src/main/java/com/metaphacts/rest/endpoint/RDFGraphStoreEndpoint.java
+++ b/metaphactory/core/src/main/java/com/metaphacts/rest/endpoint/RDFGraphStoreEndpoint.java
@@ -301,7 +301,7 @@ public class RDFGraphStoreEndpoint {
         try(RepositoryConnection con = getRepository(repository).getConnection()){
             con.remove(null,null,null, new Resource[]{uri});
         }catch(Exception e){
-            logger.error("Failed to delete GRPAH \""+ uri +"\": "+e.getMessage());
+            logger.error("Failed to delete GRAPH \""+ uri +"\": "+e.getMessage());
             logger.debug("Details:" , e);
             return Response.serverError().entity(e.getMessage()).build();
         }

--- a/researchspace/app/data/templates/http%3A%2F%2Fhelp.metaphacts.com%2Fresource%2FBasicSystemConfiguration.html
+++ b/researchspace/app/data/templates/http%3A%2F%2Fhelp.metaphacts.com%2Fresource%2FBasicSystemConfiguration.html
@@ -144,7 +144,7 @@
     New user accounts should be created using the respective &nbsp;<semantic-link uri="http://www.metaphacts.com/resource/admin/Security" title="Security">administration page </semantic-link>. The same widget can be used to modify accounts and to re-assign existing roles to users. However, creating new roles and permissions need to be done by modifying the shiro.ini manually (c.f. Basic ACLs section at the bottom of the page). <br/>
 
     <bs-alert bs-style="info"><strong>Please Note:</strong><br/>
-      If no shiro.ini file is configured, the platform will use a a pre-bundled shiro.ini file with default logins and a warning will be printed in the startup logs.
+      If no shiro.ini file is configured, the platform will use a pre-bundled shiro.ini file with default logins and a warning will be printed in the startup logs.
     </bs-alert>
     <h3> Login Protection </h3>
     By default the platform requires authentication for all resources below the root /** URL. <br/>

--- a/researchspace/app/data/templates/http%3A%2F%2Fhelp.metaphacts.com%2Fresource%2FWorkingWithData.html
+++ b/researchspace/app/data/templates/http%3A%2F%2Fhelp.metaphacts.com%2Fresource%2FWorkingWithData.html
@@ -187,11 +187,11 @@ INSERT {
     &lt;JohnDoe&gt; a foaf:Person.
     &lt;JohnDoe&gt; rdfs:label "John Doe".
   }
-  GRPAH&lt;JaneDoeGraph&gt;{
+  GRAPH&lt;JaneDoeGraph&gt;{
     &lt;JaneDoe&gt; a foaf:Person.
     &lt;JaneDoe&gt;  rdfs:label "Jane Doe".
   }
-  GRPAH&lt;RelationshipGraph&gt;{
+  GRPAPH&lt;RelationshipGraph&gt;{
     &lt;JaneDoe&gt; foaf:knows &lt;JohnDoe&gt;.
     &lt;JohnDoe&gt; foaf:knows &lt;JaneDoe&gt;.
   }
@@ -204,7 +204,7 @@ INSERT {
 DELETE { 
   ?s ?p ?o.
 } WHERE {
-  GRPAH&lt;RelationshipGraph&gt;{
+  GRAPH&lt;RelationshipGraph&gt;{
     ?s ?p ?p.
   }
 }


### PR DESCRIPTION
While reading the docs in my local test instance I came across a few typos in the SPARQL examples.