### PR TITLE
Don't start the platform until all repositories are reachable.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'java-library'
 
     // To run app in the development mode with jetty container
-    id 'org.gretty' version '3.0.4.v20200928'
+    id 'org.gretty' version '3.0.4.v20201014'
 
     // To run webpack-dev-server in the background
     id 'com.github.psxpaul.execfork' version '0.1.13'
@@ -74,9 +74,6 @@ war {
 
 farms {
     farm 'researchspace', {
-        webapp project,
-            contextPath: '/'
-
         // setup blazegraph for local development
         webapp 'com.blazegraph:blazegraph-war:2.2.0-20160908.003514-6-researchspace',
             contextPath: '/blazegraph'
@@ -86,6 +83,8 @@ farms {
             contextPath: '/digilib',
             initParameters: ["config-file": "./bundle-config/digilib-config.xml"]
 
+        webapp project,
+            contextPath: '/'
     }
 }
 
@@ -136,6 +135,8 @@ gretty {
     // see https://akhikhl.github.io/gretty-doc/Gretty-configuration.html#_inplacemode
     // see https://akhikhl.github.io/gretty-doc/Fast-reload.html
     inplaceMode = 'hard'
+
+    redeployMode = 'redeploy'
 
     // don't restart jetty when templates in the resource folder are changed
     fastReload = "${projectDir.getAbsolutePath()}/src/main/resources/org/researchspace/apps".toString()

--- a/src/main/java/org/researchspace/repository/RepositoryManager.java
+++ b/src/main/java/org/researchspace/repository/RepositoryManager.java
@@ -25,6 +25,7 @@ import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 import java.util.Optional;
 import java.util.Set;
 
@@ -302,7 +303,13 @@ public class RepositoryManager implements RepositoryManagerInterface {
                 }
             }
         } catch (Exception e) {
-            logger.error("Failed to send test query to repository \"{}\": {} \n", id, e.getMessage());
+            logger.error("Failed to send test query to repository \"{}\": {} . Waiting 10 seconds .... \n", id, e.getMessage());
+            try {
+                TimeUnit.SECONDS.sleep(10);
+            } catch (InterruptedException e1) {
+                throw new RuntimeException(e1);
+            }
+            sendTestQuery(id, repository);
         }
     }
 


### PR DESCRIPTION
Also use custom build of gretty to make sure that in development mode ResearchSpace is started after blazegraph.

see https://github.com/gretty-gradle-plugin/gretty/pull/181

Signed-off-by: Artem Kozlov <artem@rem.sh>