### PR TITLE
blazegraph optimization for labels/thumbnail service

### DIFF
--- a/src/main/java/org/researchspace/cache/ResourcePropertyCache.java
+++ b/src/main/java/org/researchspace/cache/ResourcePropertyCache.java
@@ -219,12 +219,12 @@ public abstract class ResourcePropertyCache<Key, Property> implements PlatformCa
             }
 
             // ?subject [PREDICATE] ?p[PREDICATE_IDX]
-            queryString.append("{").append(preferredProperty.format("subject", "p" + predicateIdx)).append(valuesClause)
-                    .append("}");
+            queryString.append("{").append(preferredProperty.format("subject", "p" + predicateIdx)).append("}");
 
             predicateIdx++;
         }
 
+        queryString.append(valuesClause);
         queryString.append("} ");
 
         return queryString.toString();

--- a/src/test/java/org/researchspace/cache/LabelCacheTest.java
+++ b/src/test/java/org/researchspace/cache/LabelCacheTest.java
@@ -51,8 +51,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.researchspace.cache.LabelCache;
-import org.researchspace.cache.ResourcePropertyCache;
 import org.researchspace.config.NamespaceRegistry;
 import org.researchspace.config.PropertyPattern;
 import org.researchspace.config.UnknownConfigurationException;
@@ -511,10 +509,9 @@ public class LabelCacheTest extends AbstractRepositoryBackedIntegrationTest {
         final String query = ResourcePropertyCache.constructPropertyQuery(iris, preferredLabels);
 
         final String expectedQuery = "SELECT ?subject ?p0 ?p1 WHERE {"
-                + "{{?subject <http://www.w3.org/2000/01/rdf-schema#label> ?p0 .}"
-                + "  VALUES (?subject) { (<http://my.custom.namespace/s1>)(<http://my.custom.namespace/s2>) } } "
-                + "UNION" + "{{?subject <http://www.w3.org/2004/02/skos/core#altLabel> ?p1.}"
-                + "  VALUES (?subject) { (<http://my.custom.namespace/s1>)(<http://my.custom.namespace/s2>) } } " + "}";
+                + "{{?subject <http://www.w3.org/2000/01/rdf-schema#label> ?p0 .}}" + "UNION"
+                + "{{?subject <http://www.w3.org/2004/02/skos/core#altLabel> ?p1.}}"
+                + "VALUES (?subject) { (<http://my.custom.namespace/s1>)(<http://my.custom.namespace/s2>) }" + "}";
 
         Assert.assertEquals(expectedQuery.replace(" ", ""), query.replaceAll("[\t\n ]", ""));
     }


### PR DESCRIPTION
move VALUES clause to the root of labels/thumbnails query.

previously VALUES clause was inserted into every UNION, but it seems that blazegraph ASTStaticBindingsOptimizer was not able to properly pick them up as a result it always applied them in the end, that lead to very heavy queries.