### PR TITLE
fixes #22. Don't url-decode URL path in MProxyServlet.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,6 +237,11 @@ repositories {
 
     // for digilib war
     maven { url 'https://robcast.github.io/digilib-repo/maven-repo' }
+
+    // temp, until new version of smiley-http-proxy-servlet is released
+    maven {
+        url 'https://dl.bintray.com/researchspace/public'
+    }
 }
 
 ext {
@@ -359,7 +364,7 @@ dependencies {
         //pf4j plugin framework
         "ro.fortsoft.pf4j:pf4j:1.3.0",
 
-        "org.mitre.dsmiley.httpproxy:smiley-http-proxy-servlet:1.11",
+        "org.mitre.dsmiley.httpproxy:smiley-http-proxy-servlet:1.12.1",
 
         //JsonPath
         "com.jayway.jsonpath:json-path:2.4.0",

--- a/src/main/java/org/researchspace/servlet/MProxyServlet.java
+++ b/src/main/java/org/researchspace/servlet/MProxyServlet.java
@@ -88,6 +88,24 @@ public class MProxyServlet extends ProxyServlet {
         this.key = key;
     }
 
+    // by default ProxyServlet is using request.pathInfo for path rewriting,
+    // that by default decodes encoded characters, as a result it can happen that
+    // proxy request is different from original request.
+    // So we need to use getRequestURI for this purpose.
+    // see https://github.com/mitre/HTTP-Proxy-Servlet/pull/158
+    @Override
+    protected String rewritePathInfoFromRequest(HttpServletRequest servletRequest) {
+        String path = servletRequest.getContextPath().concat(servletRequest.getServletPath());
+        return servletRequest.getRequestURI().substring(path.length());
+    }
+
+    // No need to encode uri.
+    // We already use encoded requestURI in the rewritePathInfoFromRequest.
+    @Override
+    protected CharSequence encodeUriQuery(CharSequence in, boolean encodePercent) {
+        return in;
+    }
+
     @Override
     protected HttpResponse doExecute(HttpServletRequest servletRequest, HttpServletResponse servletResponse,
             HttpRequest proxyRequest) throws IOException {


### PR DESCRIPTION
Fix depends on unreleased version of HTTP-proxy-Servlet, see fix here https://github.com/mitre/HTTP-Proxy-Servlet/pull/158.
Changes to build files are temporary to allow usage of locally build HTTP-proxy-Servlet dependency.