### PR TITLE
Add language switch to default templates header.

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/config/page-layout/header.hbs
+++ b/src/main/resources/org/researchspace/apps/default/config/page-layout/header.hbs
@@ -115,6 +115,8 @@
           </li>
         </mp-anonymous-hidden>
 
+
+        <mp-user-language-switch></mp-user-language-switch>
         <mp-anonymous-hidden alt='<li><a href="/login" title="login" class="rs-body-m-M">Logout</a></li>'>
           <bs-nav-dropdown title="Account" id="rs-account-dropdown" class="rs-account-dropdown">
 

--- a/src/main/web/components/language-switch/UserLanguageSwitch.tsx
+++ b/src/main/web/components/language-switch/UserLanguageSwitch.tsx
@@ -99,7 +99,7 @@ export class UserLanguageSwitch extends Component<UserLanguagePropsProps, State>
   private onLanguageChanged(language: string): void {
     setPreferredUserLanguage(language);
     this.setState({ language: language });
-    refresh();
+    window.location.reload();
   }
 }
 


### PR DESCRIPTION
Possible languages can be set in the `ui.prop` config file, e.g:
```
preferredLanguages=en,fr,ara
```

Language selected by the user is stored in the user session.
Selected language is used only by components that use label service, like semantic-link, semantic-form input labels, etc.