### PR TITLE
Change TemplateItem to properly work without a single root.

### DIFF
--- a/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FSemanticQuery.html
+++ b/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FSemanticQuery.html
@@ -113,7 +113,6 @@
   template='{{> template}}'
 >
   <template id='template'>
-    <div>
       <b>My List:</b>
       <ul>
         {{#each bindings}}
@@ -125,7 +124,6 @@
           </li>
         {{/each}}
       </ul>
-    </div>
   </template>
 </semantic-query>
 ]]>

--- a/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FSemanticTimeline.html
+++ b/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FSemanticTimeline.html
@@ -39,10 +39,8 @@
                              tuple-template='{{> template}}'
                              tuple-template-height=42>
             <template id='template'>
-              <div>
                 <b>{{subject.value}}</b>
                 <div>{{start.value}} - {{end.value}}</div>
-              </div>
             </template>
           </semantic-timeline>
         </mp-code-example>

--- a/src/main/web/components/dashboard/DashboardItem.tsx
+++ b/src/main/web/components/dashboard/DashboardItem.tsx
@@ -39,7 +39,6 @@ export interface DashboardViewConfig {
   id: string;
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> which is used to render the view when users drop a resource on it. Expects <code>{{iri}}</code> and <code>{{dashboardId}}</code> (or a variable specified in <code>frameVariable</code>) as context variables.
-   * **The template MUST have a single HTML root element.**
    */
   template: string;
   /**
@@ -73,12 +72,10 @@ export interface DashboardViewConfig {
   frameVariable?: string;
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> for the label of a frame, it is used in the frame controller. By default the <code><mp-label></mp-label></code> component is used. Expects <code>{{iri}}</code> and <code>{{dashboardId}}</code> (or a variable specified in <code>frameVariable</code>) as context variables.
-   * **The template MUST have a single HTML root element.**
    */
   itemLabelTemplate?: string;
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> for the body of a frame item. If it is specified, it will applied to the contents of the frame item displayed as dropdown of the frame controller. Expects <code>{{iri}}</code> and <code>{{dashboardId}}</code> (or a variable specified in <code>frameVariable</code>) as context variables.
-   * **The template MUST have a single HTML root element.**
    */
   itemBodyTemplate?: string;
 }

--- a/src/main/web/components/events/EventTargetTemplateRender.tsx
+++ b/src/main/web/components/events/EventTargetTemplateRender.tsx
@@ -30,7 +30,6 @@ export interface EventTargetTemplateRenderConfig {
   id: string;
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> that will be rendered with data passed as context variables.
-   * **The template MUST have a single HTML root element.**
    */
   template: string;
 }

