### PR TITLE
Ability to enforce KPs constraints in Knowledge Map authoring mode.

### DIFF
--- a/src/main/web/components/3-rd-party/ontodia/Ontodia.ts
+++ b/src/main/web/components/3-rd-party/ontodia/Ontodia.ts
@@ -523,7 +523,10 @@ export class Ontodia extends Component<OntodiaProps, State> {
       if (fieldConfiguration) {
         if (fieldConfiguration.authoringMode) {
           this.metadataApi = new FieldBasedMetadataApi(fieldConfiguration.metadata);
-          this.validationApi = new FieldBasedValidationApi(fieldConfiguration.metadata);
+          this.validationApi =
+            new FieldBasedValidationApi(
+              fieldConfiguration.metadata, fieldConfiguration.enforceConstraints
+            );
         }
         this.setState({ fieldConfiguration });
       } else {

--- a/src/main/web/components/3-rd-party/ontodia/Toolbar.tsx
+++ b/src/main/web/components/3-rd-party/ontodia/Toolbar.tsx
@@ -65,6 +65,8 @@ export class Toolbar<P extends ToolbarProps = ToolbarProps, S = {}> extends Comp
   protected renderSaveButton() {
     const {
       canPersistChanges,
+      hasUnpersistedChanges,
+      canSaveDiagram,
       saveDiagramLabel,
       persistChangesLabel,
       onPersistChanges,
@@ -72,10 +74,15 @@ export class Toolbar<P extends ToolbarProps = ToolbarProps, S = {}> extends Comp
       onSaveDiagram,
       onSaveDiagramAs,
     } = this.props;
-    if (canPersistChanges && onPersistChanges) {
+    if (onPersistChanges && hasUnpersistedChanges) {
       return (
-        <Dropdown id="persist-changes-button" className="btn-group-sm">
-          <Button bsStyle="success" onClick={onPersistChanges} className={styles.saveButton}>
+        <Dropdown id="persist-changes-button" className="btn-group-sm"
+          disabled={!canPersistChanges}
+        >
+          <Button disabled={!canPersistChanges}
+            bsStyle="success"
+            onClick={onPersistChanges} className={styles.saveButton}
+          >
             <span className="fa fa-floppy-o" aria-hidden="true" />
             &nbsp;
             {persistChangesLabel}
@@ -89,7 +96,7 @@ export class Toolbar<P extends ToolbarProps = ToolbarProps, S = {}> extends Comp
         </Dropdown>
       );
     }
-    if (onSaveDiagram) {
+    if (onSaveDiagram && canSaveDiagram) {
       return (
         <Dropdown id="save-diagram-button" className="btn-group-sm">
           <Button bsStyle="primary" onClick={onSaveDiagram} className={styles.saveButton}>

--- a/src/main/web/components/3-rd-party/ontodia/authoring/FieldBasedValidationApi.ts
+++ b/src/main/web/components/3-rd-party/ontodia/authoring/FieldBasedValidationApi.ts
@@ -56,10 +56,17 @@ import { fetchInitialModel, getEntityMetadata, applyEventsToCompositeValue } fro
 export class FieldBasedValidationApi implements ValidationApi {
   private dataProvider: DataProvider | undefined;
 
-  constructor(private entityMetadata: Map<ElementTypeIri, EntityMetadata>) {}
+  constructor(
+    private entityMetadata: Map<ElementTypeIri, EntityMetadata>,
+    private enforceConstraints: boolean
+  ) { }
 
   setDataProvider(dataProvider: DataProvider) {
     this.dataProvider = dataProvider;
+  }
+
+  shouldEnforceConstraints() {
+    return this.enforceConstraints;
   }
 
   validate(e: ValidationEvent): Promise<Array<ElementError | LinkError>> {
@@ -158,12 +165,12 @@ export class FieldBasedValidationApi implements ValidationApi {
 
     const initialModelTask = AuthoringState.isNewElement(state, target.id)
       ? Kefir.constant<CompositeValue>({
-          type: CompositeValue.type,
-          subject: Rdf.iri(target.id),
-          definitions: metadata.fieldByIri,
-          fields: Immutable.Map(),
-          errors: Immutable.List(),
-        })
+        type: CompositeValue.type,
+        subject: Rdf.iri(target.id),
+        definitions: metadata.fieldByIri,
+        fields: Immutable.Map(),
+        errors: Immutable.List(),
+      })
       : fetchExistingEnitityState(target.id, metadata, this.dataProvider);
 
     return initialModelTask

--- a/src/main/web/components/3-rd-party/ontodia/authoring/FieldConfigurationCommon.ts
+++ b/src/main/web/components/3-rd-party/ontodia/authoring/FieldConfigurationCommon.ts
@@ -29,6 +29,7 @@ import { FormBasedPersistenceProps } from './FormBasedPersistence';
 
 export interface FieldConfiguration {
   readonly authoringMode: boolean;
+  readonly enforceConstraints: boolean;
   readonly metadata: Map<ElementTypeIri, EntityMetadata> | undefined;
   readonly persistence: OntodiaPersistenceMode | undefined;
   readonly allFields: ReadonlyArray<Forms.FieldDefinition>;

--- a/src/main/web/components/3-rd-party/ontodia/authoring/OntodiaFieldConfiguration.ts
+++ b/src/main/web/components/3-rd-party/ontodia/authoring/OntodiaFieldConfiguration.ts
@@ -99,6 +99,13 @@ export interface OntodiaFieldConfigurationConfig {
   forceDatatypeFields?: ReadonlyArray<string>;
 
   /**
+   * Allow user to persist changes only if there are no validation errors.
+   *
+   * @default false
+   */
+  enforceConstraints?: boolean;
+
+  /**
    * Children can be either ontodia-entity-metadata or ontodia-field-input-override
    */
   readonly children: object;
@@ -127,6 +134,7 @@ export async function extractFieldConfiguration(
   if (!props) {
     return {
       authoringMode: false,
+      enforceConstraints: false,
       metadata: undefined,
       persistence: undefined,
       allFields: [],
@@ -143,6 +151,7 @@ export async function extractFieldConfiguration(
     allowRequestFields = true,
     fields: passedFields = [],
     forceDatatypeFields = [],
+    enforceConstraints = false,
   } = props;
   if (typeof typeIri !== 'string') {
     throw new Error(`Missing 'typeIri' property for ontodia-field-configuration`);
@@ -228,6 +237,7 @@ export async function extractFieldConfiguration(
 
   const finalConfig: FieldConfiguration = {
     authoringMode: props ? Boolean(props.authoringMode) : false,
+    enforceConstraints,
     metadata: collectedMetadata.size > 0 ? collectedMetadata : undefined,
     persistence: props ? props.persistence : undefined,
     allFields: fieldByIri.valueSeq().toArray(),

--- a/src/main/web/ontodia/src/ontodia/data/validationApi.ts
+++ b/src/main/web/ontodia/src/ontodia/data/validationApi.ts
@@ -30,4 +30,9 @@ export interface ValidationApi {
    * Validate element and its outbound links.
    */
   validate(e: ValidationEvent): Promise<Array<ElementError | LinkError>>;
+
+  /**
+   * Check if validation constraints should be enforce in the authoring mode.
+   */
+  shouldEnforceConstraints(): boolean
 }

--- a/src/main/web/ontodia/src/ontodia/workspace/toolbar.tsx
+++ b/src/main/web/ontodia/src/ontodia/workspace/toolbar.tsx
@@ -6,6 +6,7 @@ export interface ToolbarProps {
   canSaveDiagram?: boolean;
   onSaveDiagram?: () => void;
   canPersistChanges?: boolean;
+  hasUnpersistedChanges?: boolean;
   onPersistChanges?: () => void;
   onForceLayout?: () => void;
   onClearAll?: () => void;

--- a/src/main/web/schemas/FileInputConfig.json
+++ b/src/main/web/schemas/FileInputConfig.json
@@ -5,6 +5,11 @@
             "description": "Media type pattern to allow only specific types of files.\nSee https://github.com/okonet/attr-accept for more information.",
             "type": "string"
         },
+        "fromUrlOrDrop": {
+            "default": false,
+            "description": "Upload file from the url or drop.",
+            "type": "boolean"
+        },
         "generateIriQuery": {
             "description": "SPARQL select query which is used to generate unique IRI for the uploaded file.\nThe query should have only one projection variable `?resourceIri` with the IRI.\n\nAlso the query can use some variables which will be bound with values at runtime:\n* `?__mediaType__`: media type: `image/png`, etc\n* `?__fileName__`: file name, including extension",
             "type": "string"
@@ -42,7 +47,8 @@
         "resourceQuery",
         "namePredicateIri",
         "mediaTypePredicateIri",
-        "placeholder"
+        "placeholder",
+        "fromUrlOrDrop"
     ],
     "required": [
         "storage",

--- a/src/main/web/schemas/ImageGraphAuthoringConfig.json
+++ b/src/main/web/schemas/ImageGraphAuthoringConfig.json
@@ -48,6 +48,10 @@
             "description": "Pattern to generate the image ID from the image IRI",
             "type": "string"
         },
+        "noImagesTemplate": {
+            "description": "Template that is used when there are no images in the corresponding Knowledge Map",
+            "type": "string"
+        },
         "ontodiaId": {
             "description": "ID of Ontodia component to be used as an endpoint.",
             "type": "string"
@@ -58,6 +62,10 @@
                 "type": "string"
             },
             "type": "array"
+        },
+        "useDetailsSidebar": {
+            "description": "Use details sidebar instead of built-in mirador details view",
+            "type": "boolean"
         }
     },
     "propertyOrder": [
@@ -66,7 +74,9 @@
         "iiifServerUrl",
         "repositories",
         "ontodiaId",
-        "fields"
+        "fields",
+        "noImagesTemplate",
+        "useDetailsSidebar"
     ],
     "required": [
         "fields",

--- a/src/main/web/schemas/OntodiaConfig.json
+++ b/src/main/web/schemas/OntodiaConfig.json
@@ -360,7 +360,7 @@
                     "type": "string"
                 },
                 "elementInfoQuery": {
-                    "description": "CONSTRUCT query to retrieve data for each element (types, labels, properties).\n\nParametrized variables:\n   - `${ids}` VALUES clause content with element IRIs\n   - `${dataLabelProperty}` `dataLabelProperty` property from the settings\n   - `${propertyConfigurations}`\n\nExpected output format for triples:\n   - `?inst rdf:type ?class` element has type\n   - `?inst rdfs:label ?label` element has label\n   - `?inst ?property ?value` element has value for a datatype property",
+                    "description": "CONSTRUCT query to retrieve data for each element (types, labels, properties).\n\nParametrized variables:\n   - `${ids}` VALUES clause content with element IRIs\n   - `${dataLabelProperty}` `dataLabelProperty` property from the settings\n   - `${propertyConfigurations}`\n\nExpected output format for triples:\n   - `?inst <https://ontodia.org/context/v1.json/type> ?class` element has type\n   - `?inst <https://ontodia.org/context/v1.json/label> ?label` element has label\n   - `?inst ?property ?value` element has value for a datatype property",
                     "type": "string"
                 },
                 "filterAdditionalRestriction": {
@@ -618,6 +618,9 @@
             },
             "type": "array"
         },
+        "leftPanelInitiallyOpen": {
+            "type": "boolean"
+        },
         "linkSettings": {
             "description": "Custom options for the links",
             "items": {
@@ -740,6 +743,9 @@
             "description": "Controls if component should re-request all links from data provider when showing existing\ngraph (via loading the diagram or executing CONSTRUCT query), if link is not found in the\ndata, it is shown as dashed. Setting this to false speeds up initialization and the links on\nthe diagram will be shown exactly as they were when the diagram was saved.",
             "type": "boolean"
         },
+        "rightPanelInitiallyOpen": {
+            "type": "boolean"
+        },
         "saveDiagramLabel": {
             "description": "Custom label for \"Save diagram\" button.",
             "type": "string"
@@ -793,7 +799,9 @@
         "persistChangesLabel",
         "findRelationshipQuery",
         "hideNavigationConfirmation",
-        "postSaving"
+        "postSaving",
+        "leftPanelInitiallyOpen",
+        "rightPanelInitiallyOpen"
     ],
     "type": "object"
 }

--- a/src/main/web/schemas/OntodiaFieldConfigurationConfig.json
+++ b/src/main/web/schemas/OntodiaFieldConfigurationConfig.json
@@ -231,27 +231,6 @@
             ],
             "type": "object"
         },
-        "FormBasedPersistenceProps": {
-            "properties": {
-                "debug": {
-                    "type": "boolean"
-                },
-                "type": {
-                    "enum": [
-                        "form"
-                    ],
-                    "type": "string"
-                }
-            },
-            "propertyOrder": [
-                "type",
-                "debug"
-            ],
-            "required": [
-                "type"
-            ],
-            "type": "object"
-        },
         "FullTreeConfig": {
             "properties": {
                 "childrenQuery": {
@@ -328,6 +307,27 @@
             ],
             "type": "object"
         },
+        "LdpBasedPersistenceProps": {
+            "properties": {
+                "debug": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "enum": [
+                        "form"
+                    ],
+                    "type": "string"
+                }
+            },
+            "propertyOrder": [
+                "type",
+                "debug"
+            ],
+            "required": [
+                "type"
+            ],
+            "type": "object"
+        },
         "Literal": {
             "properties": {
                 "_datatype": {
@@ -383,37 +383,6 @@
             ],
             "type": "object"
         },
-        "OntologyPersistenceProps": {
-            "properties": {
-                "repository": {
-                    "type": "string"
-                },
-                "targetGraphIri": {
-                    "type": "string"
-                },
-                "type": {
-                    "enum": [
-                        "ontology"
-                    ],
-                    "type": "string"
-                },
-                "typePattern": {
-                    "type": "string"
-                }
-            },
-            "propertyOrder": [
-                "type",
-                "targetGraphIri",
-                "repository",
-                "typePattern"
-            ],
-            "required": [
-                "repository",
-                "targetGraphIri",
-                "type"
-            ],
-            "type": "object"
-        },
         "SimpleTreeConfig": {
             "properties": {
                 "relationPattern": {
@@ -440,6 +409,35 @@
                 "scheme",
                 "schemePattern",
                 "relationPattern"
+            ],
+            "required": [
+                "type"
+            ],
+            "type": "object"
+        },
+        "SparqlPersistenceProps": {
+            "properties": {
+                "debug": {
+                    "type": "boolean"
+                },
+                "targetGraphIri": {
+                    "type": "string"
+                },
+                "targetInsertGraphIri": {
+                    "type": "string"
+                },
+                "type": {
+                    "enum": [
+                        "sparql"
+                    ],
+                    "type": "string"
+                }
+            },
+            "propertyOrder": [
+                "type",
+                "targetGraphIri",
+                "targetInsertGraphIri",
+                "debug"
             ],
             "required": [
                 "type"
@@ -481,6 +479,11 @@
             "description": "Default template to create Iri for new entities.",
             "type": "string"
         },
+        "enforceConstraints": {
+            "default": false,
+            "description": "Allow user to persist changes only if there are no validation errors.",
+            "type": "boolean"
+        },
         "fields": {
             "description": "Fields to be used in Ontodia instance. Could be populated inline or with backend helper.",
             "items": {
@@ -498,10 +501,10 @@
         "persistence": {
             "anyOf": [
                 {
-                    "$ref": "#/definitions/FormBasedPersistenceProps"
+                    "$ref": "#/definitions/LdpBasedPersistenceProps"
                 },
                 {
-                    "$ref": "#/definitions/OntologyPersistenceProps"
+                    "$ref": "#/definitions/SparqlPersistenceProps"
                 }
             ],
             "default": "{type: \"form\"}",
@@ -523,6 +526,7 @@
         "defaultImageIri",
         "defaultSubjectTemplate",
         "forceDatatypeFields",
+        "enforceConstraints",
         "children"
     ],
     "required": [

--- a/src/main/web/schemas/SplitPaneConfig.json
+++ b/src/main/web/schemas/SplitPaneConfig.json
@@ -71,6 +71,11 @@
         },
         "BaseSplitPaneConfig": {
             "properties": {
+                "alwaysRender": {
+                    "default": false,
+                    "description": "Render opned pane even when it is in closed state",
+                    "type": "boolean"
+                },
                 "className": {
                     "description": "SplitPane custom class name",
                     "type": "string"
@@ -158,7 +163,8 @@
                 "dock",
                 "snapThreshold",
                 "split",
-                "primary"
+                "primary",
+                "alwaysRender"
             ],
             "required": [
                 "minSize"
@@ -6933,6 +6939,11 @@
         },
         "SplitPaneConfigWithDock": {
             "properties": {
+                "alwaysRender": {
+                    "default": false,
+                    "description": "Render opned pane even when it is in closed state",
+                    "type": "boolean"
+                },
                 "className": {
                     "description": "SplitPane custom class name",
                     "type": "string"
@@ -7025,7 +7036,8 @@
                 "id",
                 "snapThreshold",
                 "split",
-                "primary"
+                "primary",
+                "alwaysRender"
             ],
             "required": [
                 "dock",


### PR DESCRIPTION
Added new property `enforce-constraints` to `ontodia-field-configuration` component. With this property set to true data change can't be saved before all validation errors are resolved.