### PR TITLE
Fixed semantic search result context bug

### DIFF
--- a/src/main/web/components/semantic/search/web-components/SemanticSearchResult.tsx
+++ b/src/main/web/components/semantic/search/web-components/SemanticSearchResult.tsx
@@ -83,6 +83,7 @@ class SemanticSearchResultInner extends React.Component<InnerProps, State> {
       !_.isEqual(nextContext.resultQuery.getOrElse(null), context.resultQuery.getOrElse(null)) ||
       !_.isEqual(nextContext.bindings, context.bindings) ||
       !_.isEqual(this.state, nextState) ||
+      !_.isEqual(nextContext.visualizationContext.getOrElse(null), context.visualizationContext.getOrElse(null)) ||
       !nextContext.availableDomains.isEqual(context.availableDomains)
     ) {
       return true;


### PR DESCRIPTION
This is the fix that @aindlq provided for the semantic-search-result-context component. We were having problems getting the component to load properly in the search results template.