### PR TITLE
 Remove circular dependencies in semantic-form component.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,10 @@ module.exports = {
 
         // explicit any is sometimes OK, implicit any is not OK
         // we can re-enable this rule later when codebase is a bit more clean
-        "@typescript-eslint/no-explicit-any": "off"
+        "@typescript-eslint/no-explicit-any": "off",
+
+        // quite useless and confusing, because typescript is doing scope checks anyway
+        "@typescript-eslint/no-use-before-define": "off"
     },
     settings: {
         react: {

--- a/src/main/web/components/forms/auto-form/FormGenerator.tsx
+++ b/src/main/web/components/forms/auto-form/FormGenerator.tsx
@@ -20,7 +20,14 @@ import * as React from 'react';
 
 import { vocabularies } from 'platform/api/rdf';
 
-import * as Inputs from '../inputs';
+import { SingleValueInputProps } from '../inputs/SingleValueInput';
+import { MultipleValuesProps } from '../inputs/MultipleValuesInput';
+import { AutocompleteInput } from '../inputs/AutocompleteInput';
+import { TreePickerInput } from '../inputs/TreePickerInput';
+import { SelectInput } from '../inputs/SelectInput';
+import { DatePickerInput } from '../inputs/DatePickerInput';
+import { CheckboxInput } from '../inputs/CheckboxInput';
+import { PlainTextInput } from '../inputs/PlainTextInput';
 import { FormErrors } from '../static';
 import { FieldDefinition } from '../FieldDefinition';
 
@@ -41,7 +48,7 @@ export interface InputOverrideTarget {
   datatype?: string;
 }
 
-export type FieldInputElement = React.ReactElement<Inputs.SingleValueInputProps | Inputs.MultipleValuesProps>;
+export type FieldInputElement = React.ReactElement<SingleValueInputProps | MultipleValuesProps>;
 
 export function generateFormFromFields(params: GenerateFormFromFieldsParams): JSX.Element[] {
   const content: JSX.Element[] = [];
@@ -76,15 +83,15 @@ export function generateFormFromFields(params: GenerateFormFromFieldsParams): JS
 
 function generateInputForField(field: FieldDefinition): JSX.Element {
   if (field.treePatterns) {
-    return <Inputs.TreePickerInput for={field.id} />;
+    return <TreePickerInput for={field.id} />;
   }
 
   if (field.autosuggestionPattern) {
-    return <Inputs.AutocompleteInput for={field.id} />;
+    return <AutocompleteInput for={field.id} />;
   }
 
   if (field.valueSetPattern) {
-    return <Inputs.SelectInput for={field.id} />;
+    return <SelectInput for={field.id} />;
   }
 
   if (field.xsdDatatype) {
@@ -92,17 +99,17 @@ function generateInputForField(field: FieldDefinition): JSX.Element {
       case xsd.date.value:
       case xsd.time.value:
       case xsd.dateTime.value: {
-        return <Inputs.DatePickerInput for={field.id} />;
+        return <DatePickerInput for={field.id} />;
       }
       case xsd.boolean.value: {
-        return <Inputs.CheckboxInput for={field.id} />;
+        return <CheckboxInput for={field.id} />;
       }
       case xsd._string.value:
       case rdf.langString.value: {
-        return <Inputs.PlainTextInput for={field.id} />;
+        return <PlainTextInput for={field.id} />;
       }
     }
   }
 
-  return <Inputs.PlainTextInput for={field.id} />;
+  return <PlainTextInput for={field.id} />;
 }

--- a/src/main/web/components/forms/inputs/FormSwitch.tsx
+++ b/src/main/web/components/forms/inputs/FormSwitch.tsx
@@ -20,15 +20,16 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import { Cancellation } from 'platform/api/async';
 import { FieldDefinition, normalizeFieldDefinition } from '../FieldDefinition';
+
 import {
   SingleValueInput,
   SingleValueInputProps,
   SingleValueHandler,
   SingleValueHandlerProps,
-  CompositeInput,
-  CompositeInputProps,
-} from '../inputs';
-import { componentHasType, componentDisplayName } from 'platform/components/utils';
+} from '../inputs/SingleValueInput';
+import { CompositeInput, CompositeInputProps } from '../inputs/CompositeInput';
+
+import { componentHasType } from 'platform/components/utils';
 import FormSwitchCase, { FormSwitchCaseProps } from './FormSwitchCase';
 import { FieldValue, DataState, CompositeValue, EmptyValue, ErrorKind } from '../FieldValues';
 import HiddenInput, { HiddenInputProps } from '../inputs/HiddenInput';


### PR DESCRIPTION
Circular dependencies were the cause of some issues with webpack build, where the same code was included many times into different bundles. Which sometime caused some weird bugs in semantic forms and knowledge maps.

Also along the way disable `no-use-before-define` in es-lint, it doesn't add any value because typescript is doing proper scope checking anyway. 