### PR TITLE
Improve handling of anonymous user.

### DIFF
--- a/src/main/java/org/researchspace/config/NamespaceRegistry.java
+++ b/src/main/java/org/researchspace/config/NamespaceRegistry.java
@@ -22,14 +22,20 @@ package org.researchspace.config;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.util.*;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import java.net.URLEncoder;
-
-import com.google.common.collect.*;
+import javax.inject.Inject;
 
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
@@ -44,13 +50,21 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.researchspace.api.sparql.SparqlUtil;
-import org.researchspace.security.AnonymousUserFilter;
+import org.researchspace.security.PlatformSecurityManager;
 import org.researchspace.security.SecurityService;
-import org.researchspace.services.storage.api.*;
+import org.researchspace.services.storage.api.ObjectKind;
+import org.researchspace.services.storage.api.ObjectRecord;
+import org.researchspace.services.storage.api.ObjectStorage;
+import org.researchspace.services.storage.api.PlatformStorage;
+import org.researchspace.services.storage.api.StoragePath;
 import org.researchspace.templates.TemplateUtil;
 import org.researchspace.vocabulary.PLATFORM;
 
-import javax.inject.Inject;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 /**
  * @author Michael Schmidt <ms@metaphacts.com>
@@ -387,7 +401,8 @@ public class NamespaceRegistry {
     }
 
     public IRI getUserIRI(String userName) {
-        if (userName.equals(AnonymousUserFilter.ANONYMOUS_PRINCIPAL)) {
+        if (userName.equals(PlatformSecurityManager.ANONYMOUS_PRINCIPAL)
+                || userName.equals(PlatformSecurityManager.ANONYMOUS_WRITER_PRINCIPAL)) {
             return PLATFORM.ANONYMOUS_USER_INDIVIDUAL;
         } else {
             try {

--- a/src/main/java/org/researchspace/rest/endpoint/SecurityEndpoint.java
+++ b/src/main/java/org/researchspace/rest/endpoint/SecurityEndpoint.java
@@ -62,17 +62,16 @@ import org.researchspace.repository.MpRepositoryProvider;
 import org.researchspace.repository.RepositoryManager;
 import org.researchspace.rest.feature.CacheControl.MaxAgeCache;
 import org.researchspace.rest.feature.CacheControl.NoCache;
-import org.researchspace.security.AnonymousUserFilter;
 import org.researchspace.security.LDAPRealm;
-import org.researchspace.security.PlatformSecurityManager;
 import org.researchspace.security.PermissionUtil;
-import org.researchspace.security.PermissionsDocGroup;
-import org.researchspace.security.PermissionsParameterInfo;
-import org.researchspace.security.SecurityService;
-import org.researchspace.security.ShiroTextRealm;
 import org.researchspace.security.Permissions.ACCOUNTS;
 import org.researchspace.security.Permissions.PERMISSIONS;
 import org.researchspace.security.Permissions.ROLES;
+import org.researchspace.security.PermissionsDocGroup;
+import org.researchspace.security.PermissionsParameterInfo;
+import org.researchspace.security.PlatformSecurityManager;
+import org.researchspace.security.SecurityService;
+import org.researchspace.security.ShiroTextRealm;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.google.common.collect.Lists;
@@ -113,7 +112,7 @@ public class SecurityEndpoint {
         public String userURI = ns.getUserIRI().stringValue();
         public boolean isAuthenticated = SecurityUtils.getSubject().isAuthenticated();
         public boolean isAnonymous = SecurityUtils.getSubject().getPrincipal().toString()
-                .equals(AnonymousUserFilter.ANONYMOUS_PRINCIPAL);
+                .equals(PlatformSecurityManager.ANONYMOUS_PRINCIPAL);
 
     }
 

--- a/src/main/resources/org/researchspace/apps/assets/config/shiro.ini
+++ b/src/main/resources/org/researchspace/apps/assets/config/shiro.ini
@@ -2,6 +2,7 @@
 admin=$shiro1$SHA-256$500000$JWFyxDbrkcdlGl6Xpj02dg==$UYbUG3bHmT8Z4dTeEHToK5WdyvwR9cRefiM/9zRjfr4=,admin,root,query-catalog,repository-admin
 guest=$shiro1$SHA-256$500000$IbH5irWwZzyQlXHZg33GeA==$n+A1vGbmrIxJBBxGcsNn3cz48wDvhBkMbNPcskfAQy4=,guest
 anonymous=$shiro1$SHA-256$500000$LRgzF+Iayekl6VfDVkVWIA==$/s38LlLsNeaGzsD0Z3VTvfurv68HpReieOaNlrcKaPI=,guest
+anonymous-user=$shiro1$SHA-256$500000$IbH5irWwZzyQlXHZg33GeA==$n+A1vGbmrIxJBBxGcsNn3cz48wDvhBkMbNPcskfAQy4=,guest
 
 [roles]
 root = accounts:*:*, pages:*:*:*, storage:*:*, file:*:*, app:upload, system:restart

--- a/src/main/web/components/dashboard/DashboardComponent.tsx
+++ b/src/main/web/components/dashboard/DashboardComponent.tsx
@@ -182,14 +182,14 @@ export class DashboardComponent extends Component<Props, State> {
           }
         });
         return true;
-      } else if (iri.value === 'http://www.researchspace.org/resource/ThinkingFrames' && props && props['viewId']) {
+      } else if (iri.value === 'http://www.researchspace.org/resource/ThinkingFrames' && props && props['view']) {
         trigger({
           eventType: 'Dashboard.AddFrame',
           source: 'link',
           targets: ['thinking-frames'],
           data: {
-            resourceIri: props['resourceIri'],
-            viewId: props['viewId']
+            resourceIri: props['resource'],
+            viewId: props['view']
           }
         });
         return true;


### PR DESCRIPTION
Previously every browser session created new session for anonymous user. So number of active session was equal to number of people that accessed the platform.

This change make sure that we have only one internal session for anonymous user, so we don't even need to set cookies in case of anonymous access.

Also it adds additional user `anonymous-user`, that can have permissions different from the actual `anonymous` user, but will have the same user IRI. This user can be useful in situation where anonymous user is readonly and one needs somehow to populate clipboard or other resource for it.

Signed-off-by: Artem Kozlov <artem@rem.sh>