### PR TITLE
Add secrets from environment + unit test

### DIFF
--- a/src/main/java/org/researchspace/secrets/AbstractSecretResolver.java
+++ b/src/main/java/org/researchspace/secrets/AbstractSecretResolver.java
@@ -121,6 +121,17 @@ public abstract class AbstractSecretResolver implements SecretResolver {
         if (prefix != null) {
             key = prefix + key;
         }
+
+        /** 
+        * @GSpinaci complete transformation
+        * 
+        * Set key to lowercase
+        * Then, transform everything into character '.' except: [A-z0-9]
+        * 
+        */ 
+        key = key.toLowerCase();
+        key = key.replaceAll("[^A-z0-9]", ".");
+
         return Optional.of(key);
     }
 

--- a/src/main/java/org/researchspace/secrets/EnvironmentSecretResolver.java
+++ b/src/main/java/org/researchspace/secrets/EnvironmentSecretResolver.java
@@ -20,8 +20,17 @@ import java.util.Optional;
 
 public class EnvironmentSecretResolver extends AbstractSecretResolver {
 
-    @Override
-    protected Optional<String> lookup(String key) {
-        return Optional.ofNullable(System.getenv(key));
-    }
+  // @GSpinaci add prefix "secret."
+  public EnvironmentSecretResolver() {
+    super("secret.");
+  }
+
+  @Override
+  protected Optional<String> lookup(String key) {
+    /**
+     * @GSpinaci Get JVM property by key
+     *           such as "secret.repo.username"
+     */
+    return Optional.ofNullable(System.getProperty(key));
+  }
 }

--- a/src/test/java/org/researchspace/secrets/SecretsTest.java
+++ b/src/test/java/org/researchspace/secrets/SecretsTest.java
@@ -11,12 +11,6 @@ import javax.inject.Inject;
 import org.junit.After;
 import org.junit.Test;
 import org.researchspace.junit.AbstractIntegrationTest;
-import org.researchspace.secrets.MapSecretResolver;
-import org.researchspace.secrets.Secret;
-import org.researchspace.secrets.SecretLookup;
-import org.researchspace.secrets.SecretResolver;
-import org.researchspace.secrets.SecretsHelper;
-import org.researchspace.secrets.SecretsStore;
 
 public class SecretsTest extends AbstractIntegrationTest {
 
@@ -93,9 +87,10 @@ public class SecretsTest extends AbstractIntegrationTest {
     public void testEnvironmentSecretResolver() {
         // Create Envinronmet variable with secret
         System.setProperty("secret.test.password", "password123");
+        EnvironmentSecretResolver resolver = new EnvironmentSecretResolver();
 
         // Resolve secret
-        Optional<String> secret = SecretsHelper.resolveSecretAsString(secretResolver, "${test.password}");
+        Optional<String> secret = SecretsHelper.resolveSecretAsString(resolver, "${test.password}");
 
         assertTrue(secret.isPresent());
         assertEquals("password123", secret.get());

--- a/src/test/java/org/researchspace/secrets/SecretsTest.java
+++ b/src/test/java/org/researchspace/secrets/SecretsTest.java
@@ -88,6 +88,19 @@ public class SecretsTest extends AbstractIntegrationTest {
         assertTrue(SecretsHelper.isResolvableSecret("${-FZ7LEt#.T8W}"));
     }
 
+
+    @Test
+    public void testEnvironmentSecretResolver() {
+        // Create Envinronmet variable with secret
+        System.setProperty("secret.test.password", "password123");
+
+        // Resolve secret
+        Optional<String> secret = SecretsHelper.resolveSecretAsString(secretResolver, "${test.password}");
+
+        assertTrue(secret.isPresent());
+        assertEquals("password123", secret.get());
+    }
+
     @Test
     public void testKeyValue() {
         assertEquals("abc", SecretLookup.getLookupKey("${abc}").orElse("XXX"));


### PR DESCRIPTION
# Why

Secrets from the Java Environment would not be mapped when initialising repositories.

# What

There were a few lines of code to close #282.
Two Java classes have been modified. 

**AbstractSecretResolver** removes unexpected characters and transforms to lowercase the key to access secrets (e.g., what comes after "secret.")

**EnvironmentSecretResolver** detects when a secret starts with "secret" and returns the key.

# Video / Gif / Screenshot

There are no UI changes.

# Meta

The decision was to prepend "secret." to the secret variable name, as described in the RS documentation.

# How To Test

I have integrated the unit test in **SecretsTest.java**. 

But also, creating a repository with a username and password pair is necessary to test. Then, try a federated query against that repository using ephedra. 

This is similar to something we use for the [VeNiss app (GeoSQL repository)](https://github.com/villaitatti/VeNiss/blob/master/config/repositories/geo.ttl). In that case, we have published the app with the repository with a secret password and username pair.