### PR TITLE
Implement OSM search with RESTSail. Add default federation repository.

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/config/repositories/ephedra.ttl
+++ b/src/main/resources/org/researchspace/apps/default/config/repositories/ephedra.ttl
@@ -1,0 +1,24 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rep: <http://www.openrdf.org/config/repository#> .
+@prefix sail: <http://www.openrdf.org/config/sail#> .
+@prefix sr: <http://www.openrdf.org/config/repository/sail#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mph: <http://www.researchspace.org/resource/system/repository#> .
+@prefix ephedra: <http://www.researchspace.org/resource/system/ephedra#> .
+@prefix fedsail: <http://www.openrdf.org/config/sail/federation#> .
+@prefix sparqlr: <http://www.openrdf.org/config/repository/sparql#> .
+
+[] a rep:Repository;
+  rep:repositoryID "ephedra";
+  rdfs:label "Ephedra Service Federation";
+  rep:repositoryImpl [
+      rep:repositoryType "researchspace:FederationSailRepository";
+      sr:sailImpl [
+          sail:sailType "researchspace:Federation";
+          fedsail:member [
+              ephedra:delegateRepositoryID "osm-nominatim-search";
+              ephedra:serviceReference <http://www.researchspace.org/resource/system/services/osm/NominatimSearchService>
+            ];
+          ephedra:defaultMember "default"
+        ]
+    ] .

--- a/src/main/resources/org/researchspace/apps/default/config/repositories/osm-nominatim-search.ttl
+++ b/src/main/resources/org/researchspace/apps/default/config/repositories/osm-nominatim-search.ttl
@@ -1,0 +1,23 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rep: <http://www.openrdf.org/config/repository#> .
+@prefix sail: <http://www.openrdf.org/config/sail#> .
+@prefix sr: <http://www.openrdf.org/config/repository/sail#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mph: <http://www.researchspace.org/resource/system/repository#> .
+@prefix ephedra: <http://www.researchspace.org/resource/system/ephedra#> .
+@prefix fedsail: <http://www.openrdf.org/config/sail/federation#> .
+@prefix sparqlr: <http://www.openrdf.org/config/repository/sparql#> .
+
+[] a rep:Repository;
+  rep:repositoryID "osm-nominatim-search";
+  rdfs:label "A wrapper for OSM using RESTSail repository";
+  rep:repositoryImpl [
+      rep:repositoryType "openrdf:SailRepository";
+      sr:sailImpl [
+          sail:sailType "researchspace:RESTSail";
+          ephedra:serviceURL "https://nominatim.openstreetmap.org/search";
+          ephedra:implementsService <http://www.researchspace.org/resource/system/services/osm/NominatimSearchService>;
+          ephedra:requestRateLimit "1"^^xsd:int;
+          ephedra:httpMethod "GET"
+        ]
+    ] .

