### PR TITLE
Knowledge Maps improvements, bug fixes.

### DIFF
--- a/src/main/web/components/3-rd-party/ontodia/OntodiaEvents.ts
+++ b/src/main/web/components/3-rd-party/ontodia/OntodiaEvents.ts
@@ -103,8 +103,17 @@ export interface OntodiaEventData {
     /**
      * IRI of an entity to be focused on.
      */
-    iri: string;
+    iri?: string;
+
+    /**
+     * IRIs of an entities to be focused on.
+     */
+    iris?: string;
   };
+
+  'Ontodia.HighlightElements': {
+    iris: string[];
+  }
 }
 const event: EventMaker<OntodiaEventData> = EventMaker;
 
@@ -117,3 +126,4 @@ export const EditElement = event('Ontodia.EditElement');
 export const DeleteElement = event('Ontodia.DeleteElement');
 
 export const FocusOnElement = event('Ontodia.FocusOnElement');
+export const HighlightElements = event('Ontodia.HighlightElements');

--- a/src/main/web/ontodia/schema/context-v1.json
+++ b/src/main/web/ontodia/schema/context-v1.json
@@ -5,7 +5,7 @@
 
     "Diagram": "ontodia:Diagram",
     "layoutData": "ontodia:layoutData",
-    "linkTypeOptions": "ontodia:linkTypeOptions",
+    "linkTypeOptions": {"@id": "ontodia:linkTypeOptions", "@container": "@set"},
 
     "Layout": "ontodia:Layout",
     "elements": {"@id": "ontodia:hasElement", "@container": "@set"},

--- a/src/main/web/ontodia/src/ontodia/data/sparql/graphBuilder.ts
+++ b/src/main/web/ontodia/src/ontodia/data/sparql/graphBuilder.ts
@@ -1,7 +1,7 @@
 import { keyBy } from 'lodash';
 
 import { GenerateID } from '../../data/schema';
-import { LayoutElement, LayoutLink, SerializedDiagram, makeSerializedDiagram } from '../../editor/serializedDiagram';
+import { LayoutElement, LayoutLink, SerializedDiagram, LinkTypeOptions, makeSerializedDiagram } from '../../editor/serializedDiagram';
 import { uniformGrid } from '../../viewUtils/layout';
 
 import { Dictionary, ElementModel, LinkModel, ElementIri, LinkTypeIri } from '../model';
@@ -12,7 +12,10 @@ import { parseTurtleText } from './turtle';
 const GREED_STEP = 150;
 
 export class GraphBuilder {
-  constructor(public dataProvider: DataProvider) {}
+  constructor(
+    public dataProvider: DataProvider,
+    public linkTypeOptions?: ReadonlyArray<LinkTypeOptions>
+  ) {}
 
   createGraph(graph: {
     elementIds: ElementIri[];
@@ -23,7 +26,7 @@ export class GraphBuilder {
   }> {
     return this.dataProvider.elementInfo({ elementIds: graph.elementIds }).then((elementsInfo) => ({
       preloadedElements: elementsInfo,
-      diagram: makeLayout(graph.elementIds, graph.links),
+      diagram: makeLayout(graph.elementIds, graph.links, this.linkTypeOptions),
     }));
   }
 
@@ -78,7 +81,8 @@ export function makeGraphItems(
 
 export function makeLayout(
   elementsIds: ReadonlyArray<ElementIri>,
-  linksInfo: ReadonlyArray<LinkModel>
+  linksInfo: ReadonlyArray<LinkModel>,
+  linkTypeOptions?: ReadonlyArray<LinkTypeOptions>,
 ): SerializedDiagram {
   const rows = Math.ceil(Math.sqrt(elementsIds.length));
   const grid = uniformGrid({ rows, cellSize: { x: GREED_STEP, y: GREED_STEP } });
@@ -107,5 +111,5 @@ export function makeLayout(
       target: { '@id': target['@id'] },
     });
   });
-  return makeSerializedDiagram({ layoutData: { '@type': 'Layout', elements, links }, linkTypeOptions: [] });
+  return makeSerializedDiagram({ layoutData: { '@type': 'Layout', elements, links }, linkTypeOptions: linkTypeOptions });
 }

--- a/src/main/web/ontodia/src/ontodia/diagram/elementLayer.tsx
+++ b/src/main/web/ontodia/src/ontodia/diagram/elementLayer.tsx
@@ -460,8 +460,13 @@ class OverlayedElement extends React.Component<OverlayedElementProps, OverlayedE
     this.observeTypes();
     this.requestResize();
 
+
+    // we support resizing only for typed nodes, because we need to make sure that we can select right template
     if (this.minSize === undefined &&
-        !this.props.state.element.temporary) {
+        !this.props.state.element.temporary &&
+        // we don't want to init size until element types are loaded
+        this.props.state.element.data.types.length > 0
+    ) {
       this.initSize();
     }
   }

--- a/src/main/web/ontodia/src/ontodia/diagram/elementLayer.tsx
+++ b/src/main/web/ontodia/src/ontodia/diagram/elementLayer.tsx
@@ -461,11 +461,10 @@ class OverlayedElement extends React.Component<OverlayedElementProps, OverlayedE
     this.requestResize();
 
 
-    // we support resizing only for typed nodes, because we need to make sure that we can select right template
     if (this.minSize === undefined &&
         !this.props.state.element.temporary &&
-        // we don't want to init size until element types are loaded
-        this.props.state.element.data.types.length > 0
+        // we are waiting until there are some elements in the card, until elements are rendered there is only resizable handle
+        this.htmlElement.firstElementChild.className !== 'ontodia-overlayed-element__resizable-handle'
     ) {
       this.initSize();
     }


### PR DESCRIPTION
- fix link options propagation and de-serialization. Before the fix, if some links were hidden through the ontodia config, there were visible again when KM was reopened.
- fix bug with node resizing when nodes use different templates.
- add events to highlight or zoom into list of nodes. 