### PR TITLE
Experimental. Suport for target named graph in data authoring.

### DIFF
--- a/src/main/web/components/3-rd-party/ontodia/Ontodia.ts
+++ b/src/main/web/components/3-rd-party/ontodia/Ontodia.ts
@@ -370,12 +370,7 @@ const DEFAULT_FACTORY = {
     workspace.zoomToFit();
   },
   getPersistence: (mode) => {
-    switch (mode.type) {
-      case 'form':
-        return new FormBasedPersistence(mode);
-      default:
-        throw new Error(`Ontodia graph persistence mode is not supported: "${mode.type}"`);
-    }
+    return new FormBasedPersistence(mode);
   },
 };
 

--- a/src/main/web/components/forms/persistence/PersistenceUtils.ts
+++ b/src/main/web/components/forms/persistence/PersistenceUtils.ts
@@ -38,3 +38,16 @@ export function parseQueryStringAsUpdateOperation(queryString: string | undefine
     throw new Error('Specified deletePattern or insertPattern is not an update query.');
   }
 }
+
+/**
+ * Add WITH clause to UPDATE query to execute it on specific named graph.
+ */
+export function withNamedGraph(
+  query: SparqlJs.Update, targetGraphIri?: string
+): SparqlJs.Update {
+  if (targetGraphIri) {
+    // graph property on update opertian is missing is SparqlJs d.ts file
+    query.updates.forEach(u => u['graph'] = targetGraphIri);
+  }
+  return query;
+}

--- a/src/main/web/components/forms/persistence/SparqlPersistence.ts
+++ b/src/main/web/components/forms/persistence/SparqlPersistence.ts
@@ -31,18 +31,24 @@ import { TriplestorePersistence } from './TriplestorePersistence';
 export interface SparqlPersistenceConfig {
   type?: 'sparql';
   repository?: string;
+  targetGraphIri?: string;
+  targetInsertGraphIri?: string;
 }
 
 export class SparqlPersistence implements TriplestorePersistence {
   constructor(private config: SparqlPersistenceConfig = {}) {}
 
   persist(initialModel: CompositeValue | EmptyValue, currentModel: CompositeValue | EmptyValue): Kefir.Property<void> {
-    const updateQueries = RawSparqlPersistence.createFormUpdateQueries(initialModel, currentModel);
+    const {repository = 'default', targetGraphIri, targetInsertGraphIri} = this.config;
+    const updateQueries =
+      RawSparqlPersistence.createFormUpdateQueries(
+        initialModel, currentModel, targetGraphIri, targetInsertGraphIri
+      );
+
     const stringQueries = Immutable.List<SparqlJs.ConstructQuery>(updateQueries)
       .map(SparqlUtil.serializeQuery)
       .flatten();
 
-    const { repository = 'default' } = this.config;
     const req = request
       .post('/form-persistence/sparql')
       .type('application/json')


### PR DESCRIPTION
Experimental support for `sparql` mode for `ontodia` authoring.

Also adds the ability to specify target named graph for all inserts or restrict all delete and insert operations to a specific named graph, for both `ontodia` and `semantic-form`

Signed-off-by: Artem Kozlov <artem@rem.sh>