--- a/src/main/resources/org/researchspace/apps/default/config/services/osm-nominatim-search.ttl
+++ b/src/main/resources/org/researchspace/apps/default/config/services/osm-nominatim-search.ttl
@@ -1,0 +1,166 @@
+PREFIX sp: <http://spinrdf.org/sp#>
+PREFIX spin: <http://spinrdf.org/spin#>
+PREFIX spl: <http://spinrdf.org/spl#>
+PREFIX ephedra: <http://www.researchspace.org/resource/system/ephedra#>
+PREFIX sail: <http://www.openrdf.org/config/sail#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX : <http://www.researchspace.org/resource/system/services/osm/>
+
+:NominatimSearchService a ephedra:Service ;
+    sail:sailType "researchspace:RESTSail" ;
+    rdfs:label "A wrapper for the OpenStreetMap Nominatim search API.";
+    ephedra:hasSPARQLPattern (
+        [
+            sp:subject :_results ;
+            sp:predicate :q ;
+            sp:object :_q
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :accept-language ;
+            sp:object :_accept-language
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :countrycodes;
+            sp:object :_countrycodes
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :viewbox;
+            sp:object :_viewbox
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :bounded;
+            sp:object :_bounded
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :extratags ;
+            sp:object :_extratags
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :polygon_text ;
+            sp:object :_polygon_text
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :format ;
+            sp:object :_format
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :display_name ;
+            sp:object :_display_name
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :geotext ;
+            sp:object :_geotext
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :wikidata ;
+            sp:object :_wikidata
+            ]
+        [
+            sp:subject :_results ;
+            sp:predicate :importance ;
+            sp:object :_importance
+            ]
+        );
+
+    spin:constraint [
+        a spl:Argument ;
+        rdfs:comment "search query" ;
+        spl:predicate :_q ;
+        spl:valueType xsd:string
+        ] ;
+
+    spin:constraint [
+        a spl:Argument ;
+        rdfs:comment "Preferred language order for showing search results, comma-separated list of language codes" ;
+        spl:predicate :_accept-language ;
+        spl:valueType xsd:string
+        ] ;
+
+    spin:constraint [
+        a spl:Argument ;
+        rdfs:comment "Limit search results to one or more countries. countrycode must be the ISO 3166-1alpha2 code, e.g. gb for the United Kingdom, de for Germany." ;
+        spl:predicate :_countrycodes ;
+        spl:valueType xsd:string
+        ] ;
+
+    spin:constraint [
+        a spl:Argument ;
+        rdfs:comment "When a viewbox is given, restrict the result to items contained within that viewbox" ;
+        spl:predicate :_bounded ;
+        spl:valueType xsd:string
+        ] ;
+
+    spin:constraint [
+        a spl:Argument ;
+        rdfs:comment "The preferred area to find search results. Any two corner points of the box are accepted as long as they span a real box. x is longitude, y is latitude.  <x1>,<y1>,<x2>,<y2>" ;
+        spl:predicate :_viewbox ;
+        spl:valueType xsd:string
+        ] ;
+
+    spin:constraint [
+        a spl:Argument ;
+        rdfs:comment "request that result should contain polygon text in WKT format" ;
+        spl:predicate :_polygon_text ;
+        spl:valueType xsd:string ;
+        spl:defaultValue "1"
+        ] ;
+
+    spin:constraint [
+        a spl:Argument ;
+        rdfs:comment "Include additional information in the result if available, like wikidata id" ;
+        spl:predicate :_extratags ;
+        spl:valueType xsd:string ;
+        spl:defaultValue "1"
+        ] ;
+
+    spin:constraint [
+        a spl:Argument ;
+        rdfs:comment "we expect request in json format" ;
+        spl:predicate :_format ;
+        spl:valueType xsd:string ;
+        spl:defaultValue "json"
+        ] ;
+
+    spin:column [
+        a spin:Column ;
+        rdfs:comment "Display Name" ;
+        spl:predicate :_display_name ;
+        spl:valueType xsd:string ;
+        ephedra:jsonPath "$.display_name"
+        ] ;
+
+    spin:column [
+        a spin:Column ;
+        rdfs:comment "WKT" ;
+        spl:predicate :_geotext ;
+        spl:valueType xsd:string;
+        ephedra:jsonPath "$.geotext"
+        ] ;
+
+    spin:column [
+        a spin:Column ;
+        rdfs:comment "Wikidata ID" ;
+        spl:predicate :_wikidata ;
+        spl:valueType xsd:string;
+        ephedra:jsonPath "$.extratags.wikidata"
+        ] ;
+
+    spin:column [
+        a spin:Column ;
+        rdfs:comment "search result rank, the higher the more relevant is the result" ;
+        spl:predicate :_importance ;
+        spl:valueType xsd:string;
+        ephedra:jsonPath "$.importance"
+        ] .
+
+

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FOsmSearch.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FOsmSearch.html
@@ -1,0 +1,48 @@
+<bs-tabs id='semantic-search' mount-on-enter=true>    
+  <bs-tab event-key='place-search' title='OSM search' class="basicSearch">
+  <semantic-search config='[[searchConfigForFieldsFromQuery "SELECT DISTINCT ?field WHERE { ?field a <http://www.researchspace.org/resource/system/fields/Field> .  ?field <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E21_Person> . }"]]'>
+     <semantic-search-query-keyword 
+        domain='<http://www.cidoc-crm.org/cidoc-crm/E21_Person>'
+        tokenize-lucene-query=false
+        escape-lucene-syntax=false
+        debounce=1000
+        query='
+          PREFIX osm: <http://www.researchspace.org/resource/system/services/osm/>
+          SELECT ?subject WHERE { 
+            ?subject osm:q ?__token__ ;
+              osm:accept-language "fr" ;
+              osm:display_name ?label ;
+              osm:geotext ?geoText ;
+              osm:wikidata ?wikidataId ;
+              osm:importance ?importance .
+          }
+        '
+        debounce=500
+      ></semantic-search-query-keyword>
+    
+    <div data-flex-layout="row stretch-stretch" class='rs-results-area'>
+         <semantic-search-result-holder>
+    <div data-flex-self="md-full">
+      <bs-tabs default-active-key='4' mount-on-enter=true unmount-on-exit=true id='search-results' animation=false class='tabs-right'>
+          <bs-tab event-key="4" title="Table" class="search-tab-table">
+            <semantic-search-result> 
+              <semantic-context repository='osm-nominatim-search'>
+                <semantic-table id='semantic-search-result-table'
+                                query='SELECT DISTINCT * WHERE {  } ORDER BY ?importance'
+
+                                options='{"showFilter":false, "resultsPerPage":10}' 
+                >
+                </semantic-table>
+              </semantic-context>
+            </semantic-search-result>
+          </bs-tab>
+      </bs-tabs>
+    </div>
+  </semantic-search-result-holder>
+    
+</div>
+
+    
+    </semantic-search>
+  </bs-tab>
+</bs-tabs>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FOsmSearchComplex.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FOsmSearchComplex.html
@@ -1,0 +1,223 @@
+<semantic-search   
+  randomize-variables=false
+  categories='{      
+    "<http://www.researchspace.org/ontology/Place>": [{"kind": "place"}],
+    "<http://www.researchspace.org/ontology#Text>": [{
+      "kind": "text",
+      "escapeLuceneSyntax": false,
+      "tokenizeLuceneQuery": false,
+      "queryPattern": "{
+        BIND(?__value__ as ?query) .
+      }"
+    }]
+  }'       
+  relations = '{
+                 "<http://www.researchspace.org/ontology/falls_within>": [
+                   {
+                     "kind": "resource",
+                     "queryPattern": "
+                     {
+                       BIND(STRAFTER(STR(?__value__), \"http://www.researchspace.org/resource/country/\") as ?countryCode) .
+                     }
+                     "
+                   },
+                   {
+                    "kind": "place",
+                    "distanceQueryPattern": "
+                      BIND(CONCAT(?__geoSouthWestLong__, \",\", ?__geoSouthWestLat__, \",\", ?__geoNorthEastLong__, \",\", ?__geoNorthEastLat__) AS ?boundingBox)
+                    ",
+                    "boundingBoxQueryPattern": "
+                      BIND(CONCAT(?__geoSouthWestLong__, \",\", ?__geoSouthWestLat__, \",\", ?__geoNorthEastLong__, \",\", ?__geoNorthEastLat__) AS ?boundingBox) .
+                      BIND(\"1\" AS ?bounded) .
+                    "
+                   }
+                 ]
+               }'
+  search-profile='{ 
+                    "categories": [{
+                                     "iri": "<http://www.researchspace.org/ontology/Place>",
+                                     "label": "Place",
+                                     "thumbnail": "../images/help/thenounproject/noun_1113333.svg"
+                                   },
+                                   {
+                                     "iri": "<http://www.researchspace.org/ontology#Text>",
+                                     "label": "Text"
+                                   }
+                                ],
+                    "relations": [{
+                                    "iri": "<http://www.researchspace.org/ontology/falls_within>",
+                                    "label": "falls_within",
+                                    "hasDomain": "<http://www.researchspace.org/ontology/Place>",
+                                    "hasRange": "<http://www.researchspace.org/ontology/Place>"
+                                  }
+                                 ]
+                  }'
+  >
+
+  <semantic-search-query-builder 
+                                 geo-selector='{
+                                   "query": "
+                                      SELECT ?value ?label ?lat ?long WHERE {
+                                        ?value crm:P87_is_identified_by ?coord;
+                                               rso:displayLabel ?label.
+
+                                        ?coord wgs84_pos:lat ?lat;
+                                               wgs84_pos:long ?long.
+
+                                        ?label bds:search ?__token__ ;
+                                        bds:relevance ?score .
+                                       } ORDER BY DESC(?score)  LIMIT 20
+                                   "
+                                 }'
+                                 
+                                 resource-selector-relations='{
+                                                                "<http://www.researchspace.org/ontology/falls_within>": {
+                                                              		"kind": "resource",
+                                                                  "escapeLuceneSyntax": false,
+                                                                  "tokenizeLuceneQuery": false,
+                                                                  "suggestionTupleTemplate": "<span title=\"{{label.value}}\">{{label.value}}</span>",
+                                                              		"query": "
+                                                                    PREFIX wikibase: <http://wikiba.se/ontology#>
+                                                                    PREFIX bd: <http://www.bigdata.com/rdf#>
+                                                                    PREFIX mwapi: <https://www.mediawiki.org/ontology#API/>
+                                                                    PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+                                                                    PREFIX wd: <http://www.wikidata.org/entity/>
+
+                                                                    SELECT ?suggestion ?label WHERE {
+                                                                       SERVICE <https://query.wikidata.org/sparql> {
+                                                                        SERVICE wikibase:mwapi {
+                                                                          bd:serviceParam wikibase:endpoint \"www.wikidata.org\";
+                                                                                          wikibase:api \"EntitySearch\";
+                                                                                          mwapi:search ?__token__;
+                                                                                          mwapi:language \"en\".
+                                                                          ?item wikibase:apiOutputItem mwapi:item.
+                                                                          ?num wikibase:apiOrdinal true.
+                                                                        }
+
+                                                                        ?item wdt:P297 ?countryCode.
+                                                                        SERVICE wikibase:label { 
+                                                                          bd:serviceParam wikibase:language \"[AUTO_LANGUAGE],en\" . 
+                                                                          ?item rdfs:label ?label .
+                                                                        }
+                                                                      }
+                                                                      BIND(IRI(CONCAT(\"http://www.researchspace.org/resource/country/\", ?countryCode)) AS ?suggestion)
+                                                                    }
+                                                                  "
+                                                                }
+                                                              }'
+                                 ></semantic-search-query-builder>
+  
+    <div data-flex-layout="row stretch-stretch">
+    <semantic-search-result-holder>
+      <div data-flex-self="md-full">
+        <bs-tabs unmount-on-exit=true id='search-results' animation=false>
+          
+          <bs-tab event-key="2" title="Table">
+            <semantic-search-result>
+              <semantic-context repository='ephedra'>
+                <semantic-table id='table-result'
+                                query='
+                                  PREFIX osm: <http://www.researchspace.org/resource/system/services/osm/>
+
+                                  SELECT * WHERE {
+                                    SERVICE osm:NominatimSearchService {
+                                      ?subject osm:q ?query .
+                                      $subject osm:viewbox ?boundingBox .
+                                      ?subject osm:bounded ?bounded .
+                                      $subject osm:countrycodes ?countryCode .
+                                      ?subject osm:display_name ?label.
+                                      ?subject osm:geotext ?geoText.
+                                      ?subject osm:wikidata ?wikidataId.
+                                    }
+                                  }
+                               '
+                                
+                                column-configuration='[
+                                                        {"displayName": "Label", "cellTemplate": "{{> label}}" },
+                                                        {"displayName": "Thumbnail (from Wikidata)", "cellTemplate": "{{> wikidata}}"},
+                                                        {"displayName": "Place", "cellTemplate": "{{> place}}" }
+                                                      ]'   
+
+                >
+                  <template id='place'>
+                    <div style='height: 300px; width: 600px;'>
+                      <semantic-context repository='default'>
+                        <semantic-map query='SELECT ?wkt WHERE { BIND("{{geoText.value}}" AS ?wkt) } '>
+
+                        </semantic-map>
+                      </semantic-context>
+                    </div>
+  
+                  </template>
+
+
+                  <template id='label'>
+                    <div>{{label.value}}</div>
+                  </template>
+
+                  <template id='wikidata'>
+                    <div>
+                      {{#if wikidataId.value}}
+                      <semantic-context repository='default'>
+                        <semantic-query
+                                        query='
+                                          PREFIX wikibase: <http://wikiba.se/ontology#>
+                                          PREFIX bd: <http://www.bigdata.com/rdf#>
+                                          PREFIX mwapi: <https://www.mediawiki.org/ontology#API/>
+                                          PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+                                          PREFIX wd: <http://www.wikidata.org/entity/>
+                                          PREFIX schema: <http://schema.org/>
+
+                                          SELECT ?thumbnail ?wikiLabel ?wikiDescription WHERE { 
+                                            SERVICE <https://query.wikidata.org/sparql> {  
+                                              BIND(IRI(CONCAT(STR(wd:), "{{wikidataId.value}}")) AS ?item) .
+                                              ?item wdt:P18 ?image.
+                                              BIND(STRAFTER(wikibase:decodeUri(STR(?image)), "http://commons.wikimedia.org/wiki/Special:FilePath/") AS ?fileTitle)
+
+
+                                              SERVICE wikibase:mwapi {
+                                                bd:serviceParam wikibase:endpoint "commons.wikimedia.org";
+                                                                wikibase:api "Generator";
+                                                                wikibase:limit "once";
+                                                                mwapi:generator "allpages";
+                                                                mwapi:gapfrom ?fileTitle;
+                                                                mwapi:gapnamespace 6; # NS_FILE
+                                                                mwapi:gaplimit 1;
+                                                                mwapi:prop "imageinfo";
+                                                                mwapi:iiprop "url";
+                                                                mwapi:iiurlwidth 320 .
+                                                ?url wikibase:apiOutput "imageinfo/ii/@url".
+                                                ?thumbnail wikibase:apiOutput "imageinfo/ii/@thumburl"
+                                              }
+                                              
+                                              SERVICE wikibase:label {
+                                                bd:serviceParam wikibase:language "en" .
+                                                ?item rdfs:label ?wikiLabel .
+                                                ?item schema:description ?wikiDescription .
+                                              }
+                                            }
+                                          }
+
+                                '
+                                        template='{{> thumbnail}}'
+                                        >
+                          <template id='thumbnail'>
+                            <div>
+                              <p>{{bindings.0.wikiLabel.value}}</p>
+                              <p>{{bindings.0.wikiDescription.value}}</p>
+                              <img src='{{bindings.0.thumbnail.value}}'/>
+                            </div>
+                          </template>
+                        </semantic-query>
+                        </semantic-context>
+                      {{/if}}                    </div>
+                  </template>
+                </semantic-table>
+              </semantic-context>
+            </semantic-search-result>
+          </bs-tab>
+        </bs-tabs>
+      </div>
+    </semantic-search-result-holder>
+  </div>
+</semantic-search>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FOsmSearchForm.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FOsmSearchForm.html
@@ -1,0 +1,180 @@
+<semantic-search>
+  <semantic-search-form-query
+                              query-template='{
+                                                "queryString": "
+                                                  PREFIX osm: <http://www.researchspace.org/resource/system/services/osm/>
+                                                  SELECT ?subject WHERE { 
+                                                    BIND(?query as ?q) . 
+                                                    BIND(STRAFTER(STR(?country), \"http://www.researchspace.org/resource/country/\") as ?countryCode) .
+                                                  }
+                                                ",
+                                                "arguments": {
+                                                  "query": {"type": "xsd:string"},
+                                                  "country": {"type": "xsd:anyURI", "optional": true}
+                                                }
+                                              }'
+                              fields='[
+                                        {
+                                          "id": "query",
+                                          "label": "Query",
+                                          "description": "search string",
+                                          "xsdDatatype": "xsd:string",
+                                          "minOccurs": "1",
+                                          "maxOccurs": "1"
+                                        },
+                                        {
+                                          "id": "country",
+                                          "label": "Country",
+                                          "description": "country",
+                                          "xsdDatatype": "xsd:anyURI",
+                                          "minOccurs": "0",
+                                          "maxOccurs": "1",
+                                          "autosuggestionPattern": "
+                                                                    PREFIX wikibase: <http://wikiba.se/ontology#>
+                                                                    PREFIX bd: <http://www.bigdata.com/rdf#>
+                                                                    PREFIX mwapi: <https://www.mediawiki.org/ontology#API/>
+                                                                    PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+                                                                    PREFIX wd: <http://www.wikidata.org/entity/>
+
+                                                                    SELECT ?value ?label WHERE {
+                                                                       SERVICE <https://query.wikidata.org/sparql> {
+                                                                        SERVICE wikibase:mwapi {
+                                                                          bd:serviceParam wikibase:endpoint \"www.wikidata.org\";
+                                                                                          wikibase:api \"EntitySearch\";
+                                                                                          mwapi:search ?__token__;
+                                                                                          mwapi:language \"en\".
+                                                                          ?item wikibase:apiOutputItem mwapi:item.
+                                                                          ?num wikibase:apiOrdinal true.
+                                                                        }
+
+                                                                        ?item wdt:P297 ?countryCode.
+                                                                        SERVICE wikibase:label { 
+                                                                          bd:serviceParam wikibase:language \"en\" . 
+                                                                          ?item rdfs:label ?label .
+                                                                        }
+                                                                      }
+                                                                      BIND(IRI(CONCAT(\"http://www.researchspace.org/resource/country/\", ?countryCode)) AS ?value)
+                                                                    }
+
+                                          "
+                                         }
+                                      ]'>
+    <semantic-form-text-input for="query"></semantic-form-text-input>
+    <semantic-form-autocomplete-input for="country" escape-lucene-syntax="false" tokenize-lucene-query="false"
+></semantic-form-autocomplete-input>
+    <button type='button' name='submit' className='btn btn-default'>Search</button>
+  </semantic-search-form-query>
+  
+    <div data-flex-layout="row stretch-stretch">
+    <semantic-search-result-holder>
+      <div data-flex-self="md-full">
+        <bs-tabs unmount-on-exit=true id='search-results' animation=false>
+          
+          <bs-tab event-key="2" title="Table">
+            <semantic-search-result>
+              <semantic-context repository='ephedra'>
+                <semantic-table id='table-result'
+                                query='
+                                  PREFIX osm: <http://www.researchspace.org/resource/system/services/osm/>
+
+                                  SELECT * WHERE {
+                                    SERVICE osm:NominatimSearchService {
+                                      ?subject osm:q ?q .
+                                      $subject osm:viewbox ?boundingBox .
+                                      ?subject osm:bounded ?bounded .
+                                      $subject osm:countrycodes ?countryCode .
+                                      ?subject osm:display_name ?label.
+                                      ?subject osm:geotext ?geoText.
+                                      ?subject osm:wikidata ?wikidataId.
+                                    }
+                                  }
+                               '
+                                
+                                column-configuration='[
+                                                        {"displayName": "Label", "cellTemplate": "{{> label}}" },
+                                                        {"displayName": "Thumbnail (from Wikidata)", "cellTemplate": "{{> wikidata}}"},
+                                                        {"displayName": "Place", "cellTemplate": "{{> place}}" }
+                                                      ]'   
+
+                >
+                  <template id='place'>
+                    <div style='height: 300px; width: 600px;'>
+                      <semantic-context repository='default'>
+                        <semantic-map query='SELECT ?wkt WHERE { BIND("{{geoText.value}}" AS ?wkt) } '>
+
+                        </semantic-map>
+                      </semantic-context>
+                    </div>
+  
+                  </template>
+
+
+                  <template id='label'>
+                    <div>{{label.value}}</div>
+                  </template>
+
+                  <template id='wikidata'>
+                    <div>
+                      {{#if wikidataId.value}}
+                      <semantic-context repository='default'>
+                        <semantic-query
+                                        query='
+                                          PREFIX wikibase: <http://wikiba.se/ontology#>
+                                          PREFIX bd: <http://www.bigdata.com/rdf#>
+                                          PREFIX mwapi: <https://www.mediawiki.org/ontology#API/>
+                                          PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+                                          PREFIX wd: <http://www.wikidata.org/entity/>
+                                          PREFIX schema: <http://schema.org/>
+
+                                          SELECT ?thumbnail ?wikiLabel ?wikiDescription WHERE { 
+                                            SERVICE <https://query.wikidata.org/sparql> {  
+                                              BIND(IRI(CONCAT(STR(wd:), "{{wikidataId.value}}")) AS ?item) .
+                                              ?item wdt:P18 ?image.
+                                              BIND(STRAFTER(wikibase:decodeUri(STR(?image)), "http://commons.wikimedia.org/wiki/Special:FilePath/") AS ?fileTitle)
+
+
+                                              SERVICE wikibase:mwapi {
+                                                bd:serviceParam wikibase:endpoint "commons.wikimedia.org";
+                                                                wikibase:api "Generator";
+                                                                wikibase:limit "once";
+                                                                mwapi:generator "allpages";
+                                                                mwapi:gapfrom ?fileTitle;
+                                                                mwapi:gapnamespace 6; # NS_FILE
+                                                                mwapi:gaplimit 1;
+                                                                mwapi:prop "imageinfo";
+                                                                mwapi:iiprop "url";
+                                                                mwapi:iiurlwidth 320 .
+                                                ?url wikibase:apiOutput "imageinfo/ii/@url".
+                                                ?thumbnail wikibase:apiOutput "imageinfo/ii/@thumburl"
+                                              }
+                                              
+                                              SERVICE wikibase:label {
+                                                bd:serviceParam wikibase:language "en" .
+                                                ?item rdfs:label ?wikiLabel .
+                                                ?item schema:description ?wikiDescription .
+                                              }
+                                            }
+                                          }
+
+                                '
+                                        template='{{> thumbnail}}'
+                                        >
+                          <template id='thumbnail'>
+                            <div>
+                              <p>{{bindings.0.wikiLabel.value}}</p>
+                              <p>{{bindings.0.wikiDescription.value}}</p>
+                              <img src='{{bindings.0.thumbnail.value}}'/>
+                            </div>
+                          </template>
+                        </semantic-query>
+                        </semantic-context>
+                      {{/if}}                    </div>
+                  </template>
+                </semantic-table>
+              </semantic-context>            </semantic-search-result>
+          </bs-tab>
+        </bs-tabs>
+      </div>
+    </semantic-search-result-holder>
+  </div>
+</semantic-search>


### PR DESCRIPTION
- don't fail on missing bindings in the RESTSail, e.g in the OSM link to wikidata is optional in the response.
- implements OSM search with RESTSail.
- adds default osm-nominatim-search and ephedra, so OSM federation can be used without additional config.
- adds examples on how to use OSM with structured search