### PR TITLE
Parameterized autofocus for simple-search component

### DIFF
--- a/src/main/web/components/semantic/simple-search/SimpleSearch.ts
+++ b/src/main/web/components/semantic/simple-search/SimpleSearch.ts
@@ -35,6 +35,7 @@ export interface SimpleSearchProps extends SemanticSimpleSearchConfig {
   onSelected?: (value: SparqlClient.Binding | SparqlClient.Binding[]) => void;
   defaultQuery?: string;
   multi?: boolean;
+  autofocus?: boolean;
 }
 
 interface BackwardCompatibilityProps extends SimpleSearchProps {
@@ -58,6 +59,7 @@ export class SimpleSearch extends Component<SimpleSearchProps, SimpleSearchState
     minSearchTermLength: 3,
     resourceBindingName: 'resource',
     template: '<mp-label iri="{{resource.value}}"></mp-label>',
+    autofocus: true,
   };
 
   public render() {
@@ -103,6 +105,7 @@ export class SimpleSearch extends Component<SimpleSearchProps, SimpleSearchState
       templates: {
         suggestion: this.props.template,
       },
+      autofocus: this.props.autofocus,
     };
 
     return createElement(


### PR DESCRIPTION
This parameterizes the autofocus on the simple-search component to allow users to select whether they want the search bar to be in focus or not on page load. The default value is true, that is the search bar will be autoselected.

`autofocus='false'`

Makes is so the user must click on the search bar in order to type in it.