### PR TITLE
Pull git storage on startup.

### DIFF
--- a/src/main/java/org/researchspace/services/storage/git/GitStorage.java
+++ b/src/main/java/org/researchspace/services/storage/git/GitStorage.java
@@ -151,6 +151,11 @@ public class GitStorage implements ObjectStorage {
                 logger.info("Checking out branch '" + config.getBranch() + "' at " + config.getLocalPath());
                 git.checkout().setName(config.getBranch()).call();
             }
+
+            if (config.getBranch() != null) {
+                // pull changes from remote on startup
+                git.pull().setRemote("origin").setRemoteBranchName(config.getBranch()).call();
+            }
         } catch (GitAPIException | IOException e) {
             repository.close();
             throw e;


### PR DESCRIPTION
Quite convenient when developing templates locally and deploying on some remote server, to just restart platform instance on the server to get the latest changes.

Signed-off-by: Artem Kozlov <artem@rem.sh>