### PR TITLE
Tree input. Ability to override tree-patterns from the Knowledge Pattern.

### DIFF
--- a/src/main/web/components/forms/ValidationHelpers.ts
+++ b/src/main/web/components/forms/ValidationHelpers.ts
@@ -36,7 +36,7 @@ ASK {
 `;
   } else {
     // for many ranges value should have type that is in the list
-    const ranges = field.range.map(r => r.value).join(', ');
+    const ranges = field.range.map(r => `<${r.value}>`).join(', ');
     return `
 ASK {
 ?value rdf:type/rdfs:subClassOf* ?range .

--- a/src/main/web/components/forms/persistence/PersistenceUtils.ts
+++ b/src/main/web/components/forms/persistence/PersistenceUtils.ts
@@ -40,7 +40,7 @@ export function parseQueryStringAsUpdateOperation(queryString: string | undefine
 }
 
 /**
- * Add WITH clause to UPDATE query to execute it on specific named graph.
+ * Add WITH clause to UPDATE query to fully execute it on specific named graph.
  */
 export function withNamedGraph(
   query: SparqlJs.Update, targetGraphIri?: string
@@ -49,5 +49,25 @@ export function withNamedGraph(
     // graph property on update opertian is missing is SparqlJs d.ts file
     query.updates.forEach(u => u['graph'] = targetGraphIri);
   }
+  return query;
+}
+
+/**
+ * Add GRAPH clause to INSERT part of the UPDATE query to fully execute it on specific named graph.
+ */
+export function addInsertIntoGraph(
+  query: SparqlJs.Update, targetGraphIri?: string
+): SparqlJs.Update {
+  query.updates.forEach(u => {
+    const insertOrDelete = u as SparqlJs.InsertDeleteOperation;
+    if (insertOrDelete.updateType === 'insertdelete') {
+      insertOrDelete.insert =
+        [{
+          type: 'graph',
+          name: targetGraphIri as SparqlJs.Term,
+          triples: insertOrDelete.insert[0].triples,
+        }];
+    }
+  });
   return query;
 }

--- a/src/main/web/components/semantic/lazy-tree/SemanticTreeInput.ts
+++ b/src/main/web/components/semantic/lazy-tree/SemanticTreeInput.ts
@@ -400,6 +400,7 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
             RemovableBadge,
             {
               key: item.iri.value,
+              title: item.iri.value,
               onClick: onSelectionClick ? () => onSelectionClick(selection, item) : undefined,
               onRemove: () => {
                 const previous = this.state.confirmedSelection;

--- a/src/main/web/styling/app/_form.scss
+++ b/src/main/web/styling/app/_form.scss
@@ -282,7 +282,7 @@
   }
 
   .clearable-input {
-    height: 35px;
+    min-height: 35px;
     border: 1px solid $color-primary-50;
   }
 


### PR DESCRIPTION
Add `orderByPattern` to influence a tree order, useful for periods or events.

```
    <semantic-form-tree-picker-input for="broader"
                                     tree-patterns='{"scheme": "{{scheme}}", "orderByPattern": "?item crm:P4_has_time-span/crm:P82a_begin_of_the_begin ?order"}'
    ></semantic-form-tree-picker-input>

```

Signed-off-by: Artem Kozlov <artem@rem.sh>