### PR TITLE
fix encodeIri breaking when parameter is not a string

### DIFF
--- a/src/main/web/components/forms/FormModel.ts
+++ b/src/main/web/components/forms/FormModel.ts
@@ -389,7 +389,7 @@ const DISALLOWED_CHARACTERS = /[\u0000-\u0020<>:?*"|/\\&$@=+,#\u007f-\u00ff%\s]/
 const COLLAPSE_UNDERSCORES = /_+/gi;
 
 export function encodeIri(fileName: string) {
-  let transformed = fileName;
+  let transformed = String(fileName);
   transformed = transformed.replace(DISALLOWED_CHARACTERS, '_');
   transformed = transformed.replace(COLLAPSE_UNDERSCORES, '_');
   return transformed;


### PR DESCRIPTION
The `encodeIri` function of `FormModel` breaks when its parameter is not a string. This PR fixes this by always converting the parameter to a String.

In Researchspace `encodeIri` is sometimes given a number even though the parameter is declared as string in Typescript. This happens particularly through the new-subject parameter of the semantic-form element.