### PR TITLE
add demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ The ResearchSpace is distributed under AGPL-3.0 or later.
 
 # How to try it?
 
-> :warning: **WARNING**: Currently we are working on demo application .....
-
 The easiest way to try researchspace is to use a [setup with docker-compose](#setup-with-docker). 
+
+Or you can visit the demo application [Late Hokusai](https://latehokusai.researchspace.org/resource/rsp:Start).
 
 # Overview
 


### PR DESCRIPTION
Following links in the GeoSPARQL issue https://github.com/opengeospatial/ogc-geosparql/issues/59 and finding my way through https://github.com/ncarboni/awesome-GLAM-semweb I have come to find ResearchSpace. After exploring it at the Late Hokusai site, I was surprised not to find it linked here in the README, but a warning about a missing demo.

This has been corrected and is proposed to be taken in.