--- a/src/main/web/components/semantic/map/SemanticMap.ts
+++ b/src/main/web/components/semantic/map/SemanticMap.ts
@@ -82,13 +82,11 @@ export interface SemanticMapConfig {
 
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> for marker popup. By default shows `<semantic-link>` to the resource with a short textual description
-   * **The template MUST have a single HTML root element.**
    */
   tupleTemplate?: string;
 
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> which is applied when query returns no results
-   * **The template MUST have a single HTML root element.**
    */
   noResultTemplate?: string;
 

--- a/src/main/web/components/semantic/query/SemanticQuery.ts
+++ b/src/main/web/components/semantic/query/SemanticQuery.ts
@@ -37,7 +37,6 @@ export interface SemanticQueryConfig {
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link>, that gets a <a target='_blank' href='https://www.w3.org/TR/sparql11-results-json/#select-results'>bindings</a> object injected as template context i.e. the result binding to iterate over. [each helper](http://handlebarsjs.com/builtin_helpers.html#iteration) can be used to iterate over the bindings.
    * The template will only be rendered if and only if the result is not empty, so that one does not need to have additional if expressions around the component in order to hide it, for example, a list header if actually no result are to be displayed.
-   * **The template MUST have a single HTML root element.**
    * **Example:** `My Result: {{#each bindings}}{{bindingName.value}}{{/each}}` .
    * **Default:** If no template is provided, all tuples for the first projection variable will we rendered as a comma-separated list.
    */
@@ -45,7 +44,6 @@ export interface SemanticQueryConfig {
 
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> which is applied when query returns no results.
-   * **The template MUST have a single HTML root element.**
    */
   noResultTemplate?: string;
 

--- a/src/main/web/components/semantic/table/SemanticTable.ts
+++ b/src/main/web/components/semantic/table/SemanticTable.ts
@@ -92,7 +92,6 @@ interface BaseConfig extends ControlledProps {
 
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> which is applied when the query returns no results
-   * **The template MUST have a single HTML root element.**
    */
   noResultTemplate?: string;
 
@@ -150,7 +149,6 @@ interface RowConfig extends BaseConfig {
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> for the whole table row. Can be used to have visualizations different from the standard, e.g grid of thumbnails.
    * The template has access to all projection variables for a single result tuple
-   * **The template MUST have a single HTML root element.**
    */
   tupleTemplate: string;
 }

--- a/src/main/web/components/semantic/table/Table.ts
+++ b/src/main/web/components/semantic/table/Table.ts
@@ -77,7 +77,6 @@ export interface ColumnConfiguration {
    * Custom cell visualization <semantic-link
    *   uri='http://help.metaphacts.com/resource/FrontendTemplating'>template</semantic-link>.
    * Template has access to all projection variables for a single result tuple.
-   * **The template MUST have a single HTML root element.**
    */
   cellTemplate?: string;
 }

--- a/src/main/web/components/semantic/tree/SemanticTree.ts
+++ b/src/main/web/components/semantic/tree/SemanticTree.ts
@@ -76,14 +76,12 @@ export interface SemanticTreeConfig {
    * which is used to render every tree node. Template has access to all projection
    * variables for a single result tuple.
    * By default `<semantic-link>` component is used for node visualization.
-   * **The template MUST have a single HTML root element.**
    */
   tupleTemplate?: string;
 
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link>
    * which is applied when the query returns no results.
-   * **The template MUST have a single HTML root element.**
    */
   noResultTemplate?: string;
 

--- a/src/main/web/components/timeline/SemanticTimeline.tsx
+++ b/src/main/web/components/timeline/SemanticTimeline.tsx
@@ -222,7 +222,6 @@ export interface TimelineOptions {
   groupOrder?: string;
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> for the groups contents.
-   * **The template MUST have a single HTML root element.**
    * The variables that available in the template are following:
    * <pre>
    * {
@@ -472,12 +471,10 @@ interface SemanticTimelineConfigBase {
   query: string;
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> which is applied when query returns no results.
-   * **The template MUST have a single HTML root element.**
    */
   noResultTemplate?: string;
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> for the items contents.
-   * **The template MUST have a single HTML root element.**
    * @default {{start.value}} - {{end.value}}
    */
   tupleTemplate?: string;
@@ -487,7 +484,6 @@ interface SemanticTimelineConfigBase {
   tupleTemplateHeight?: number | string;
   /**
    * <semantic-link uri='http://help.metaphacts.com/resource/FrontendTemplating'>Template</semantic-link> of a loading which is applied when items are drawn.
-   * **The template MUST have a single HTML root element.**
    */
   loadingTemplate?: string;
   /**


### PR DESCRIPTION
Previously many components that accept template as a parameter expected that the template should have a single root node.
That was because in React before v16 it was not possible to return array from render method.
But since React 16 it is now perfectly valid to do this.

Affects `semantic-table`, `semantic-query`, `semantic-tree`, `semantic-map`, `semantic-timeline`.

As an example see changes to `SemanticQuery` and `SemanticTimeline` help pages.

Signed-off-by: Artem Kozlov <artem@rem.sh>