### PR TITLE
semantic-form improvements.

### DIFF
--- a/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FSemanticForm.html
+++ b/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FSemanticForm.html
@@ -221,6 +221,7 @@
       <dt><code>new-subject-template: string</code></dt>
       <dd>
         <p>IRI template to customize subject generation in the "creating a new instance" form mode.</p>
+        <p>If <code>new-subject-template</code> is relative IRI then it will be resolved against <code>Default</code> namespace. </p>
         <p>The template allows to reference form values, e.g if there is field with ID equal to <code>ABC</code>
         that uniquely identify record, we can specify subject template as
         <code>http://example.com/records/{{ABC}}</code>, where ABC will be substituted with value of the field <code>ABC</code>.</p>

--- a/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FSemanticForm.html
+++ b/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FSemanticForm.html
@@ -226,6 +226,7 @@
         that uniquely identify record, we can specify subject template as
         <code>http://example.com/records/{{ABC}}</code>, where ABC will be substituted with value of the field <code>ABC</code>.</p>
         <p><code>{{UUID}}</code> placeholder allows to substitute a random UUID.<p>
+        <p><code>{{FIELD_VALUE_LOCAL_NAME fieldName}}</code> placeholder allows to use field value local name. Useful together with <code>type</code> field in auto-generated forms to create IRIs with type information, e.g <code>http://localhost:10214/resource/E21_Person/b517d013-242c-4610-9155-48ce891ffef6</code></p>
       </dd>
       <dt id="prop-browser-persistence"><code>browser-persistence: boolean</code></dt>
       <dd>

--- a/src/main/web/api/sparql/SparqlUtil.ts
+++ b/src/main/web/api/sparql/SparqlUtil.ts
@@ -23,7 +23,6 @@ import * as SparqlJs from 'sparqljs';
 
 import { Rdf } from 'platform/api/rdf';
 import { getCurrentResource } from 'platform/api/navigation';
-import { ConfigHolder } from 'platform/api/services/config-holder';
 
 import { isQuery, isTerm, isIri } from './TypeGuards';
 
@@ -31,9 +30,11 @@ import { isQuery, isTerm, isIri } from './TypeGuards';
 // to initialize it explicitly in all tests, but the expectation is that
 // in production run init is called on the system startup
 let Parser: SparqlJs.SparqlParser = new SparqlJs.Parser();
-export let RegisteredPrefixes: { [key: string]: string } = {};
+export let RegisteredPrefixes: {
+  Default: string; Admin: string; Help: string;
+} & { [key: string]: string };
 export function init(registeredPrefixes: { [key: string]: string }) {
-  RegisteredPrefixes = registeredPrefixes;
+  RegisteredPrefixes = registeredPrefixes as typeof RegisteredPrefixes;
   Parser = new SparqlJs.Parser(registeredPrefixes);
 }
 

--- a/src/main/web/components/forms/FormModel.ts
+++ b/src/main/web/components/forms/FormModel.ts
@@ -24,6 +24,7 @@ import * as URI from 'urijs';
 import { escapeRegExp } from 'lodash';
 
 import { Rdf, XsdDataTypeValidation, vocabularies } from 'platform/api/rdf';
+import { SparqlUtil } from 'platform/api/sparql';
 
 import { FieldDefinition } from './FieldDefinition';
 import { FieldValue, FieldError, ErrorKind, CompositeValue, FieldState, AtomicValue } from './FieldValues';
@@ -57,12 +58,13 @@ export function generateSubjectByTemplate(
   });
 
   const isAbsoluteUri = URI(subject).scheme();
-  if (isAbsoluteUri || !ownerSubject) {
+  if (isAbsoluteUri) {
     return Rdf.iri(subject);
   }
 
-  const combinedPath = URI.joinPaths(ownerSubject.value, subject).toString();
-  return Rdf.iri(URI(ownerSubject.value).pathname(combinedPath).toString());
+  const base = ownerSubject ? ownerSubject.value : SparqlUtil.RegisteredPrefixes.Default;
+  const combinedPath = URI.joinPaths(base, subject).toString();
+  return Rdf.iri(URI(base).pathname(combinedPath).toString());
 }
 
 export function wasIriGeneratedByTemplate(


### PR DESCRIPTION
## Resolve relative `new-subject-template` with `Default` namespace.

Together with #65 this change helps to create forms that produce resolvable IRIs out of the box.
Also with relative `new-subject-template` form configuration can be easily made transferable between different deployments.

**Example.**
`Default = http://localhost:10214/resource/`. `semantic-form` with `new-subject-template='/person/{{UUID}}'` parameter, will create new resource with IRI like `http://localhost:10214/resource/person/123e4567-e89b-12d3-a456-426655440000`.

## Local name value helper for new-subject-template.
`{{FIELD_VALUE_LOCAL_NAME fieldName}}` placeholder allows to use field value local name.

Useful together with `type` field in auto-generated forms to create IRIs with type information.

**Example**
If we have a `type` field in the `semantic-form` and following `new-subject-template` configuration `/{{FIELD_VALUE_LOCAL_NAME type}}/{{UUID}}`, we can get slightly better IRI for new resources.
E.g. for `type` with value `http://www.cidoc-crm.org/cidoc-crm/E21_Person` we get new IRI like `http://localhost:10214/resource/E21_Person/b517d013-242c-4610-9155-48ce891ffef6`
