### PR TITLE
Fixes #19. Add order to Field Definitions.

### DIFF
--- a/metaphacts-platform/web/src/main/api/rdf/vocabularies/field.ts
+++ b/metaphacts-platform/web/src/main/api/rdf/vocabularies/field.ts
@@ -36,6 +36,7 @@ module field {
   export const range = iri('range');
   export const min_occurs = iri('minOccurs');
   export const max_occurs = iri('maxOccurs');
+  export const order = iri('order');
   export const default_value = iri('defaultValue');
   export const valueset_pattern = iri('valueSetPattern');
   export const autosuggestion_pattern = iri('autosuggestionPattern');

--- a/metaphacts-platform/web/src/main/api/services/ldp-field.ts
+++ b/metaphacts-platform/web/src/main/api/services/ldp-field.ts
@@ -50,6 +50,7 @@ function deserialize(fieldIri: Rdf.Iri, graph: Rdf.Graph): FieldDefinitionProp {
     xsdDatatype: [field.xsd_datatype],
     minOccurs: [field.min_occurs],
     maxOccurs: [field.max_occurs],
+    order: [field.order],
     selectPattern: [field.select_pattern, sp.text],
     deletePattern: [field.delete_pattern, sp.text],
     askPattern: [field.ask_pattern, sp.text],

--- a/metaphacts-platform/web/src/main/components/forms/FieldDefinition.ts
+++ b/metaphacts-platform/web/src/main/components/forms/FieldDefinition.ts
@@ -76,6 +76,10 @@ export interface FieldDefinition {
    */
   maxOccurs: number;
   /**
+   * Number used for ordering Field Definition.
+   */
+  order: number;
+  /**
    * List of default values assigned to field.
    */
   defaultValues: ReadonlyArray<string>;
@@ -160,6 +164,7 @@ export interface FieldDefinitionProp {
   range?: string | Rdf.Iri | ReadonlyArray<string | Rdf.Iri>;
   minOccurs?: number | 'unbound';
   maxOccurs?: number | 'unbound';
+  order?: number | 'unbound';
   defaultValues?: ReadonlyArray<string>;
   selectPattern?: string;
   askPattern?: string;
@@ -213,6 +218,12 @@ export function normalizeFieldDefinition(
     definition.maxOccurs = Infinity;
   } else {
     definition.maxOccurs = parseInt(definition.maxOccurs, 10);
+  }
+
+  if (!definition.order || definition.order === 'unbound') {
+    definition.order = 0;
+  } else {
+    definition.order = parseInt(definition.order, 10);
   }
 
   if (typeof definition.domain === 'string') {

--- a/metaphacts-platform/web/src/main/components/forms/field-editor/FieldEditorComponent.ts
+++ b/metaphacts-platform/web/src/main/components/forms/field-editor/FieldEditorComponent.ts
@@ -129,6 +129,7 @@ class FieldEditorComponent extends Component<Props, State> {
       range: [] as Value[],
       min: Nothing<Value>(),
       max: Nothing<Value>(),
+      order: Nothing<Value>(),
       defaults: [] as Value[],
       testSubject: Nothing<Value>(),
       insertPattern: Nothing<Value>(),
@@ -355,6 +356,23 @@ class FieldEditorComponent extends Component<Props, State> {
           placeholder: 'Any positive number from 1 to n. \"unbound\" for unlimited.',
           onChange: e => this.updateValues({max: getFormValue(e)}, Validation.validateMax),
           value: this.state.max.map(v => v.value).getOrElse(undefined),
+        }),
+      }),
+      row({
+        label: 'Order',
+        expanded: this.state.order.isJust,
+        onExpand: () => this.updateValues(
+          {order: Just({value: '1'})},
+          Validation.validateOrder
+        ),
+        onCollapse: () => this.updateValues({order: nothing}),
+        error: this.state.order.map(v => v.error).getOrElse(undefined),
+        element: input({
+          className: block('order-input').toString(),
+          type: 'text',
+          placeholder: 'Any positive number greater than 0.',
+          onChange: e => this.updateValues({order: getFormValue(e)}, Validation.validateOrder),
+          value: this.state.order.map(v => v.value).getOrElse(undefined),
         }),
       }),
       this.renderMultipleValuesInput({

--- a/metaphacts-platform/web/src/main/components/forms/field-editor/FieldEditorState.ts
+++ b/metaphacts-platform/web/src/main/components/forms/field-editor/FieldEditorState.ts
@@ -41,6 +41,7 @@ export interface State {
   range?: ReadonlyArray<Value>;
   min?: Data.Maybe<Value>;
   max?: Data.Maybe<Value>;
+  order?: Data.Maybe<Value>;
   defaults?: ReadonlyArray<Value>;
   testSubject?: Data.Maybe<Value>;
 
@@ -143,6 +144,7 @@ export namespace ValidatedTreeConfig {
  * @param  {string} xsdtype - xsdDatatype full IRI string
  * @param  {string} min - minOccurs
  * @param  {string} max - maxOccurs
+ * @param  {string} order - order
  * @param  {string} defaults - defaultValues
  * @param  {string} selectPattern - SPARQL selectPattern string
  * @param  {string} del - SPARQL deletePattern string
@@ -162,6 +164,7 @@ export function createFieldDefinitionGraph(properties: {
   range: ReadonlyArray<string>;
   min: string | undefined;
   max: string | undefined;
+  order: string | undefined;
   defaultValues: ReadonlyArray<string>;
   selectPattern: string | undefined;
   insertPattern: string;
@@ -173,7 +176,7 @@ export function createFieldDefinitionGraph(properties: {
   testSubject: string | undefined;
 }): Rdf.Graph {
   const {
-    id, label, description, domain, xsdDatatype, range, min, max, defaultValues, testSubject,
+    id, label, description, domain, xsdDatatype, range, min, max, order, defaultValues, testSubject,
     selectPattern, insertPattern, deletePattern, askPattern, valueSetPattern, autosuggestionPattern,
     categories, treePatterns,
   } = properties;
@@ -210,6 +213,9 @@ export function createFieldDefinitionGraph(properties: {
   }
   if (max) {
     triples.push(Rdf.triple(baseIri, field.max_occurs, Rdf.literal(max, xsd._string) ));
+  }
+  if (order) {
+    triples.push(Rdf.triple(baseIri, field.order, Rdf.literal(order, xsd._string) ));
   }
   for (const value of defaultValues) {
     triples.push(Rdf.triple(baseIri, field.default_value, Rdf.literal(value, xsd._string)));
@@ -318,6 +324,7 @@ export function getFieldDefitionState(fieldIri: Rdf.Iri): Kefir.Property<State> 
         range,
         min: fromNullable(fieldDef.minOccurs as string).map(createValue),
         max: fromNullable(fieldDef.maxOccurs as string).map(createValue),
+        order: fromNullable(fieldDef.order as string).map(createValue),
         defaults: fieldDef.defaultValues.map(createValue) as ReadonlyArray<Value>,
         testSubject: fromNullable(fieldDef.testSubject).map(createValue),
         insertPattern: fromNullable(fieldDef.insertPattern).map(createValue),
@@ -334,12 +341,12 @@ export function getFieldDefitionState(fieldIri: Rdf.Iri): Kefir.Property<State> 
 
 export function unwrapState(state: State) {
   const {
-    id, label, description, categories, domain, xsdDatatype, range, min, max, defaults, testSubject,
-    selectPattern, insertPattern, deletePattern, askPattern, valueSetPattern, autosuggestionPattern,
-    treePatterns,
+    id, label, description, categories, domain, xsdDatatype, range, min, max, order, defaults,
+    testSubject, selectPattern, insertPattern, deletePattern, askPattern, valueSetPattern,
+    autosuggestionPattern, treePatterns,
   } = state;
   const fields = {
-    id, description, xsdDatatype, min, max, testSubject, selectPattern,
+    id, description, xsdDatatype, min, max, order, testSubject, selectPattern,
     insertPattern, deletePattern, askPattern, valueSetPattern, autosuggestionPattern,
   };
   type Unwrapped = { [K in keyof typeof fields]: string | undefined } & {

--- a/metaphacts-platform/web/src/main/components/forms/field-editor/Validation.ts
+++ b/metaphacts-platform/web/src/main/components/forms/field-editor/Validation.ts
@@ -35,7 +35,7 @@ export function collectStateErrors(state: State): Error[] {
 
   const values = [
     state.id, state.description, state.xsdDatatype,
-    state.min, state.max, state.testSubject, state.selectPattern, state.insertPattern,
+    state.min, state.max, state.order, state.testSubject, state.selectPattern, state.insertPattern,
     state.deletePattern, state.askPattern, state.valueSetPattern, state.autosuggestionPattern,
   ];
   for (const value of values) {
@@ -131,6 +131,21 @@ export function validateMax(v: string): Value {
   }
 }
 
+/**
+ * Returns a valid order observable value if value is >= 0 or unbound,
+ * an error observable otherwise.
+ */
+export function validateOrder(v: string): Value {
+  const num = Number(v);
+  if (Number.isInteger(num) && num >= 0 ) {
+    return {value: v};
+  } else {
+    return {
+      value: v,
+      error: new Error('Order must be >= 0'),
+    };
+  }
+}
 /**
  * Returns a valid value (SPARQL insert) observable if supplied queryString is a valid
  * SPARQL INSERT query and fulfills all constraints e.g. containing ?value ?subject.

--- a/metaphacts-platform/web/src/test/common/ts/forms/FieldCommonTypes.test.ts
+++ b/metaphacts-platform/web/src/test/common/ts/forms/FieldCommonTypes.test.ts
@@ -47,6 +47,7 @@ describe('FieldCommonTypes', () => {
       xsdDatatype: Rdf.iri('test'),
       minOccurs: 1,
       maxOccurs: 2,
+      order: 0,
       defaultValues: [],
       selectPattern: '',
       constraints: [
@@ -70,6 +71,7 @@ describe('FieldCommonTypes', () => {
       id: 'test',
       minOccurs: 0,
       maxOccurs: Infinity,
+      order: 0,
       defaultValues: [],
       categories: [],
       constraints: [],


### PR DESCRIPTION
This pull request adds the order property to Field Definitions.

Order is an RDF predicate, and it is stored in the field namespace. We have also added another form control that accepts numeric orders. The textbox has validation as well, users can only write 0s or positive integers.


