### PR TITLE
Add parameter to specify initial state for semantic-search.

### DIFF
--- a/src/main/web/components/semantic/search/config/SearchConfig.ts
+++ b/src/main/web/components/semantic/search/config/SearchConfig.ts
@@ -421,6 +421,11 @@ export interface SemanticSearchConfig {
    *   `dropdown` - dropdown field.
    */
   selectorMode?: 'stack' | 'dropdown';
+
+  /**
+   * Compressed JSON representation of the search state. Can be used to load saved search.
+   */
+  initialState?: string;
 }
 
 /**


### PR DESCRIPTION
Previously search component, by default, is geting initial value from `?semanticSearch` url queury param, now one can use explicit parameter to provide initial value:

```
      <semantic-query
        query='SELECT ?searchStructure { ?? Platform:searchState ?searchStructure }'
        template='{{> template}}'
      >
        <template id='template'>
           <semantic-search ... initial-state='{{bindings.0.searchStructure.value}}'></semantic-search>
        </template>
      </semantic-query>

```