### PR TITLE
Semantic tree picker

### DIFF
--- a/src/main/web/components/forms/ResourceEditorForm.ts
+++ b/src/main/web/components/forms/ResourceEditorForm.ts
@@ -569,7 +569,7 @@ function getSubject(props: ResourceEditorFormProps): Rdf.Iri {
   return subjectIri || Rdf.iri('');
 }
 
-function getInvalidFields(fields: ReadonlyArray<FieldDefinitionProp>) {
+function getInvalidFields(fields: ReadonlyArray<FieldDefinitionProp>) { 
   return fields.filter((field) => !field.insertPattern || !field.deletePattern);
 }
 

--- a/src/main/web/components/forms/forms.scss
+++ b/src/main/web/components/forms/forms.scss
@@ -646,6 +646,10 @@ fieldset[disabled] .form-control {
 
 }
 
+a.SemanticTreeInput--browseButton.btn-default {
+  min-height: auto;
+}
+
 .field-editor__delete-label-button.btn-default,
 .field-editor__row .btn-default:not(.SemanticTreeInput--browseButton)  {
 

--- a/src/main/web/components/forms/inputs/TreePickerInput.tsx
+++ b/src/main/web/components/forms/inputs/TreePickerInput.tsx
@@ -30,7 +30,7 @@ import {
   ComplexTreePatterns,
   createDefaultTreeQueries,
   LightwightTreePatterns,
-  CustomButton,
+  NewFrameButton,
 } from 'platform/components/semantic/lazy-tree';
 
 import { FieldDefinition, getPreferredLabel, TreeQueriesConfig, SimpleTreeConfig } from '../FieldDefinition';
@@ -79,7 +79,7 @@ export interface TreePickerInputProps extends MultipleValuesProps {
    * Custom button template
    * 
    */
-  customButton?: CustomButton;
+  newFrameButton?: NewFrameButton;
 
 
   /**
@@ -194,7 +194,7 @@ export class TreePickerInput extends MultipleValuesInput<TreePickerInputProps, S
   };
 
   private renderTreePicker() {
-    const { openDropdownOnFocus, closeDropdownOnSelection, definition, customButton, queryItemLabel } = this.props;
+    const { openDropdownOnFocus, closeDropdownOnSelection, definition, newFrameButton, queryItemLabel } = this.props;
     const { treeVersionKey, treeQueries, treeSelection } = this.state;
     const { rootsQuery, childrenQuery, parentsQuery, searchQuery } = treeQueries;
 
@@ -238,7 +238,7 @@ export class TreePickerInput extends MultipleValuesInput<TreePickerInputProps, S
             () => this.onTreeSelectionChanged(selectionLeafs)
           );
         }}
-        customButton={customButton}
+        newFrameButton={newFrameButton}
         queryItemLabel={queryItemLabel}
       />
     );

--- a/src/main/web/components/forms/inputs/TreePickerInput.tsx
+++ b/src/main/web/components/forms/inputs/TreePickerInput.tsx
@@ -30,6 +30,7 @@ import {
   ComplexTreePatterns,
   createDefaultTreeQueries,
   LightwightTreePatterns,
+  CustomButton,
 } from 'platform/components/semantic/lazy-tree';
 
 import { FieldDefinition, getPreferredLabel, TreeQueriesConfig, SimpleTreeConfig } from '../FieldDefinition';
@@ -73,6 +74,20 @@ export interface TreePickerInputProps extends MultipleValuesProps {
    * Form template that can be used to create new instance or edit existing one.
    */
   nestedFormTemplate?: string;
+
+  /**
+   * Custom button template
+   * 
+   */
+  customButton?: CustomButton;
+
+
+  /**
+   * 
+   * If present, this query is fired and requires ?item_label
+   * This will be the label viewed when the element is selected.
+   */
+  queryItemLabel?: string;
 }
 
 interface State {
@@ -179,7 +194,7 @@ export class TreePickerInput extends MultipleValuesInput<TreePickerInputProps, S
   };
 
   private renderTreePicker() {
-    const { openDropdownOnFocus, closeDropdownOnSelection, definition } = this.props;
+    const { openDropdownOnFocus, closeDropdownOnSelection, definition, customButton, queryItemLabel } = this.props;
     const { treeVersionKey, treeQueries, treeSelection } = this.state;
     const { rootsQuery, childrenQuery, parentsQuery, searchQuery } = treeQueries;
 
@@ -223,6 +238,8 @@ export class TreePickerInput extends MultipleValuesInput<TreePickerInputProps, S
             () => this.onTreeSelectionChanged(selectionLeafs)
           );
         }}
+        customButton={customButton}
+        queryItemLabel={queryItemLabel}
       />
     );
   }

