### PR TITLE
Prevent default test query for SailRepositories

### DIFF
--- a/src/main/java/org/researchspace/repository/RepositoryManager.java
+++ b/src/main/java/org/researchspace/repository/RepositoryManager.java
@@ -173,7 +173,12 @@ public class RepositoryManager implements RepositoryManagerInterface {
      */
     public void sentTestQueries() {
         for (Entry<String, Repository> entry : initializedRepositories.entrySet()) {
-            this.sendTestQuery(entry.getKey(), entry.getValue());
+
+            // @gspinaci Prevent default test query sending for SailRepositories 
+            // SailRepositories requires custom queries
+            if(!(entry.getValue() instanceof SailRepository)) {
+                this.sendTestQuery(entry.getKey(), entry.getValue());
+            }
         }
     }
 


### PR DESCRIPTION
Adding a simple control to prevent the sending of default test query for SailRepositories. 

For example, the SailRepository for Wikidata, and the upcoming for Geonames, are SailRepositories and both requires the queries to have mandatory identifiers.

When the test query is the following one (see the code below), a generic exception is raised.
https://github.com/researchspace/researchspace/blob/60233ec3181ff76c7dabb7a03a4e06b592db2166/src/main/java/org/researchspace/repository/RepositoryManager.java#L292-L314
