### PR TITLE
Ability to force LDP assets loading from the app.

### DIFF
--- a/src/main/java/org/researchspace/config/groups/GlobalConfiguration.java
+++ b/src/main/java/org/researchspace/config/groups/GlobalConfiguration.java
@@ -75,4 +75,8 @@ public class GlobalConfiguration extends ConfigurationGroupBase {
         return getStringList("repositoriesLDPLoad", Lists.newArrayList(RepositoryManager.ASSET_REPOSITORY_ID));
     }
 
+    public List<String> getForceLDPLoadFromStorages() {
+        return getStringList("forceLDPLoadFromStorages");
+    }
+
 }


### PR DESCRIPTION
`forceLDPLoadFromStorages` config property can be used to force loading of LDP assets from the app. On restart, if LDP asset exist in the app, it will be deleted from the database and fully reloaded.

Here is our use-case for this feature. We have dev and prod deployment, they both have different runtime-storage, but share project app. 
We develop new functionality on dev and then when it is ready we can copy relevant templates and Knowledge Patterns to the project app, redeploy it on prod, and can be sure that all Knowledge Patterns are in sync with templates. 

Signed-off-by: Artem Kozlov <artem@rem.sh>