### PR TITLE
Fix #263.

### DIFF
--- a/src/main/java/org/researchspace/repository/sparql/SPARQLBasicAuthRepositoryFactory.java
+++ b/src/main/java/org/researchspace/repository/sparql/SPARQLBasicAuthRepositoryFactory.java
@@ -54,6 +54,7 @@ public class SPARQLBasicAuthRepositoryFactory extends AbstractMpSPARQLRepository
                 result = new SPARQLAuthenticatingRepository(httpConfig.getQueryEndpointUrl());
             }
             result.setBasicAuthCredentials(httpConfig.getUsername(), httpConfig.getPassword());
+            result.setWritable(httpConfig.isWritable());
         } else {
             throw new RepositoryConfigException("Invalid configuration class: " + config.getClass());
         }


### PR DESCRIPTION
The setup of the option `writable` was missing. With this patch now the system can set it.