### PR TITLE
Git storage. Set branch when clonning repository.

### DIFF
--- a/src/main/java/org/researchspace/services/storage/git/GitStorage.java
+++ b/src/main/java/org/researchspace/services/storage/git/GitStorage.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import static java.util.Collections.singleton;
 
 import javax.annotation.Nullable;
 
@@ -41,6 +42,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.MergeCommand;
 import org.eclipse.jgit.api.ResetCommand;
@@ -128,7 +130,14 @@ public class GitStorage implements ObjectStorage {
     private void cloneRepository() throws GitAPIException, IOException {
         logger.info("Cloning remote repository <" + config.getRemoteUrl() + "> at " + config.getLocalPath());
 
-        Git.cloneRepository().setDirectory(config.getLocalPath().toFile()).setURI(config.getRemoteUrl()).call().close();
+        CloneCommand cloneCommand = Git.cloneRepository().setDirectory(config.getLocalPath().toFile())
+                .setURI(config.getRemoteUrl());
+
+        if (config.getBranch() != null) {
+            String remoteBranch = "refs/heads/" +  config.getBranch();
+            cloneCommand.setBranchesToClone(singleton(remoteBranch)).setBranch(remoteBranch);
+        }
+        cloneCommand.call().close();
     }
 
     private void initializeExisting(Path gitFolder) throws GitAPIException, IOException {


### PR DESCRIPTION
In jGit default clone fetches only master, we need to manually specify the branch from the config.