### PR TITLE
semantci-form. Fix initialization bug, allow to edit resources in autocomplete input.

### DIFF
--- a/src/main/web/components/forms/inputs/AutocompleteInput.tsx
+++ b/src/main/web/components/forms/inputs/AutocompleteInput.tsx
@@ -68,6 +68,9 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
         <ValidationMessages errors={FieldValue.getErrors(this.props.value)} />
         {this.state.nestedFormOpen ? (
           <NestedModalForm
+            subject={
+              FieldValue.isEmpty(this.props.value) ? null : this.props.value.value as Rdf.Iri
+            }
             definition={this.props.definition}
             onSubmit={this.onNestedFormSubmit}
             onCancel={() => this.setState({ nestedFormOpen: false })}
@@ -129,10 +132,10 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
           }}
           minimumInput={MINIMUM_LIMIT}
         />
-        {showCreateNewButton && value === undefined ? (
+        {showCreateNewButton ? (
           <Button className={`${CLASS_NAME}__create-button`} bsStyle="default" onClick={this.toggleNestedForm}>
-            <span className="fa fa-plus" />
-            {' Create new'}
+            {value === undefined ? <span className="fa fa-plus" /> : null}
+            {value === undefined ? ' Create new' : 'Edit'}
           </Button>
         ) : null}
       </div>

--- a/src/main/web/components/forms/inputs/CompositeInput.ts
+++ b/src/main/web/components/forms/inputs/CompositeInput.ts
@@ -237,11 +237,6 @@ export class CompositeInput extends SingleValueInput<ComponentProps, {}> {
         result = mergeDataState(result, DataState.Loading);
         continue;
       }
-      const state = this.inputStates.get(fieldId) || READY_INPUT_STATE;
-      result = mergeDataState(result, state.dataState);
-      if (state.dataState === DataState.Ready) {
-        continue;
-      }
       for (const ref of refs) {
         if (ref) {
           result = mergeDataState(result, ref.dataState());

--- a/src/main/web/components/forms/inputs/NestedModalForm.tsx
+++ b/src/main/web/components/forms/inputs/NestedModalForm.tsx
@@ -38,6 +38,7 @@ import { trigger } from 'platform/api/events';
 import * as FormEvents from 'platform/components/forms/FormEvents';
 
 export interface NestedModalFormProps {
+  subject?: Rdf.Iri
   definition: FieldDefinition;
   onSubmit: (value: AtomicValue) => void;
   onCancel: () => void;
@@ -52,11 +53,11 @@ export class NestedModalForm extends Component<NestedModalFormProps, {}> {
   }
 
   render() {
-    const { definition, onSubmit, onCancel, children } = this.props;
+    const { definition, onSubmit, onCancel, children, subject } = this.props;
     const propsOverride: Partial<ResourceEditorFormProps> = {
       id: children.props.id,
       browserPersistence: false,
-      subject: Rdf.iri(''),
+      subject: subject || Rdf.iri(''),
       postAction: (subject: Rdf.Iri) => {
         if (children.props.postAction) {
           performFormPostAction({
@@ -76,7 +77,10 @@ export class NestedModalForm extends Component<NestedModalFormProps, {}> {
     return (
       <Modal bsSize="large" show={true} onHide={onCancel}>
         <Modal.Header closeButton={true}>
-          <Modal.Title>{`Create New ${getPreferredLabel(definition.label) || definition.id || 'Value'}`}</Modal.Title>
+          <Modal.Title>{
+            (subject ? `Create New ` : 'Edit ') +
+                        `${getPreferredLabel(definition.label) || definition.id || 'Value'}`
+          }</Modal.Title>
         </Modal.Header>
         <Modal.Body>{cloneElement(children, propsOverride)}</Modal.Body>
       </Modal>


### PR DESCRIPTION
semantic-form data was marked with DataState.Ready before all nested composite inputs were properly initialized, because of this it was not possible to use composite inputs in sparql persistence mode. In LDP mode the bug was visible only when some KPs created intermediate nodes with UUID (on every save new UUID was generated for intermediate nodes).

Also this change allows to edit resources in autocomplete input with nested forms. Previously it was only possible to create new resource with nested forms.