--- a/src/main/web/components/semantic/lazy-tree/SemanticTreeInput.ts
+++ b/src/main/web/components/semantic/lazy-tree/SemanticTreeInput.ts
@@ -46,6 +46,10 @@ import { LazyTreeSelector, LazyTreeSelectorProps } from './LazyTreeSelector';
 import { ItemSelectionChanged } from './SemanticTreeInputEvents';
 
 import * as styles from './SemanticTreeInput.scss';
+import { ResourceLinkComponent } from 'platform/api/navigation/components';
+
+const ITEM_INPUT_VARIABLE = 'query_item_iri';
+const ITEM_OUTPUT_VARIABLE = 'item_label';
 
 export interface ComplexTreePatterns {
   /*
@@ -114,6 +118,16 @@ export interface SemanticTreeInputProps extends ComplexTreePatterns {
    * @default false
    */
   closeDropdownOnSelection?: boolean;
+
+  /**
+   * Creates a custom button with a Semantic-link with the following parameters
+   */
+  customButton?: CustomButton;
+
+  /**
+   * query to retrieve the item label that will be visualized
+   */
+  queryItemLabel?: string;
 }
 
 const ITEMS_LIMIT = 200;
@@ -149,6 +163,14 @@ interface SearchResult {
   error?: any;
   matchedCount?: number;
   matchLimit?: number;
+}
+
+export interface CustomButton {
+  iri: string;
+  view?: string;
+  resource?: string;
+  mode?: string;
+  tooltip?: string;
 }
 
 /**
@@ -237,7 +259,9 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
   componentDidMount() {
     const { initialSelection } = this.props;
     if (initialSelection && initialSelection.length !== 0) {
-      this.setInitialSelection(initialSelection).onValue(() => {/**/});
+      this.setInitialSelection(initialSelection).onValue(() => {
+        this.updateTextField();
+      });
     }
   }
 
@@ -285,13 +309,11 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
         }));
         return this.restoreTreeFromLeafNodes(bindings);
       })
-      .map(
-        (forest) => {
-          const confirmedSelection = forest as TreeSelection<Node>;
-          this.setState({ confirmedSelection });
-          return confirmedSelection;
-        }
-      );
+      .map((forest) => {
+        const confirmedSelection = forest as TreeSelection<Node>;
+        this.setState({ confirmedSelection });
+        return confirmedSelection;
+      });
   };
 
   componentWillUnmount() {
@@ -305,14 +327,27 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
         createElement(ErrorNotification, { errorMessage: this.state.loadError })
       );
     } else {
-      const result = D.div(
-        {
-          ref: (holder) => (this.overlayHolder = holder),
-          className: classnames(styles.holder, this.props.className),
-        },
-        D.div({ className: styles.inputAndButtons }, this.renderTextField(), this.renderBrowseButton()),
-        this.renderOverlay()
-      );
+      let result;
+      if (this.props.customButton) {
+        result = D.div(
+          {
+            ref: (holder) => (this.overlayHolder = holder),
+            className: classnames(styles.holder, this.props.className),
+          },
+          D.div({ className: styles.inputAndButtons }, this.renderTextField(), this.renderOpenNewFrameButton()),
+          this.renderOverlay()
+        );
+      } else {
+        result = D.div(
+          {
+            ref: (holder) => (this.overlayHolder = holder),
+            className: classnames(styles.holder, this.props.className),
+          },
+          D.div({ className: styles.inputAndButtons }, this.renderTextField(), this.renderBrowseButton()),
+          this.renderOverlay()
+        );
+      }
+
       if (this.props.droppable) {
         return createElement(
           Droppable,
@@ -334,6 +369,38 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
     }
   }
 
+  /**
+   * If the attribute query_item_label is specified, and contains ?query_item_iri,
+   * For each of the selected items the query will be fired and
+   * and the label will be updated
+   */
+  private updateTextField() {
+    const { queryItemLabel } = this.props;
+    if (queryItemLabel) {
+      const selection = this.state.confirmedSelection;
+      const selectedItems = TreeSelection.leafs(selection);
+
+      if (queryItemLabel.indexOf(ITEM_INPUT_VARIABLE) > 0) {
+        selectedItems.map((selectedItem) => {
+          SparqlClient.select(queryItemLabel.replace(`?${ITEM_INPUT_VARIABLE}`, `<${selectedItem.iri.value}>`)).onValue(
+            (result) => {
+              const label = Rdf.literal(result.results.bindings[0][ITEM_OUTPUT_VARIABLE].value);
+              const node = TreeSelection.nodesFromKey(selection, selectedItem.iri.value).first();
+
+              selection.updateNode(selection.getKeyPath(node), (singleNode) => {
+                singleNode.label = label;
+                this.setState({ confirmedSelection: selection });
+                return singleNode;
+              });
+            }
+          );
+        });
+      }
+
+      // TODO: Raise exception here
+    }
+  }
+
   public setValue(iri: Rdf.Iri) {
     this.setInitialSelection([iri]).onValue(this.onSelectionChanged);
   }
@@ -341,18 +408,21 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
   private onSelectionChanged = (selection: TreeSelection<Node>) => {
     if (this.props.onSelectionChanged) {
       this.props.onSelectionChanged(selection);
+      this.updateTextField();
     }
 
     /**
      * selection always has one empty root node, so if selection is 1 then in reality there is nothing selected.
      */
-    if (this.props.id && selection.nodes.size <=2 ) {
+    if (this.props.id && selection.nodes.size <= 2) {
       const iri = selection.nodes.size == 1 ? undefined : selection.nodes.last().first().iri.value;
       trigger({
-        eventType: ItemSelectionChanged, source: this.props.id, data: {iri}
+        eventType: ItemSelectionChanged,
+        source: this.props.id,
+        data: { iri },
       });
     }
-  }
+  };
 
   private renderTextField() {
     const textFieldProps: ClearableInputProps & ReactProps<ClearableInput> = {
@@ -397,8 +467,8 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
       ClearableInput,
       textFieldProps,
       selectedItems
-        .map((item) =>
-          createElement(
+        .map((item) => {
+          return createElement(
             RemovableBadge,
             {
               key: item.iri.value,
@@ -408,13 +478,13 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
                 const previous = this.state.confirmedSelection;
                 const newSelection = TreeSelection.unselect(previous, previous.keyOf(item));
                 this.setState({ confirmedSelection: newSelection }, () => {
-                  this.onSelectionChanged(newSelection)
+                  this.onSelectionChanged(newSelection);
                 });
               },
             },
             item.label.value
-          )
-        )
+          );
+        })
         .toArray()
     );
   }
