### PR TITLE
git storage. Clone git repository if it is not already present.

### DIFF
--- a/src/main/java/org/researchspace/services/storage/git/GitStorage.java
+++ b/src/main/java/org/researchspace/services/storage/git/GitStorage.java
@@ -36,6 +36,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jgit.api.Git;
@@ -78,9 +81,6 @@ import org.researchspace.services.storage.api.SizedStream;
 import org.researchspace.services.storage.api.StorageException;
 import org.researchspace.services.storage.api.StorageLocation;
 import org.researchspace.services.storage.api.StoragePath;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 public class GitStorage implements ObjectStorage {
     private static final Logger logger = LogManager.getLogger(GitStorage.class);
@@ -127,9 +127,8 @@ public class GitStorage implements ObjectStorage {
 
     private void cloneRepository() throws GitAPIException, IOException {
         logger.info("Cloning remote repository <" + config.getRemoteUrl() + "> at " + config.getLocalPath());
-        // TODO: this requires to provide Git credentials in some form
-        throw new StorageException(String.format(
-                "Automatic git clone is not supported: a '.git' repository must exist in %s", config.getLocalPath()));
+
+        Git.cloneRepository().setDirectory(config.getLocalPath().toFile()).setURI(config.getRemoteUrl()).call().close();
     }
 
     private void initializeExisting(Path gitFolder) throws GitAPIException, IOException {


### PR DESCRIPTION
Quite convenient when setting up new installation, so one doesn't need to to manually clone git repo first.

Also can be used for demo setups, one can simply provide docker compose with configured git runtime readonly storage pointing to publicly available github repository with demo app, e.g:

```
-Dconfig.storage.test.type=git
-Dconfig.storage.test.mutable=false
-Dconfig.storage.test.localPath=/git-clone-app
-Dconfig.storage.test.remoteUrl=https://github.com/somerepo",
-Dconfig.storage.test.branch=master
```

for private repositories one should provide remoteUrl in the following format `git@github.com:somerepo.git`, and repository credentials will be picked up from the `~/.ssh`.