### PR TITLE
Fix prefixed IRI resolution in TemplateService when local name contains ":" symbol.

### DIFF
--- a/src/main/java/org/researchspace/config/NamespaceRegistry.java
+++ b/src/main/java/org/researchspace/config/NamespaceRegistry.java
@@ -372,7 +372,7 @@ public class NamespaceRegistry {
      * @return
      */
     public boolean looksLikePrefixedIri(String prefixedIri) {
-        return (prefixedIri.split(":").length == 2 || prefixedIri.endsWith(":"));
+        return (prefixedIri.contains(":"));
     }
 
     public String getPlatformNamespace() {

--- a/src/test/java/org/researchspace/config/NamespaceRegistryTest.java
+++ b/src/test/java/org/researchspace/config/NamespaceRegistryTest.java
@@ -27,7 +27,6 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.researchspace.config.NamespaceRegistry;
 import org.researchspace.config.NamespaceRegistry.ProtectedNamespaceDeletionException;
 import org.researchspace.config.NamespaceRegistry.RuntimeNamespace;
 import org.researchspace.junit.AbstractRepositoryBackedIntegrationTest;
@@ -265,6 +264,14 @@ public class NamespaceRegistryTest extends AbstractRepositoryBackedIntegrationTe
     }
 
     @Test
+    public void testPrefixedIRISucceedingWithColonInLocalName() throws Exception {
+        final NamespaceRegistry ns = getNamespaceRegistry();
+        namespaceRule.set(DUMMY_PREFIX1, DUMMY_NAMESPACE1);
+        final Optional<IRI> iri1 = ns.resolveToIRI("myns1:skos:Concept");
+        Assert.assertEquals("http://myns1.example.com/skos:Concept", iri1.get().stringValue());
+    }
+
+    @Test
     public void testIRIResolutionFailingBecausePrefixUndefined() throws Exception {
 
         final NamespaceRegistry ns = getNamespaceRegistry();
@@ -347,7 +354,7 @@ public class NamespaceRegistryTest extends AbstractRepositoryBackedIntegrationTe
 
         Assert.assertFalse(ns.looksLikePrefixedIri("test1"));
 
-        Assert.assertFalse(ns.looksLikePrefixedIri("test1:test2:test3"));
+        Assert.assertTrue(ns.looksLikePrefixedIri("test1:test2:test3"));
     }
 
     NamespaceRegistry getNamespaceRegistry() {


### PR DESCRIPTION
In SPARQL grammar it is valid to have colon symbol in the local name of prefixed IRI, e.g if we have `prefix example: <http://example.com/>`, it is valid to have IRI `example:something:SomethingElse` that will be resolved to `<http://example.com/something:SomethingElse>`, when such prefixed IRI was used as a template IRI it was incorrectly resolved by TemplateService.