@@ -469,6 +539,52 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
           matchLimit: parametrized.limit,
         }))
       );
+  }
+
+  renderOpenNewFrameButton() {
+    const { customButton } = this.props;
+    return createElement(
+      OverlayTrigger,
+      {
+        placement: 'bottom',
+        overlay: createElement(
+          Tooltip,
+          {
+            id: 'SemanticTreeInput__tooltip',
+          },
+          customButton.tooltip ? customButton.tooltip : 'Open new frame'
+        ),
+      },
+      createElement(
+        ResourceLinkComponent,
+        {
+          className: styles.browseButton,
+          active: this.state.mode.type === 'full',
+          iri: customButton.iri,
+          'urlqueryparam-view': customButton.view ? customButton.view : '',
+          'urlqueryparam-resource': customButton.resource ? customButton.resource : '',
+          'urlqueryparam-mode': customButton.mode ? customButton.mode : '',
+          onClick: () => {
+            const modeType = this.state.mode.type;
+            if (modeType === 'collapsed' || modeType === 'search') {
+              this.search.cancelAll();
+              this.setState({
+                searchText: undefined,
+                searching: false,
+                searchResult: undefined,
+                mode: { type: 'full', selection: this.state.confirmedSelection },
+              });
+            } else if (modeType === 'full') {
+              this.closeDropdown({ saveSelection: false });
+            }
+          },
+        },
+        D.span({
+          className: 'fa fa-plus fa-lg',
+          ['aria-hidden' as any]: true,
+        })
+      )
+    );
   }
 
   renderBrowseButton() {
@@ -668,7 +784,7 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
           },
           () => {
             if (this.props.closeDropdownOnSelection) {
-              this.closeDropdown({saveSelection: true});
+              this.closeDropdown({ saveSelection: true });
             }
           }
         );

