### PR TITLE
semantic-form-tree-picker-input

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,54 @@
 # Why
 
-What is the reason for these changes, to give reviewers some context. 📚
+The semantic-form-tree-picker-input in forms allows to render a dropdown where the user can select terms from a vocabulary (called 'scheme') structured as a tree.
+
+The current version of the semantic-form-tree-picker-input has:
+-  'tree-patterns' to specify the scheme details ;
+-  'nested-form-template' to displays a button (New) that open a modal where the user can create a new term in the vocabulary.
+
+An update of the Semantic Tree Input is requested for the following actions:
+
+- allow the user to easily open the entire Vocabulary in a new frame;
+- allow an easy customisation of the term labels when displayed in the vocabulary list or in the selected term.
 
 # What
+```
+<semantic-form-tree-picker-input 
+   for='type' label="Type" 
+   placeholder="Select type"
+   close-dropdown-on-selection='false'
+   tree-patterns='{"scheme": "http://www.researchspace.org/resource/vocab/types", 
+                               "schemePattern": "?item <http://www.cidoc-crm.org/cidoc-crm/P71i_is_listed_in> <http://www.researchspace.org/resource/vocab/types>",
+                               "relationPattern": "?item crm:P127_has_broader_term ?parent",
+                                 "labelPattern": "?item skos:prefLabel ?label"}'
 
-What code changes are included inside? 👀
-If a new component has been added or updated provide an example on how to use it.
+ scheme-page-button-config='{"iri": "http://www.researchspace.org/resource/ThinkingFrames",
+                   "view": "authority-content",
+                    "scheme": "http://www.researchspace.org/resource/vocab/types",
+                     "tooltip": "Open list of terms"
+                                                      }'
+
+ nested-form-template='{{{{raw}}}}
+                                            {{> forms:E55_Type nested=true editable=true 
+                                                scheme="http://www.researchspace.org/resource/vocab/types"
+                                                entityType="type" }}
+                                          {{{{/raw}}}}'
+
+ query-item-label='SELECT ?label WHERE {
+                                    ?item skos:altLabel ?label .
+                                 }'
+>
+</semantic-form-tree-picker-input> 
+```
+
+<img width="723" alt="semantic-tree-input example" src="https://github.com/researchspace/researchspace/assets/25387447/22c296a0-543b-44ec-b6c8-1dbc59fd43ed">
+
+
+
+
+The Semantic Tree Input has been updated with two new features.
+
+
 
 # Video / Gif / Screenshot
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,54 +1,11 @@
 # Why
 
-The semantic-form-tree-picker-input in forms allows to render a dropdown where the user can select terms from a vocabulary (called 'scheme') structured as a tree.
-
-The current version of the semantic-form-tree-picker-input has:
--  'tree-patterns' to specify the scheme details ;
--  'nested-form-template' to displays a button (New) that open a modal where the user can create a new term in the vocabulary.
-
-An update of the Semantic Tree Input is requested for the following actions:
-
-- allow the user to easily open the entire Vocabulary in a new frame;
-- allow an easy customisation of the term labels when displayed in the vocabulary list or in the selected term.
+What is the reason for these changes, to give reviewers some context. 📚
 
 # What
-```
-<semantic-form-tree-picker-input 
-   for='type' label="Type" 
-   placeholder="Select type"
-   close-dropdown-on-selection='false'
-   tree-patterns='{"scheme": "http://www.researchspace.org/resource/vocab/types", 
-                               "schemePattern": "?item <http://www.cidoc-crm.org/cidoc-crm/P71i_is_listed_in> <http://www.researchspace.org/resource/vocab/types>",
-                               "relationPattern": "?item crm:P127_has_broader_term ?parent",
-                                 "labelPattern": "?item skos:prefLabel ?label"}'
 
- scheme-page-button-config='{"iri": "http://www.researchspace.org/resource/ThinkingFrames",
-                   "view": "authority-content",
-                    "scheme": "http://www.researchspace.org/resource/vocab/types",
-                     "tooltip": "Open list of terms"
-                                                      }'
-
- nested-form-template='{{{{raw}}}}
-                                            {{> forms:E55_Type nested=true editable=true 
-                                                scheme="http://www.researchspace.org/resource/vocab/types"
-                                                entityType="type" }}
-                                          {{{{/raw}}}}'
-
- query-item-label='SELECT ?label WHERE {
-                                    ?item skos:altLabel ?label .
-                                 }'
->
-</semantic-form-tree-picker-input> 
-```
-
-<img width="723" alt="semantic-tree-input example" src="https://github.com/researchspace/researchspace/assets/25387447/22c296a0-543b-44ec-b6c8-1dbc59fd43ed">
-
-
-
-
-The Semantic Tree Input has been updated with two new features.
-
-
+What code changes are included inside? 👀
+If a new component has been added or updated provide an example on how to use it.
 
 # Video / Gif / Screenshot
 

--- a/src/main/web/components/forms/forms.scss
+++ b/src/main/web/components/forms/forms.scss
@@ -451,33 +451,46 @@ fieldset[disabled] .form-control {
     flex: auto;
   }
 
