### PR TITLE
dev env. Use the same blazegraph as in docker-compose.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # if build was triggered by labeled action we want to execute it only if it is build_image label
-    if: github.event.action != 'labeled' || github.event.label.name == 'build_image'
+    if: github.event.action != 'labeled' || github.event.label.name == 'build_image' || github.event.label.name == 'build_zip'
     
     steps:
       - uses: actions/checkout@v2
@@ -63,9 +63,19 @@ jobs:
       - name: Set current date as env variable
         run: echo "::set-env name=DATE::$(date +'%Y-%m-%d')"
 
-      # build war and zip only if build_image label is present or we are building from master
+      # build war only if build_image label is present and build_zip don't
       - name: war
-        if: contains(github.event.pull_request.labels.*.name, 'build_image') || github.ref == 'refs/heads/master'
+        if: contains(github.event.pull_request.labels.*.name, 'build_image') && !contains(github.event.pull_request.labels.*.name, 'build_zip')
+        uses: eskatos/gradle-command-action@v1
+        env:
+          CHROMIUM_BIN: /usr/bin/google-chrome
+          ORG_GRADLE_PROJECT_buildVersion: ${{env.DATE}}_${{github.sha}}
+        with:
+          arguments: war
+
+      # build zip only if build_zip label is present or we are building from master
+      - name: zip
+        if: contains(github.event.pull_request.labels.*.name, 'build_zip') || github.ref == 'refs/heads/master'
         uses: eskatos/gradle-command-action@v1
         env:
           CHROMIUM_BIN: /usr/bin/google-chrome
@@ -108,7 +118,7 @@ jobs:
           docker push researchspace/platform-ci:latest
 
       # upload zip bundle 
-      - if: contains(github.event.pull_request.labels.*.name, 'build_image') || github.ref == 'refs/heads/master'
+      - if: contains(github.event.pull_request.labels.*.name, 'build_zip') || github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v2
         with:
           name: zip-bundle

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ farms {
             contextPath: '/'
 
         // setup blazegraph for local development
-        webapp 'com.blazegraph:blazegraph-war:2.2.0-20160908.003514-6',
+        webapp 'com.blazegraph:blazegraph-war:2.2.0-20160908.003514-6-researchspace',
             contextPath: '/blazegraph'
 
         // setup digilib for local development

--- a/bundle-config/RWStore.properties
+++ b/bundle-config/RWStore.properties
@@ -36,3 +36,9 @@ com.bigdata.rdf.sail.truthMaintenance=false
 com.bigdata.rdf.store.AbstractTripleStore.quads=true
 com.bigdata.rdf.store.AbstractTripleStore.textIndex=true
 com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.NoAxioms
+
+# Enable geo-spatial index
+com.bigdata.rdf.store.AbstractTripleStore.geoSpatial=true
+
+# Enable InlineIVs for CIDOC-CRM
+com.bigdata.rdf.store.AbstractTripleStore.vocabularyClass=org.researchspace.ResearchSpaceVocabulary


### PR DESCRIPTION
so we can easily move blazegraph.jnl from local dev env do docker deployment and vice versa.

Also build zip distribution only for master.

Signed-off-by: Artem Kozlov <artem@rem.sh>