### PR TITLE
Sail

### DIFF
--- a/src/main/java/org/researchspace/repository/MpRepositoryVocabulary.java
+++ b/src/main/java/org/researchspace/repository/MpRepositoryVocabulary.java
@@ -55,6 +55,11 @@ public class MpRepositoryVocabulary {
     public static final String FEDERATION_NAMESPACE = "http://www.researchspace.org/resource/system/ephedra#";
 
     /**
+     * Namespace for the SQL configuration properties of custom services.
+     */
+    public static final String SQL_NAMESPACE = "http://www.researchspace.org/resource/system/sql#";
+
+    /**
      * For each federation member declared in the federation descriptor,
      * delegateRepositoryID points to its repository ID.
      */
@@ -126,6 +131,11 @@ public class MpRepositoryVocabulary {
     public static final IRI AUTHORIZATION_KEY = VF.createIRI(FEDERATION_NAMESPACE, "authKey");
     public static final IRI AUTHORIZATION_VALUE = VF.createIRI(FEDERATION_NAMESPACE, "authValue");
     public static final IRI AUTHORIZATION_LOCATION = VF.createIRI(FEDERATION_NAMESPACE, "authLocation");
+
+    // SQL authorization
+    public static final IRI INCLUDE_SQL_QUERY = VF.createIRI(SQL_NAMESPACE, "includesSQLQuery");
+    public static final IRI HAS_QUERY_ID = VF.createIRI(SQL_NAMESPACE, "hasQueryId");
+    public static final IRI HAS_QUERY_TEXT = VF.createIRI(SQL_NAMESPACE, "text");
 
     public static final Set<IRI> queryHints = Sets.newHashSet(EXECUTE_FIRST, EXECUTE_LAST, DISABLE_JOIN_REORDERING);
 

--- a/src/main/java/org/researchspace/sail/rest/AbstractServiceWrappingSailConfig.java
+++ b/src/main/java/org/researchspace/sail/rest/AbstractServiceWrappingSailConfig.java
@@ -35,6 +35,11 @@ import org.researchspace.repository.MpRepositoryVocabulary;
  * Holds one generic parameter: service URL.
  * 
  * @author Andriy Nikolov <an@metaphacts.com>
+ * 
+ * Update for generic purpose
+ * 
+ * @modifier Janmaruko Hōrensō <@gspinaci>
+ * 
  *
  */
 public abstract class AbstractServiceWrappingSailConfig extends AbstractSailImplConfig {
@@ -49,11 +54,11 @@ public abstract class AbstractServiceWrappingSailConfig extends AbstractSailImpl
     private String unResolvedUsername;
     private String unResolvedPassword;
 
-    public AbstractServiceWrappingSailConfig() {
+    protected AbstractServiceWrappingSailConfig() {
 
     }
 
-    public AbstractServiceWrappingSailConfig(String type) {
+    protected AbstractServiceWrappingSailConfig(String type) {
         super(type);
     }
 
@@ -61,7 +66,7 @@ public abstract class AbstractServiceWrappingSailConfig extends AbstractSailImpl
     public void validate() throws SailConfigException {
         super.validate();
         if (StringUtils.isEmpty(url)) {
-            throw new SailConfigException("REST service URL is not provided");
+            throw new SailConfigException("SAIL service URL is not provided");
         }
     }
 

--- a/src/main/java/org/researchspace/sail/rest/AbstractServiceWrappingSailConnection.java
+++ b/src/main/java/org/researchspace/sail/rest/AbstractServiceWrappingSailConnection.java
@@ -20,6 +20,7 @@
 package org.researchspace.sail.rest;
 
 import java.io.InputStream;
+import java.sql.ResultSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -220,6 +221,9 @@ public abstract class AbstractServiceWrappingSailConnection<C extends AbstractSe
     protected abstract ServiceParametersHolder extractInputsAndOutputs(List<StatementPattern> stmtPatterns)
             throws SailException;
 
-    protected abstract Collection<BindingSet> convertStream2BindingSets(InputStream inputStream,
+    protected abstract Collection<BindingSet> convertResult2BindingSets(InputStream result,
+            ServiceParametersHolder parametersHolder) throws SailException;
+
+    protected abstract Collection<BindingSet> convertResult2BindingSets(ResultSet result,
             ServiceParametersHolder parametersHolder) throws SailException;
 }

--- a/src/main/java/org/researchspace/sail/rest/RESTSailConfig.java
+++ b/src/main/java/org/researchspace/sail/rest/RESTSailConfig.java
@@ -88,6 +88,7 @@ public class RESTSailConfig extends AbstractServiceWrappingSailConfig {
     }
 
     public static final String JSON = "JSON";
+    public static final String XML = "XML";
 
     private String httpMethod;
 

--- a/src/main/java/org/researchspace/sail/rest/RESTSailConnection.java
+++ b/src/main/java/org/researchspace/sail/rest/RESTSailConnection.java
@@ -20,6 +20,7 @@ package org.researchspace.sail.rest;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -92,38 +93,48 @@ public class RESTSailConnection extends AbstractServiceWrappingSailConnection<RE
     }
 
     @Override
-    protected Collection<BindingSet> convertStream2BindingSets(InputStream inputStream,
+    protected Collection<BindingSet> convertResult2BindingSets(ResultSet result,
             ServiceParametersHolder parametersHolder) throws SailException {
+        throw new UnsupportedOperationException("Unimplemented method 'convertResult2BindingSets'");
 
+    }
+
+    @Override
+    protected Collection<BindingSet> convertResult2BindingSets(InputStream result,
+            ServiceParametersHolder parametersHolder) throws SailException {
         logger.trace("REST Response received");
 
         List<BindingSet> results = Lists.newArrayList();
 
         try {
-            String stringResponse = IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
+            String stringResponse = IOUtils.toString(result, StandardCharsets.UTF_8.name());
 
-            // TODO: check the string format and call the right type. E.g., json or XML
             String type = RESTSailConfig.JSON;
 
             logger.trace("REST Response type is {}", type);
             switch (type) {
-            case RESTSailConfig.JSON:
+                case RESTSailConfig.JSON:
 
-                // Get the root path
-                Optional<Parameter> param = getSail().getSubjectParameter();
-                String rootPath = param.isPresent() ? param.get().getJsonPath() : "$";
+                    // Get the root path
+                    Optional<Parameter> param = getSail().getSubjectParameter();
+                    String rootPath = param.isPresent() ? param.get().getJsonPath() : "$";
 
-                results = executeJson(stringResponse, rootPath, parametersHolder.getOutputVariables());
-                break;
+                    results = executeJson(stringResponse, rootPath, parametersHolder.getOutputVariables());
+                    break;
 
-            default:
-                break;
+                case RESTSailConfig.XML:
+                    logger.trace("XML format not supported yet");
+                    break;
+
+                default:
+                    break;
             }
 
             return results;
         } catch (Exception e) {
             throw new SailException(e);
         }
+
     }
 
     /**
@@ -234,7 +245,7 @@ public class RESTSailConnection extends AbstractServiceWrappingSailConnection<RE
         }
         InputStream resultStream = (InputStream) response.getEntity();
         return new CollectionIteration<BindingSet, QueryEvaluationException>(
-                convertStream2BindingSets(resultStream, parametersHolder));
+                convertResult2BindingSets(resultStream, parametersHolder));
     }
 
     protected Response submit(ServiceParametersHolder parametersHolder) {
@@ -430,4 +441,5 @@ public class RESTSailConnection extends AbstractServiceWrappingSailConnection<RE
 
         return map;
     }
+
 }

--- a/src/main/java/org/researchspace/sail/rest/sql/MpJDBCDriverManager.java
+++ b/src/main/java/org/researchspace/sail/rest/sql/MpJDBCDriverManager.java
@@ -37,7 +37,7 @@ public class MpJDBCDriverManager {
 
     private final CopyOnWriteArrayList<Driver> registeredDrivers = new CopyOnWriteArrayList<>();
 
-    public MpJDBCDriverManager() {
+    protected MpJDBCDriverManager() {
     }
 
     public Connection getConnection(String url) throws SQLException {
@@ -65,45 +65,41 @@ public class MpJDBCDriverManager {
     public Connection getConnection(String url, java.util.Properties info) throws SQLException {
 
         if (url == null) {
-            throw new SQLException("The url cannot be null", "08001");
+          throw new SQLException("The url cannot be null", "08001");
         }
 
-        logger.trace("DriverManager.getConnection(\"" + url + "\")");
+        logger.trace("getConnection: {}", url);
 
         SQLException reason = null;
         SQLException originalReason = null;
 
         try {
-            return DriverManager.getConnection(url, info);
+          return DriverManager.getConnection(url, info);
         } catch (SQLException e) {
-            originalReason = e;
+          originalReason = e;
         }
 
         for (Driver driver : registeredDrivers) {
-            try {
-                Connection con = driver.connect(url, info);
-                if (con != null) {
-                    logger.trace("getConnection returning " + driver.getClass().getName());
-                    return (con);
-                }
-            } catch (SQLException ex) {
-                if (reason == null) {
-                    reason = ex;
-                }
+          try {
+            Connection con = driver.connect(url, info);
+            if (con != null) {
+              logger.trace("getConnection: returning {}", driver.getClass().getName());
+              return (con);
             }
-        }
-
-        if (reason == null) {
-            reason = originalReason;
+          } catch (SQLException ex) {
+            if (reason == null) {
+              reason = ex;
+            }
+          }
         }
 
         // if we got here nobody could connect.
         if (reason != null) {
-            logger.warn("getConnection failed: " + reason);
-            throw reason;
+          logger.trace("getConnection: failed {}", reason);
+          throw reason;
         }
 
-        logger.warn("getConnection: no suitable driver found for " + url);
+        logger.warn("getConnection: no suitable driver found for {}", url);
         throw new SQLException("No suitable driver found for " + url, "08001");
     }
 

--- a/src/main/java/org/researchspace/sail/rest/sql/SQLSail.java
+++ b/src/main/java/org/researchspace/sail/rest/sql/SQLSail.java
@@ -1,0 +1,189 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2021, © Trustees of the British Museum
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+ package org.researchspace.sail.rest.sql;
+
+ import java.util.Map;
+ import java.util.Set;
+ import java.util.regex.Matcher;
+ import java.util.regex.Pattern;
+ 
+ import javax.inject.Provider;
+ 
+ import com.google.common.collect.Maps;
+ import com.google.inject.Inject;
+ 
+ import org.apache.commons.lang3.StringUtils;
+ import org.eclipse.rdf4j.model.IRI;
+ import org.eclipse.rdf4j.model.Model;
+ import org.eclipse.rdf4j.model.Resource;
+ import org.eclipse.rdf4j.model.util.Models;
+ import org.eclipse.rdf4j.model.vocabulary.SPIN;
+ import org.eclipse.rdf4j.sail.SailConnection;
+ import org.eclipse.rdf4j.sail.SailException;
+ import org.researchspace.repository.MpRepositoryVocabulary;
+ import org.researchspace.sail.rest.AbstractServiceWrappingSail;
+ import org.researchspace.vocabulary.SPL;
+ 
+ /**
+  * 
+  * @author Janmaruko Hōrensō <@gspinaci>
+  *
+  */
+ 
+ public class SQLSail extends AbstractServiceWrappingSail<SQLSailConfig> {
+ 
+     private static final String SQL_PARAMETER = "?";
+     private static final String SQL_PARAMETER_DELIMITER = "_";
+ 
+     public class SQLParameter {
+ 
+         private String name;
+         private IRI type;
+ 
+         public SQLParameter(String name) {
+             this.setName(name);
+             this.setType(null);
+         }
+ 
+         public IRI getType() {
+             return type;
+         }
+ 
+         public void setType(IRI type) {
+             this.type = type;
+         }
+ 
+         public String getName() {
+             return name;
+         }
+ 
+         public void setName(String name) {
+             this.name = name;
+         }
+     }
+ 
+ 
+     public class SQLQuery {
+ 
+         private String query;
+         private Map<Integer, SQLParameter> inputParametersMap;
+ 
+         public SQLQuery() {
+             setQuery(null);
+             setInputParametersMap(Maps.newHashMap());
+         }
+ 
+         public Map<Integer, SQLParameter> getInputParametersMap() {
+             return inputParametersMap;
+         }
+ 
+         public void setInputParametersMap(Map<Integer, SQLParameter> inputParametersMap) {
+             this.inputParametersMap = inputParametersMap;
+         }
+ 
+         public String getQuery() {
+             return query;
+         }
+ 
+         public void setQuery(String query) {
+             this.query = query;
+         }
+ 
+         public void putInput(Integer index, SQLParameter parameter) {
+             getInputParametersMap().put(index, parameter);
+         }
+ 
+     }
+ 
+     private Map<String, SQLQuery> sqlQueriesMap =  Maps.newHashMap();
+     private static final Pattern SQL_VARS_PATTERN = Pattern.compile("\\?[a-zA-Z_]+");
+ 
+     @Inject
+     Provider<MpJDBCDriverManager> jdbcDriverManager;
+ 
+     public SQLSail(SQLSailConfig config) {
+         super(config);
+     }
+ 
+     protected void parseQueriesMap() {
+ 
+         Model model = getServiceDescriptor().getModel();
+ 
+         Set<Resource> queries = Models.getPropertyResources(model, getServiceDescriptor().getServiceIRI(), MpRepositoryVocabulary.INCLUDE_SQL_QUERY);
+ 
+         queries.stream().forEach(resource -> {
+             String queryId = Models.getPropertyString(model, resource, MpRepositoryVocabulary.HAS_QUERY_ID).orElse("");
+             String queryText = Models.getPropertyString(model, resource, MpRepositoryVocabulary.HAS_QUERY_TEXT).orElse("");
+ 
+             Matcher matcher = SQL_VARS_PATTERN.matcher(queryText);
+             SQLQuery query = new SQLQuery();
+ 
+             int index = 0;
+ 
+             while (matcher.find()) { 
+                 String varName = matcher.group().replace(SQL_PARAMETER, "");
+                 Set<Resource> res = Models.getPropertyResources(model, getServiceDescriptor().getServiceIRI(), SPIN.CONSTRAINT_PROPERTY);
+ 
+                 SQLParameter sqlParameter = new SQLParameter(varName);
+ 
+                 res.stream()
+                 .filter(
+                     reso -> {
+                         String tmp = Models.getPropertyString(model, reso, SPL.PREDICATE_PROPERTY).orElse("");
+                         return StringUtils.equals(MpRepositoryVocabulary.NAMESPACE.concat(SQL_PARAMETER_DELIMITER).concat(varName), tmp);
+                     }
+                 ).forEach(
+                     reso-> {
+                         IRI typeIri = Models.getPropertyIRI(model, reso, SPL.VALUETYPE_PROPERTY).orElse(null);
+                         sqlParameter.setType(typeIri);
+                     }
+                 );
+ 
+                 query.putInput(++index, sqlParameter);
+             }
+ 
+             query.setQuery(matcher.replaceAll(SQL_PARAMETER));
+             sqlQueriesMap.put(queryId, query);
+         });
+     }
+ 
+     public Map<String, SQLQuery> getSQLQueries() {
+         if (sqlQueriesMap.isEmpty())
+             parseQueriesMap();
+ 
+         return this.sqlQueriesMap;
+     }
+ 
+     public SQLQuery getQueryById(String id) {
+         if (sqlQueriesMap.isEmpty())
+             parseQueriesMap();
+ 
+         return this.sqlQueriesMap.get(id);
+     }
+ 
+ 
+     @Override
+     protected SailConnection getConnectionInternal() throws SailException {
+         initParameters();
+ 
+         getConfig().setDriverManager(this.jdbcDriverManager.get());
+ 
+         return new SQLSailConnection(this);
+     }
+ }

--- a/src/main/java/org/researchspace/sail/rest/sql/SQLSailConfig.java
+++ b/src/main/java/org/researchspace/sail/rest/sql/SQLSailConfig.java
@@ -1,0 +1,41 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2024, © Trustees of the British Museum
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.researchspace.sail.rest.sql;
+
+import org.researchspace.sail.rest.AbstractServiceWrappingSailConfig;
+
+/**
+ * 
+ * @author Janmaruko Hōrensō <@gspinaci>
+ *
+ */
+
+public class SQLSailConfig extends AbstractServiceWrappingSailConfig {
+
+  protected MpJDBCDriverManager driverManager; 
+
+
+  public MpJDBCDriverManager getDriverManager() {
+    return driverManager;
+  }
+
+  public void setDriverManager(MpJDBCDriverManager driverManager) {
+    this.driverManager = driverManager;
+  }
+
+}

--- a/src/main/java/org/researchspace/sail/rest/sql/SQLSailConnection.java
+++ b/src/main/java/org/researchspace/sail/rest/sql/SQLSailConnection.java
@@ -107,8 +107,7 @@ public class SQLSailConnection extends AbstractServiceWrappingSailConnection<SQL
 
                 IRI type = entry.getValue().getType();
                 String name = entry.getValue().getName();
-                String value = parametersHolder.getInputParameters().get(name);
-
+                String value = parametersHolder.getInputParameters().get(name);     
                 if (value == null || value.isEmpty())
                     throw new SailException("The variable " + name + " is missing.");
 
@@ -184,15 +183,15 @@ public class SQLSailConnection extends AbstractServiceWrappingSailConnection<SQL
         List<BindingSet> bindingSets = Lists.newArrayList();
 
         // Convert inputStream to list of binding sets
-
+        
         try {
             while (resultSet.next()) {
 
                 MapBindingSet mapBindingSet = new MapBindingSet();
                 for (Map.Entry<IRI, String> outputParameter : parametersHolder.getOutputVariables().entrySet()) {
-
+                    
                     Parameter parameter = getSail().getServiceDescriptor().getOutputParameters()
-                            .get(outputParameter.getKey().getLocalName());
+                            .get(outputParameter.getValue());
                     IRI type = parameter.getValueType();
 
                     String strObj = resultSet.getString(outputParameter.getValue());

--- a/src/main/java/org/researchspace/sail/rest/sql/SQLSailConnection.java
+++ b/src/main/java/org/researchspace/sail/rest/sql/SQLSailConnection.java
@@ -1,0 +1,238 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2021, © Trustees of the British Museum
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.researchspace.sail.rest.sql;
+
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.ws.rs.core.Response;
+
+import com.google.common.collect.Lists;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.evaluation.iterator.CollectionIteration;
+import org.eclipse.rdf4j.query.impl.MapBindingSet;
+import org.eclipse.rdf4j.sail.SailException;
+import org.researchspace.sail.rest.AbstractServiceWrappingSail;
+import org.researchspace.sail.rest.AbstractServiceWrappingSailConnection;
+import org.researchspace.sail.rest.RESTWrappingSailUtils;
+import org.researchspace.sail.rest.sql.SQLSail.SQLParameter;
+import org.researchspace.sail.rest.sql.SQLSail.SQLQuery;
+import org.researchspace.federation.repository.service.ServiceDescriptor.Parameter;
+import org.researchspace.repository.MpRepositoryVocabulary;
+
+/**
+ * 
+ * @author Janmaruko Hōrensō <@gspinaci>
+ *
+ */
+
+public class SQLSailConnection extends AbstractServiceWrappingSailConnection<SQLSailConfig> {
+
+    private static final Logger logger = LogManager.getLogger(SQLSailConnection.class);
+
+    protected static final ValueFactory VF = SimpleValueFactory.getInstance();
+
+    protected Connection databaseConnection = null;
+    private PreparedStatement ps;
+
+    public SQLSailConnection(AbstractServiceWrappingSail<SQLSailConfig> sailBase) {
+        super(sailBase);
+
+        // Initialize connection to the database
+        initializeConnection();
+    }
+
+    protected void initializeConnection() throws SailException {
+        try {
+
+            String url = this.getSail().getConfig().getUrl();
+            String username = this.getSail().getConfig().getUsername();
+            String passw = this.getSail().getConfig().getPassword();
+
+            MpJDBCDriverManager driverManager = this.getSail().getConfig().getDriverManager();
+            this.databaseConnection = driverManager.getConnection(url, username, passw);
+
+        } catch (SQLException e) {
+            throw new SailException(e.getMessage());
+        }
+    }
+
+    protected ResultSet submit(ServiceParametersHolder parametersHolder) throws SailException {
+
+        SQLQuery sqlQuery = ((SQLSail) getSail()).getQueryById(parametersHolder.getSubjVarName());
+
+        // Prepare the statement to handle the input parameters
+        // if they are required
+        try {
+            ps = this.databaseConnection.prepareStatement(sqlQuery.getQuery());
+
+            for (Map.Entry<Integer, SQLParameter> entry : sqlQuery.getInputParametersMap().entrySet()) {
+
+                IRI type = entry.getValue().getType();
+                String name = entry.getValue().getName();
+                String value = parametersHolder.getInputParameters().get(name);
+
+                if (value == null || value.isEmpty())
+                    throw new SailException("The variable " + name + " is missing.");
+
+                if (type.equals(XSD.FLOAT)) {
+                    ps.setDouble(entry.getKey(), new Double(value));
+                }
+
+                if (type.equals(XSD.STRING)) {
+                    ps.setString(entry.getKey(), value);
+                }
+
+                if (type.equals(XSD.INTEGER) || type.equals(XSD.INT)) {
+                    ps.setInt(entry.getKey(), new Integer(value));
+                }
+
+            }
+
+            return ps.executeQuery();
+
+        } catch (SQLException e) {
+            throw new SailException(e.getMessage());
+        }
+
+    }
+
+    @Override
+    protected ServiceParametersHolder extractInputsAndOutputs(List<StatementPattern> stmtPatterns)
+            throws SailException {
+
+        ServiceParametersHolder res = new ServiceParametersHolder();
+
+        // Check query ID
+        Literal queryId = RESTWrappingSailUtils
+                .getLiteralObjectInputParameter(stmtPatterns, null, MpRepositoryVocabulary.HAS_QUERY_ID)
+                .orElseThrow(() -> new SailException("The SQL query ID was not provided using the "
+                        + MpRepositoryVocabulary.HAS_QUERY_ID + " property."));
+
+        res.setSubjVarName(queryId.stringValue());
+
+        // Iterate over input triples in descriptor
+        // Use the SPARQL query to get values and create input parameter holder as a set
+        // of tuple IRI, value
+        for (Map.Entry<IRI, Parameter> entry : getSail().getMapInputParametersByProperty().entrySet()) {
+
+            // Get subject and value
+            Optional<Var> subject = RESTWrappingSailUtils.getSubjectOutputVariable(stmtPatterns, null, entry.getKey());
+            Optional<Value> value = RESTWrappingSailUtils.getObjectInputParameter(stmtPatterns, subject.orElse(null),
+                    entry.getKey());
+
+            // Add value from query or default value
+            value = value.isPresent() ? value : entry.getValue().getDefaultValue();
+            if (value.isPresent())
+                res.getInputParameters().put(entry.getValue().getParameterName(), value.get().stringValue());
+        }
+
+        for (Map.Entry<IRI, Parameter> entry : getSail().getMapOutputParametersByProperty().entrySet()) {
+
+            Optional<Var> subject = RESTWrappingSailUtils.getSubjectOutputVariable(stmtPatterns, null, entry.getKey());
+            Optional<Var> value = RESTWrappingSailUtils.getObjectOutputVariable(stmtPatterns, subject.orElse(null),
+                    entry.getKey());
+
+            if (value.isPresent())
+                res.getOutputVariables().put(entry.getKey(), value.get().getName());
+        }
+
+        return res;
+    }
+
+    @Override
+    protected Collection<BindingSet> convertResult2BindingSets(ResultSet resultSet,
+            ServiceParametersHolder parametersHolder) throws SailException {
+
+        List<BindingSet> bindingSets = Lists.newArrayList();
+
+        // Convert inputStream to list of binding sets
+
+        try {
+            while (resultSet.next()) {
+
+                MapBindingSet mapBindingSet = new MapBindingSet();
+                for (Map.Entry<IRI, String> outputParameter : parametersHolder.getOutputVariables().entrySet()) {
+
+                    Parameter parameter = getSail().getServiceDescriptor().getOutputParameters()
+                            .get(outputParameter.getKey().getLocalName());
+                    IRI type = parameter.getValueType();
+
+                    String strObj = resultSet.getString(outputParameter.getValue());
+
+                    if (strObj != null) {
+                        if (StringUtils.equals(type.stringValue(), RDFS.RESOURCE.stringValue())) {
+                            logger.trace("Creating Resource ({})", strObj);
+                            mapBindingSet.addBinding(outputParameter.getValue(), VF.createIRI(strObj));
+                        } else {
+                            logger.trace("Creating Literal({},{})", strObj, type);
+                            mapBindingSet.addBinding(outputParameter.getValue(), VF.createLiteral(strObj,
+                                    type));
+                        }
+                    }
+
+                }
+                bindingSets.add(mapBindingSet);
+            }
+
+            return bindingSets;
+
+        } catch (Exception e) {
+            throw new SailException(e);
+        }
+    }
+
+    @Override
+    protected Collection<BindingSet> convertResult2BindingSets(InputStream inputStream,
+            ServiceParametersHolder parametersHolder) throws SailException {
+        throw new UnsupportedOperationException("Unimplemented method 'convertResult2BindingSets'");
+    }
+
+    @Override
+    protected CloseableIteration<? extends BindingSet, QueryEvaluationException> executeAndConvertResultsToBindingSet(
+            ServiceParametersHolder parametersHolder) {
+
+        ResultSet resultSet = submit(parametersHolder);
+
+        return new CollectionIteration<BindingSet, QueryEvaluationException>(
+                convertResult2BindingSets(resultSet, parametersHolder));
+    }
+
+}

--- a/src/main/java/org/researchspace/sail/rest/sql/SQLSailFactory.java
+++ b/src/main/java/org/researchspace/sail/rest/sql/SQLSailFactory.java
@@ -1,0 +1,53 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2024, © Trustees of the British Museum
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.researchspace.sail.rest.sql;
+
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.config.SailConfigException;
+import org.eclipse.rdf4j.sail.config.SailFactory;
+import org.eclipse.rdf4j.sail.config.SailImplConfig;
+
+/**
+ * 
+ * @author Janmaruko Hōrensō <@gspinaci>
+ *
+ */
+
+public class SQLSailFactory implements SailFactory {
+
+  public static final String SAIL_TYPE = "researchspace:SQLSail";
+
+  @Override
+  public String getSailType() {
+    return SAIL_TYPE;
+  }
+
+  @Override
+  public SailImplConfig getConfig() {
+    return new SQLSailConfig();
+  }
+
+  @Override
+  public Sail getSail(SailImplConfig originalConfig) throws SailConfigException {
+    if (!(originalConfig instanceof SQLSailConfig)) {
+      throw new SailConfigException("Wrong config type: " + originalConfig.getClass().getCanonicalName() + ". ");
+    }
+    return new SQLSail((SQLSailConfig) originalConfig);
+  }
+
+}

--- a/src/main/java/org/researchspace/secrets/AbstractSecretResolver.java
+++ b/src/main/java/org/researchspace/secrets/AbstractSecretResolver.java
@@ -121,6 +121,17 @@ public abstract class AbstractSecretResolver implements SecretResolver {
         if (prefix != null) {
             key = prefix + key;
         }
+
+        /** 
+        * @GSpinaci complete transformation
+        * 
+        * Set key to lowercase
+        * Then, transform everything into character '.' except: [A-z0-9]
+        * 
+        */ 
+        key = key.toLowerCase();
+        key = key.replaceAll("[^A-z0-9]", ".");
+
         return Optional.of(key);
     }
 

--- a/src/main/java/org/researchspace/secrets/AbstractSecretResolver.java
+++ b/src/main/java/org/researchspace/secrets/AbstractSecretResolver.java
@@ -39,11 +39,11 @@ public abstract class AbstractSecretResolver implements SecretResolver {
 
     private String prefix;
 
-    public AbstractSecretResolver() {
+    protected AbstractSecretResolver() {
         this(null);
     }
 
-    public AbstractSecretResolver(@Nullable String prefix) {
+    protected AbstractSecretResolver(@Nullable String prefix) {
         this.prefix = prefix;
     }
 

--- a/src/main/java/org/researchspace/secrets/EnvironmentSecretResolver.java
+++ b/src/main/java/org/researchspace/secrets/EnvironmentSecretResolver.java
@@ -20,8 +20,17 @@ import java.util.Optional;
 
 public class EnvironmentSecretResolver extends AbstractSecretResolver {
 
-    @Override
-    protected Optional<String> lookup(String key) {
-        return Optional.ofNullable(System.getenv(key));
-    }
+  // @GSpinaci add prefix "secret."
+  public EnvironmentSecretResolver() {
+    super("secret.");
+  }
+
+  @Override
+  protected Optional<String> lookup(String key) {
+    /**
+     * @GSpinaci Get JVM property by key
+     *           such as "secret.repo.username"
+     */
+    return Optional.ofNullable(System.getProperty(key));
+  }
 }

--- a/src/main/resources/META-INF/services/org.eclipse.rdf4j.sail.config.SailFactory
+++ b/src/main/resources/META-INF/services/org.eclipse.rdf4j.sail.config.SailFactory
@@ -1,3 +1,4 @@
 org.researchspace.sail.virtuoso.VirtuosoKeywordSearchSailFactory
 org.researchspace.federation.repository.MpFederationFactory
 org.researchspace.sail.rest.RESTSailFactory
+org.researchspace.sail.rest.sql.SQLSailFactory

--- a/src/test/java/org/researchspace/secrets/SecretsTest.java
+++ b/src/test/java/org/researchspace/secrets/SecretsTest.java
@@ -11,12 +11,6 @@ import javax.inject.Inject;
 import org.junit.After;
 import org.junit.Test;
 import org.researchspace.junit.AbstractIntegrationTest;
-import org.researchspace.secrets.MapSecretResolver;
-import org.researchspace.secrets.Secret;
-import org.researchspace.secrets.SecretLookup;
-import org.researchspace.secrets.SecretResolver;
-import org.researchspace.secrets.SecretsHelper;
-import org.researchspace.secrets.SecretsStore;
 
 public class SecretsTest extends AbstractIntegrationTest {
 
@@ -93,9 +87,10 @@ public class SecretsTest extends AbstractIntegrationTest {
     public void testEnvironmentSecretResolver() {
         // Create Envinronmet variable with secret
         System.setProperty("secret.test.password", "password123");
+        EnvironmentSecretResolver resolver = new EnvironmentSecretResolver();
 
         // Resolve secret
-        Optional<String> secret = SecretsHelper.resolveSecretAsString(secretResolver, "${test.password}");
+        Optional<String> secret = SecretsHelper.resolveSecretAsString(resolver, "${test.password}");
 
         assertTrue(secret.isPresent());
         assertEquals("password123", secret.get());

--- a/src/test/java/org/researchspace/secrets/SecretsTest.java
+++ b/src/test/java/org/researchspace/secrets/SecretsTest.java
@@ -88,6 +88,19 @@ public class SecretsTest extends AbstractIntegrationTest {
         assertTrue(SecretsHelper.isResolvableSecret("${-FZ7LEt#.T8W}"));
     }
 
+
+    @Test
+    public void testEnvironmentSecretResolver() {
+        // Create Envinronmet variable with secret
+        System.setProperty("secret.test.password", "password123");
+
+        // Resolve secret
+        Optional<String> secret = SecretsHelper.resolveSecretAsString(secretResolver, "${test.password}");
+
+        assertTrue(secret.isPresent());
+        assertEquals("password123", secret.get());
+    }
+
     @Test
     public void testKeyValue() {
         assertEquals("abc", SecretLookup.getLookupKey("${abc}").orElse("XXX"));


### PR DESCRIPTION
# Why
The SQLSail business core was outdated and integrated only in the branch build-docker/archipelago. With the SQLSail integrated in the master, we can merge all the modifications Villa i Tatti did on semantic-map.

# What

In `MpRepositoryVocabulary.java`, I added the required namespaces. `AbstractServiceWrappingSailConfig.java` and `AbstractServiceWrappingSailConnection.java` have been generalised. The latter with another method to override to handle other type of results, not only streams.

I created the classes `SQLSail.java`, `SQLSailConfig.java`, `SQLSailFactory.java`, and `SQLSailConnection.java` where the business logic for SQLSail is contained.

# Video / Gif / Screenshot

No changes in the UI

# Meta

The code was required to add another abstract method in `AbstractServiceWrappingSailConnection.java` to have other classes (RestSail, and SQLSail) extend it without worrying for different types.

# How To Test

@aindlq we should define a common way to create Unit Test for SQL connections.