### PR TITLE
adding templates for managing field categories

### DIFF
--- a/src/main/resources/org/researchspace/apps/assets/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fassets%2F.html
+++ b/src/main/resources/org/researchspace/apps/assets/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fassets%2F.html
@@ -59,7 +59,11 @@
       [[#if (hasPermission "api:ldp:container:<http://www.metaphacts.com/ontologies/platform#fieldDefinitionContainer>:read:any")]]
         [[>Admin:IconPanelInclude title="Fields" faIcon="fa fa-list-ul fa-5x" pageLink="http://www.researchspace.org/resource/assets/Fields"]]
       [[/if]]
-    
+  
+      [[#if (hasPermission "api:ldp:container:<http://www.metaphacts.com/ontologies/platform#fieldDefinitionCategoryContainer>:read:any")]]
+      [[>Admin:IconPanelInclude title="Field Categories" faIcon="fa fa-tag fa-5x" pageLink="http://www.researchspace.org/resource/assets/FieldCategories"]]
+       [[/if]]
+  
       [[#if (hasPermission "api:ldp:*")]]
     		[[>Admin:IconPanelInclude title="LDP" faIcon="fa fa-archive fa-5x" pageLink="http://www.metaphacts.com/ontologies/platform#rootContainer" assets="true"]]
       [[/if]]

--- a/src/main/resources/org/researchspace/apps/assets/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fassets%2FFieldCategories.html
+++ b/src/main/resources/org/researchspace/apps/assets/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fassets%2FFieldCategories.html
@@ -1,0 +1,175 @@
+<ol class="page-breadcrumb">
+  <li>
+    <mp-link title="Home" url="/">Home</mp-link>
+  </li>
+  <li>
+    <semantic-link title="Assets" data-uri="http://www.metaphacts.com/resource/assets/">Assets</semantic-link>
+  </li>
+  <li class="active">Field Categories</li>
+</ol>
+
+<div class="page">
+  <div class="page__header">
+    <div class="page__header-thumbnail">
+      <h2><i class="fa fa-tag fa-2x"></i></h2>
+    </div>
+    <div class="page__header-body">
+      <h2>
+        Field Categories
+      </h2>
+    </div>
+  </div>
+  <div class="page__body">
+    <bs-tabs class="page__body-navtabs-" unmount-on-exit=true>
+      <bs-tab event-key="1" title="Tree View">
+
+        <semantic-tree query="
+        SELECT ?node ?parent ?label WHERE {
+          GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> {
+            ?node <http://www.w3.org/2004/02/skos/core#inScheme> <http://www.metaphacts.com/ontologies/platform/FieldCategories> .
+            ?node rdfs:label ?label .
+          optional { ?node <http://www.w3.org/2004/02/skos/core#broader> ?parent }
+          }
+
+        }" tuple-template='{{> node}}' no-result-template='{{> empty-tree}}'>
+          <template id='node'>
+            <div>
+              {{> edit}}
+
+            </div>
+          </template>
+
+          <template id='empty-tree'>
+            <div><strong>No categories found</strong></div>
+          </template>
+
+          <template id="edit">
+            <span>
+              <!-- Modal dialog -->
+              <mp-overlay-dialog title="Edit Category '{{label.value}}'" type="modal" bs-size="large">
+
+                <mp-overlay-dialog-trigger>
+                  <a>
+                    {{label.value}} </a>
+                </mp-overlay-dialog-trigger>
+
+                <mp-overlay-dialog-content>
+
+
+
+                  <semantic-form subject="{{node.value}}" post-action="reload" persistence="sparql"
+                    browser-persistence="false" form-id="edit category" fields='[
+                        {
+                          "id": "label",
+                          "label": "Label",
+                          "description": "The name of the category",
+                          "xsdDatatype": "xsd:string",
+                          "minOccurs": "0",
+                          "maxOccurs": "1",
+                          "selectPattern": "SELECT $value WHERE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject rdfs:label $value }}",
+                          "insertPattern": "INSERT { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject rdfs:label $value }} WHERE {}",
+                          "deletePattern": "DELETE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject rdfs:label $value. $subject <http://www.w3.org/2004/02/skos/core#inScheme> <http://www.metaphacts.com/ontologies/platform/FieldCategories>}} WHERE {}"
+                        },
+                                                                                            {
+              "id": "parent",
+              "label": "Parent Category",
+              "description": "This will become the parent category",
+              "xsdDatatype": "xsd:anyURI",
+              "minOccurs": "0",
+              "maxOccurs": "1",
+              "selectPattern": "SELECT $value WHERE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject <http://www.w3.org/2004/02/skos/core#broader> $value }}",
+              "insertPattern": "INSERT { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject <http://www.w3.org/2004/02/skos/core#broader> $value }} WHERE {}",
+              "deletePattern": "DELETE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject <http://www.w3.org/2004/02/skos/core#broader> $value }} WHERE {}",
+              "treePatterns": {
+                "type": "simple",
+                "schemePattern": " GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> {?item <http://www.w3.org/2004/02/skos/core#inScheme> <http://www.metaphacts.com/ontologies/platform/FieldCategories>}"
+              }
+            }
+                      ]'>
+                    <bs-panel>
+                      <semantic-form-recover-notification></semantic-form-recover-notification>
+                      <semantic-form-text-input for="label"></semantic-form-text-input>
+                      <semantic-form-tree-picker-input for="parent"></semantic-form-tree-picker-input>
+                      <semantic-form-errors></semantic-form-errors>
+
+                      <button name="submit" class="btn btn-default">Save</button>
+                      <button name="reset" class="btn btn-default">Reset</button>
+                    </bs-panel>
+                    </semantic-form>
+                </mp-overlay-dialog-content>
+
+              </mp-overlay-dialog>
+
+            </span>
+          </template>
+        </semantic-tree>
+
+      </bs-tab>
+      <bs-tab event-key="2" title="Table View">
+        <semantic-table query="
+
+            SELECT ?Category ?Parent WHERE {    
+              GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { 
+                ?Category <http://www.w3.org/2004/02/skos/core#inScheme> <http://www.metaphacts.com/ontologies/platform/FieldCategories> .
+                OPTIONAL {$Category <http://www.w3.org/2004/02/skos/core#broader> $Parent}              } 
+            }" number-of-displayed-rows=2 options='{"showFilter": true}'></semantic-table>
+
+      </bs-tab>
+    </bs-tabs>
+
+
+
+    <semantic-form new-subject-template="http://www.metaphacts.com/ontologies/platform/formContainer/category/{{label}}"
+      post-action="reload" persistence="sparql" browser-persistence="false" form-id="category" fields='[
+            {
+              "id": "label",
+              "label": "Label",
+              "description": "The name of the category",
+              "xsdDatatype": "xsd:string",
+              "minOccurs": "1",
+              "maxOccurs": "unbound",
+              "selectPattern": "SELECT $value WHERE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject rdfs:label $value } }",
+              "insertPattern": "INSERT { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject rdfs:label $value }} WHERE {}",
+              "deletePattern": "DELETE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject rdfs:label $value }} WHERE {}"
+            },
+            {
+              "id": "parent",
+              "label": "Parent Category",
+              "description": "This will become the parent category",
+              "xsdDatatype": "xsd:anyURI",
+              "minOccurs": "0",
+              "maxOccurs": "1",
+              "selectPattern": "SELECT $subject WHERE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> {$subject <http://www.w3.org/2004/02/skos/core#inScheme> <http://www.metaphacts.com/ontologies/platform/FieldCategories> }}",
+              "insertPattern": "INSERT { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject <http://www.w3.org/2004/02/skos/core#broader> $value }} WHERE {}",
+              "deletePattern": "DELETE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $category <http://www.w3.org/2004/02/skos/core#broader> $subject }} WHERE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { ?category <http://www.w3.org/2004/02/skos/core#broader> ?subject}}",
+              "treePatterns": {
+                "type": "simple",
+                "schemePattern": "GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { ?item <http://www.w3.org/2004/02/skos/core#inScheme> <http://www.metaphacts.com/ontologies/platform/FieldCategories> }"
+              }
+            },                
+            {
+              "id": "type",
+              "label": "Type",
+              "description": "The type of the created instance",
+              "xsdDatatype": "xsd:anyURI",
+              "selectPattern": "SELECT $value WHERE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> {$subject a $value }}",
+              "insertPattern": "INSERT { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject <http://www.w3.org/2004/02/skos/core#inScheme> $value }} WHERE {}",
+              "deletePattern": "DELETE { GRAPH <http://www.metaphacts.com/ontologies/platform/FieldCategories> { $subject <http://www.w3.org/2004/02/skos/core#inScheme> $value }} WHERE {}"
+            }
+          ]'>
+      <h3>Create a new Category</h3>
+      <bs-panel>
+        <semantic-form-recover-notification></semantic-form-recover-notification>
+        <semantic-form-text-input for="label"></semantic-form-text-input>
+        <semantic-form-tree-picker-input for="parent"></semantic-form-tree-picker-input>
+        <semantic-form-hidden-input for="type"
+          default-value="http://www.metaphacts.com/ontologies/platform/FieldCategories"></semantic-form-hidden-input>
+        <semantic-form-errors></semantic-form-errors>
+
+        <button name="submit" class="btn btn-default">Save</button>
+        <button name="reset" class="btn btn-default">Reset</button>
+      </bs-panel>
+    </semantic-form>
+  </div>
+  <div class="clearfix"></div>
+</div>


### PR DESCRIPTION
This template enables the management of field categories, including the editing of category labels, parent categories, and their deletion if necessary. It uses form input in sparql mode and writes the categories to a specific named graph (this may not be 100% desirable, LDP mode may be better but it does not allow us to delete categories, as far as I could tell)

Creating this as a draft pull request, feel free to make changes as needed.