-  &__create-button {
-    margin-left: 5px;
+  .semantic-form-tree-picker-input__create-button.btn-default {
+
+    min-height: 40px;
+    height: auto;
+
+    margin-left: -1px;
+    padding: 0 15px;
+
+    border: 1px solid $input-border-color;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+
+    background-color: $input-color-bg;
 
     display: flex;
     align-items: center;
 
-    background-color: $input-color-bg;
-
-    border-radius: $input-border-radius;
-
-    height: $input-height;
-
     font-weight: 600;
-    font-size: 16px;
-    padding: 0 15px;
 
-    .fa-plus {
-
-      font-size: 14px;
+    &:hover, 
+    &:active, 
+    &.active, 
+    &:focus, 
+    &.focus, 
+    &:active:hover, 
+    &:active:focus, 
+    &:active.focus, 
+    &.active:hover, 
+    &.active:focus, 
+    &.active.focus, 
+    .open > &.dropdown-toggle, 
+    .open > &.dropdown-toggle:hover, 
+    .open > &.dropdown-toggle:focus, 
+    .open > &.dropdown-toggle.focus {
+  
+      border: 1px solid $input-border-color;
+      background-color: $input-color-bg;
     }
   }
 
-  &__create-button.btn-default,
-  &__create-button.btn-default:active:hover {
-
-    border: 1px solid $input-border-color;
-  }
 }
 
 .semantic-form-errors {

--- a/src/main/web/components/semantic/lazy-tree/SparqlNodeModel.ts
+++ b/src/main/web/components/semantic/lazy-tree/SparqlNodeModel.ts
@@ -31,7 +31,7 @@ import { TreeNode, mergeRemovingDuplicates } from './NodeModel';
 
 export interface Node extends TreeNode {
   readonly iri: Rdf.Iri;
-  readonly label?: Rdf.Literal;
+  label?: Rdf.Literal;
   readonly children?: ReadonlyArray<Node>;
   readonly reachedLimit?: boolean;
   /** search relevance */


### PR DESCRIPTION
# Why
The semantic-form-tree-picker-input in forms allows to render a dropdown where the user can select terms from a vocabulary (called 'scheme') structured as a tree.

The current version of the semantic-form-tree-picker-input has:
-  'tree-patterns' to specify the scheme details;
-  'nested-form-template' to display a button (New) that opens a modal where the user can create a new term in the vocabulary.

An update of the Semantic Tree Input is requested for the following actions:
- allow the user to easily open the entire Vocabulary in a new frame;
- allow an easy customisation of the term labels when displayed in the vocabulary list or in the selected term.

# What
```
<semantic-form-tree-picker-input 
  for='type' 
  label="Type" 
  placeholder="Select type"
  close-dropdown-on-selection='false'
  tree-patterns='{"scheme": "http://www.researchspace.org/resource/vocab/types", 
                  "schemePattern": "?item <http://www.cidoc-crm.org/cidoc-crm/P71i_is_listed_in> <http://www.researchspace.org/resource/vocab/types>",
                  "relationPattern": "?item crm:P127_has_broader_term ?parent",
                  "labelPattern": "?item skos:prefLabel ?label"
                 }'

  scheme-page-button-config='{"iri": "http://www.researchspace.org/resource/ThinkingFrames",
                              "view": "authority-content",
                              "scheme": "http://www.researchspace.org/resource/vocab/types",
                              "tooltip": "Open list of terms"
                            }'

  nested-form-template='{{{{raw}}}}{{> forms:E55_Type nested=true editable=true 
                        scheme="http://www.researchspace.org/resource/vocab/types"
                        entityType="type" }}{{{{/raw}}}}'

  query-item-label='SELECT ?label WHERE {
                      ?item skos:altLabel ?label .
                    }'
>
</semantic-form-tree-picker-input> 
```

The Semantic Tree Input has been updated with two new features.


### **A custom button to open the Vocabulary in a new frame**
With the attribute scheme-page-button-config we can now render a button on the right side of the input. 
This button allows to open the vocabulary (scheme) in a new frame. 

In the following example,  we can see how the custom button is handled.
```
<semantic-form-tree-picker-input 
    scheme-page-button-config='{"iri": "http://www.researchspace.org/resource/ThinkingFrames",
                                "view": "authority-content",
                                "scheme": "http://www.researchspace.org/resource/vocab/types",
                                "tooltip": "Open list of terms"
                              }'
>
</semantic-form-tree-picker-input>
```
**Note:** The button must have iri, view and scheme. Tooltip value is optional.

### **A custom SPARQL query for selected term label**
Currently, the Semantic Tree Input component uses the custom label service to render the label of a selected item. With this update, the component can now trigger a custom SPARQL select query containing the logic to retrieve that label. 

The functionality has been constructed as follows:

```
<semantic-form-tree-picker-input 
  query-item-label='SELECT ?label WHERE {
    ?item skos:altLabel ?label .
  }'
>
</semantic-form-tree-picker-input>
```

**Note:** The SPARQL query must have ?item and ?label variables.


# Video / Gif / Screenshot

This picture shows how the new tree picker input is displayed
<img width="723" alt="semantic-tree-input example" src="https://github.com/researchspace/researchspace/assets/25387447/22c296a0-543b-44ec-b6c8-1dbc59fd43ed">

# How To Test
Create a new semantic-form template, define a vocabulary list and add a semantic-form-tree-picker-input using the vocabulary, following the example above.