--- a/src/main/web/components/semantic/lazy-tree/SemanticTreeInput.ts
+++ b/src/main/web/components/semantic/lazy-tree/SemanticTreeInput.ts
@@ -122,7 +122,7 @@ export interface SemanticTreeInputProps extends ComplexTreePatterns {
   /**
    * Creates a custom button with a Semantic-link with the following parameters
    */
-  customButton?: CustomButton;
+  newFrameButton?: NewFrameButton;
 
   /**
    * query to retrieve the item label that will be visualized
@@ -165,7 +165,7 @@ interface SearchResult {
   matchLimit?: number;
 }
 
-export interface CustomButton {
+export interface NewFrameButton {
   iri: string;
   view?: string;
   resource?: string;
@@ -328,7 +328,7 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
       );
     } else {
       let result;
-      if (this.props.customButton) {
+      if (this.props.newFrameButton) {
         result = D.div(
           {
             ref: (holder) => (this.overlayHolder = holder),
@@ -542,7 +542,7 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
   }
 
   renderOpenNewFrameButton() {
-    const { customButton } = this.props;
+    const { newFrameButton } = this.props;
     return createElement(
       OverlayTrigger,
       {
@@ -552,18 +552,18 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
           {
             id: 'SemanticTreeInput__tooltip',
           },
-          customButton.tooltip ? customButton.tooltip : 'Open new frame'
+          newFrameButton.tooltip ? newFrameButton.tooltip : 'Open new frame'
         ),
       },
       createElement(
         ResourceLinkComponent,
         {
-          className: styles.browseButton,
+          className: `${styles.browseButton} btn btn-default`,
           active: this.state.mode.type === 'full',
-          iri: customButton.iri,
-          'urlqueryparam-view': customButton.view ? customButton.view : '',
-          'urlqueryparam-resource': customButton.resource ? customButton.resource : '',
-          'urlqueryparam-mode': customButton.mode ? customButton.mode : '',
+          iri: newFrameButton.iri,
+          'urlqueryparam-view': newFrameButton.view ? newFrameButton.view : '',
+          'urlqueryparam-resource': newFrameButton.resource ? newFrameButton.resource : '',
+          'urlqueryparam-mode': newFrameButton.mode ? newFrameButton.mode : '',
           onClick: () => {
             const modeType = this.state.mode.type;
             if (modeType === 'collapsed' || modeType === 'search') {
@@ -668,6 +668,7 @@ export class SemanticTreeInput extends Component<SemanticTreeInputProps, State> 
           : D.div({ className: styles.dropdown }, this.renderDropdownContent(mode), this.renderDropdownFooter(mode))
       )
     );
+    
   }
 
   private updateForest(

--- a/src/main/web/components/semantic/lazy-tree/SparqlNodeModel.ts
+++ b/src/main/web/components/semantic/lazy-tree/SparqlNodeModel.ts
@@ -31,7 +31,7 @@ import { TreeNode, mergeRemovingDuplicates } from './NodeModel';
 
 export interface Node extends TreeNode {
   readonly iri: Rdf.Iri;
-  readonly label?: Rdf.Literal;
+  label?: Rdf.Literal;
   readonly children?: ReadonlyArray<Node>;
   readonly reachedLimit?: boolean;
   /** search relevance */


### PR DESCRIPTION

# Why

This update is requested for the following use cases.

For the VeNiss project, when curators are creating primary sources, they also need to specify the archival location. The archival locations vocabulary is structured in a tree. For each archival location, its displayed label is the concatenation of the names of all ancestors. 

In the same way, when curators are creating primary sources, they should be able to create new archival locations easily. For this reason, the system should provide an easy way to open the Vocabulary in a new frame.


# What

The Semantic Tree Input has been updated with two new features.


**Specify a custom button to open a new frame.**
Normally, the Semantic Tree Input component features a default button to open and browse the elements returned by the query. With these new attributes, the system can replace this button with another one, able to open up a new frame.

In the following example,  we can see how the custom button is handled.
```
<semantic-form-tree-picker-input 
  label="Archival location" 
  for='example'
  custom-button='{
    "iri": "http://www.researchspace.org/resource/ThinkingFrames",
    "view": "authority-content",
    "resource": "http://www.researchspace.org/resource/vocab/archival_location",
   "tooltip": "This is the tooltip to open a new frame for vocab example"
  }'
</semantic-form-tree-picker-input>
```

**Custom SPARQL query to update displayed labels.**
Normally, the Semantic Tree Input component uses the custom label service. With this update, the component can now trigger a SPARQL select query containing the whole business logic to retrieve that label. This functionality has been tested with the following use case: get the full path (intended as the concatenation of `rdfs:label` properties from the element to the tree root) of a node belonging to a tree. 

The Semantic Tree Picker has been constructed as follows:

```
<semantic-form-tree-picker-input 
  label="Archival location" 
  for='example'
  query-item-label='
    select (group_concat(distinct ?lbl; separator=", ") as ?item_label) where {
      {
        select ?class ?lbl where {
          ?query_item_iri crm:P46i_forms_part_of* ?mid.
          ?mid crm:P46i_forms_part_of* ?class.
          ?class rdfs:label ?lbl
        }
        group by ?class ?lbl
        order by desc(count(?mid))
      }
    }
  '
</semantic-form-tree-picker-input>
```

**Note:** The query associated with the attribute `query-item-label` must have a `?query_item_iri` variable and it will be replaced with the IRI of the selected element.

# Video / Gif / Screenshot

This picture shows how the new tree picker input is displayed
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/8267319/229095707-4424452a-022b-4dd4-b460-ff57ee7f8620.png">

# Meta

This solution is tailored to the use cases described above. When specific new use cases will rise, the system should be also able to display a list of buttons instead of replacing the default one.

The displayed label should not be stored anywhere in the database. Otherwise, if the curator changes the structure of the tree, updating the parents of a single element, the displayed label should be changed accordingly.  

# How To Test

Create a new form template and paste the example above.

