### PR TITLE
Use label properties from config in ontodia entity search.

### DIFF
--- a/src/main/web/components/3-rd-party/ontodia/data/OntodiaDataProvider.ts
+++ b/src/main/web/components/3-rd-party/ontodia/data/OntodiaDataProvider.ts
@@ -31,6 +31,7 @@ import {
 
 import { WrappingError } from 'platform/api/async';
 import { SparqlUtil, SparqlTypeGuards, VariableRenameBinder } from 'platform/api/sparql';
+import { ConfigHolder } from 'platform/api/services/config-holder';
 import { getBaseUrl } from 'platform/api/http';
 import { FieldDefinition } from 'platform/components/forms';
 import { xsd, rdf } from 'platform/api/rdf/vocabularies';
@@ -67,6 +68,9 @@ export function createDataProvider(params: {
   } else {
     sparqlProfile = SUPPORTED_PROFILES['default'];
   }
+
+  // apply label properties from the config to full text search in Ontodia
+  sparqlProfile.dataLabelProperty = ConfigHolder.getUIConfig().labelPropertyPattern;
 
   // this is workaround for field-based navigation
   const fieldConfigDefaults = createFieldConfiguration(fields, forceFields);


### PR DESCRIPTION
Only rdfs:label was applied in entity search, because it is hardcoded in the dataprovider profile. With this change we always set it to the value from UI config.

Signed-off-by: Artem Kozlov <artem@rem.sh>