### PR TITLE
Ability to connect to sparql repository in readonly mode.

### DIFF
--- a/src/main/java/org/researchspace/data/rdf/container/LDPAssetsLoader.java
+++ b/src/main/java/org/researchspace/data/rdf/container/LDPAssetsLoader.java
@@ -145,7 +145,13 @@ public class LDPAssetsLoader {
         for (Entry<String, Map<String, Map<StoragePath, FindResult>>> entry : mapResultsByRepositoryIdAndStorageId
                 .entrySet()) {
             if (isLoadableFromStorage(entry.getKey())) {
-                loadAllToRepository(entry.getKey(), entry.getValue());
+                boolean isWritable = repositoryManager.getRepository(entry.getKey()).isWritable();
+                if (isWritable) {
+                    loadAllToRepository(entry.getKey(), entry.getValue());
+                } else {
+                    logger.warn("Skipping loading of LDP assets into the " + entry.getKey()
+                            + " repository, because it is not writable!");
+                }
             } else {
                 logger.info("Skipping loading LDP assets into the \"" + entry.getKey()
                         + "\" repository: the repository is not listed in "

--- a/src/main/java/org/researchspace/repository/MpRepositoryVocabulary.java
+++ b/src/main/java/org/researchspace/repository/MpRepositoryVocabulary.java
@@ -80,6 +80,8 @@ public class MpRepositoryVocabulary {
     public static final IRI AUTHENTICATION_TOKEN = VF.createIRI(NAMESPACE, "authenticationToken");
     public static final IRI REALM = VF.createIRI(NAMESPACE, "realm");
     public static final IRI QUAD_MODE = VF.createIRI(NAMESPACE, "quadMode");
+    public static final IRI WRITABLE = VF.createIRI(NAMESPACE, "writable");
+
     public static final IRI USE_ASYNCHRONOUS_PARALLEL_JOIN = VF.createIRI(FEDERATION_NAMESPACE,
             "useAsynchronousParallelJoin");
     public static final IRI USE_COMPETING_JOIN = VF.createIRI(FEDERATION_NAMESPACE, "useCompetingJoin");

--- a/src/main/java/org/researchspace/repository/sparql/CustomSPARQLConnection.java
+++ b/src/main/java/org/researchspace/repository/sparql/CustomSPARQLConnection.java
@@ -1,0 +1,49 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2021, © Trustees of the British Museum
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.researchspace.repository.sparql;
+
+import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.sparql.SPARQLConnection;
+import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
+
+/**
+ * Override of the default rdf4j {@link SPARQLConnection}.
+ */
+public class CustomSPARQLConnection extends SPARQLConnection {
+
+    public CustomSPARQLConnection(SPARQLRepository repository, SPARQLProtocolSession client, boolean quadMode) {
+        super(repository, client, quadMode);
+    }
+
+    public CustomSPARQLConnection(SPARQLRepository repository, SPARQLProtocolSession client) {
+        super(repository, client);
+    }
+
+    @Override
+    public void commit() throws RepositoryException {
+        // all write operations are going through commit method
+        // so it is a good place to enforce readonly status of the repository.
+        if (this.getRepository().isWritable()) {
+            super.commit();
+        } else {
+            throw new RepositoryException(
+                    "Can't commit transaction. " + this.getRepository().toString() + " repository is readonly!");
+        }
+    }
+}

--- a/src/main/java/org/researchspace/repository/sparql/CustomSPARQLRepository.java
+++ b/src/main/java/org/researchspace/repository/sparql/CustomSPARQLRepository.java
@@ -19,6 +19,8 @@ package org.researchspace.repository.sparql;
 
 import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
 /**
@@ -31,6 +33,17 @@ import org.eclipse.rdf4j.rio.RDFFormat;
  * we can't do this on the level of {@link MpSPARQLProtocolSession}.
  */
 public class CustomSPARQLRepository extends org.eclipse.rdf4j.repository.sparql.SPARQLRepository {
+    /**
+     * quadMode is defined as private in the superclass, so we store it here to make
+     * the value accessible in our custom sparql connection.
+     */
+    private boolean quadMode;
+
+    /**
+     * true if repository supports writes
+     */
+    private boolean isWritable;
+
     public CustomSPARQLRepository(String endpointUrl) {
         super(endpointUrl);
     }
@@ -40,25 +53,55 @@ public class CustomSPARQLRepository extends org.eclipse.rdf4j.repository.sparql.
     }
 
     @Override
+    public void enableQuadMode(boolean flag) {
+        super.enableQuadMode(flag);
+        this.quadMode = flag;
+    }
+
+    public void setWritable(boolean isWritable) {
+        this.isWritable = isWritable;
+    }
+
+    @Override
+    public boolean isWritable() throws RepositoryException {
+        return this.isWritable;
+    }
+
+    @Override
     protected SPARQLProtocolSession createHTTPClient() {
         SPARQLProtocolSession session = super.createHTTPClient();
 
-        // rdf4j has nice performance optimization that help to avoid unnecessary serialization
+        // rdf4j has nice performance optimization that help to avoid unnecessary
+        // serialization
         // and deserialization of query results, which is quite relevant for us because
         // very often we just send the result to the web client
         // without doing any manipulations on the server side.
         //
-        // This feature works only when the result format returned from triplestore matches format
-        // of the supplied RDFWriter. But rdf4j (as of v3.2.0) create Accept header for request query without taking into consideration
-        // supplied RDFWriter, and by default just use default preferred result format. (xml for select, and turtle for construct)
-        // We need to change preferred format for select to JSON, because that is what we use on client-side.
+        // This feature works only when the result format returned from triplestore
+        // matches format
+        // of the supplied RDFWriter. But rdf4j (as of v3.2.0) create Accept header for
+        // request query without taking into consideration
+        // supplied RDFWriter, and by default just use default preferred result format.
+        // (xml for select, and turtle for construct)
+        // We need to change preferred format for select to JSON, because that is what
+        // we use on client-side.
         //
-        // As a result passthrough optimization is not going to happen if someone manually requests some other format.
-        // Hopefully in future versions rdf4j will take RDFWriter format into consideration, we then can remove this logic.
+        // As a result passthrough optimization is not going to happen if someone
+        // manually requests some other format.
+        // Hopefully in future versions rdf4j will take RDFWriter format into
+        // consideration, we then can remove this logic.
         //
         // see https://github.com/eclipse/rdf4j/pull/1943
         session.setPreferredTupleQueryResultFormat(TupleQueryResultFormat.JSON);
         session.setPreferredRDFFormat(RDFFormat.TURTLE);
         return session;
+    }
+
+    @Override
+    public RepositoryConnection getConnection() throws RepositoryException {
+        if (!isInitialized()) {
+            init();
+        }
+        return new CustomSPARQLConnection(this, createHTTPClient(), this.quadMode);
     }
 }

--- a/src/main/java/org/researchspace/repository/sparql/DefaultMpSPARQLRepositoryFactory.java
+++ b/src/main/java/org/researchspace/repository/sparql/DefaultMpSPARQLRepositoryFactory.java
@@ -56,15 +56,17 @@ public class DefaultMpSPARQLRepositoryFactory extends AbstractMpSPARQLRepository
      */
     @Override
     public SPARQLRepository getRepositoryInternal(MpSPARQLRepositoryConfig config) throws RepositoryConfigException {
-        SPARQLRepository result = null;
+        CustomSPARQLRepository result = null;
 
         if (config instanceof SPARQLRepositoryConfig) {
             SPARQLRepositoryConfig httpConfig = config;
             if (httpConfig.getUpdateEndpointUrl() != null) {
-                result = new CustomSPARQLRepository(httpConfig.getQueryEndpointUrl(), httpConfig.getUpdateEndpointUrl());
+                result = new CustomSPARQLRepository(httpConfig.getQueryEndpointUrl(),
+                        httpConfig.getUpdateEndpointUrl());
             } else {
                 result = new CustomSPARQLRepository(httpConfig.getQueryEndpointUrl());
             }
+            result.setWritable(config.isWritable());
         } else {
             throw new RepositoryConfigException("Invalid configuration class: " + config.getClass());
         }

--- a/src/main/java/org/researchspace/repository/sparql/MpSPARQLRepositoryConfig.java
+++ b/src/main/java/org/researchspace/repository/sparql/MpSPARQLRepositoryConfig.java
@@ -43,6 +43,7 @@ public class MpSPARQLRepositoryConfig extends SPARQLRepositoryConfig {
     protected static final ValueFactory vf = SimpleValueFactory.getInstance();
 
     private boolean usingQuads = true;
+    private boolean writable = true;
 
     public MpSPARQLRepositoryConfig() {
         super();
@@ -66,10 +67,19 @@ public class MpSPARQLRepositoryConfig extends SPARQLRepositoryConfig {
         this.usingQuads = usingQuads;
     }
 
+    public boolean isWritable() {
+        return writable;
+    }
+
+    public void setWritable(boolean writable) {
+        this.writable = writable;
+    }
+
     @Override
     public Resource export(Model model) {
         Resource implNode = super.export(model);
         model.add(implNode, MpRepositoryVocabulary.QUAD_MODE, vf.createLiteral(usingQuads));
+        model.add(implNode, MpRepositoryVocabulary.WRITABLE, vf.createLiteral(writable));
         return implNode;
     }
 
@@ -80,6 +90,8 @@ public class MpSPARQLRepositoryConfig extends SPARQLRepositoryConfig {
         try {
             Models.objectLiteral(model.filter(implNode, MpRepositoryVocabulary.QUAD_MODE, null))
                     .ifPresent(lit -> setUsingQuads(lit.booleanValue()));
+            Models.objectLiteral(model.filter(implNode, MpRepositoryVocabulary.WRITABLE, null))
+                    .ifPresent(lit -> setWritable(lit.booleanValue()));
         } catch (ModelException e) {
             throw new SailConfigException(e.getMessage(), e);
         }

--- a/src/test/resources/org/researchspace/repository/test-sparql-basic-auth-repository.ttl
+++ b/src/test/resources/org/researchspace/repository/test-sparql-basic-auth-repository.ttl
@@ -8,4 +8,5 @@
 		<http://www.researchspace.org/resource/system/repository#username> "testuser" ;
 		<http://www.researchspace.org/resource/system/repository#password> "testpassword";
 		<http://www.researchspace.org/resource/system/repository#quadMode> "true"^^xsd:boolean ;
+		<http://www.researchspace.org/resource/system/repository#writable> "true"^^xsd:boolean ;
 	].

--- a/src/test/resources/org/researchspace/repository/test-sparql-digest-auth-repository.ttl
+++ b/src/test/resources/org/researchspace/repository/test-sparql-digest-auth-repository.ttl
@@ -9,4 +9,5 @@
 		<http://www.researchspace.org/resource/system/repository#password> "testpassword";
 		<http://www.researchspace.org/resource/system/repository#realm> "testrealm";
 		<http://www.researchspace.org/resource/system/repository#quadMode> "true"^^xsd:boolean ;
+		<http://www.researchspace.org/resource/system/repository#writable> "true"^^xsd:boolean ;
 	].


### PR DESCRIPTION
`mph:writable false` can be used to make connected repository a readonly one, e.g:

```
@prefix rep: <http://www.openrdf.org/config/repository#> .
@prefix sail: <http://www.openrdf.org/config/sail#> .
@prefix sr: <http://www.openrdf.org/config/repository/sail#> .
@prefix sparqlr: <http://www.openrdf.org/config/repository/sparql#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix mph: <http://www.researchspace.org/resource/system/repository#> .


[] a rep:Repository ;
    rep:repositoryID "default" ;
    rdfs:label "default" ;
    rep:repositoryImpl [
        rep:repositoryType "researchspace:SPARQLBasicAuthRepository" ;
        sparqlr:query-endpoint <http://localhost:10216/sparql> ;
        mph:writable false ;
        mph:username "user" ;
        mph:password "password"
        ].
```

Useful when connecting to existing repository for debugging/development purpose locally.