### PR TITLE
oxigraph. Ability to enable silent mode for repository.

### DIFF
--- a/src/main/java/org/researchspace/data/rdf/container/LDPAssetsLoader.java
+++ b/src/main/java/org/researchspace/data/rdf/container/LDPAssetsLoader.java
@@ -170,7 +170,10 @@ public class LDPAssetsLoader {
         logger.info("All LDP assets loading finished");
 
         //generate KPs if they don't already exist
-        String checkIfKPsExistForPreloadedOntologies = "SELECT ?ontology (count(?prop) as ?propCount) (count(?kp) as ?kpCount) {" +
+        String checkIfKPsExistForPreloadedOntologies = "" +
+                        "PREFIX owl: <http://www.w3.org/2002/07/owl#>" +
+                        "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
+                        "SELECT ?ontology (count(?prop) as ?propCount) (count(?kp) as ?kpCount) {" +
                              "?ontology a owl:Ontology . " +
                              "BIND((IF((STRENDS(STR(?ontology),\"/\")),STR(?ontology),CONCAT(STR(?ontology),\"/\"))) as ?ontologyURI)" +
                              "BIND(IRI(CONCAT(STR(?ontologyURI),\"context\")) as ?ontologyContext)" +

--- a/src/main/java/org/researchspace/repository/MpRepositoryVocabulary.java
+++ b/src/main/java/org/researchspace/repository/MpRepositoryVocabulary.java
@@ -101,6 +101,7 @@ public class MpRepositoryVocabulary {
     public static final IRI REALM = VF.createIRI(NAMESPACE, "realm");
     public static final IRI QUAD_MODE = VF.createIRI(NAMESPACE, "quadMode");
     public static final IRI WRITABLE = VF.createIRI(NAMESPACE, "writable");
+    public static final IRI SILENT_MODE = VF.createIRI(NAMESPACE, "silentMode");
 
     public static final IRI USE_ASYNCHRONOUS_PARALLEL_JOIN = VF.createIRI(FEDERATION_NAMESPACE,
             "useAsynchronousParallelJoin");

--- a/src/main/java/org/researchspace/repository/RepositoryManager.java
+++ b/src/main/java/org/researchspace/repository/RepositoryManager.java
@@ -260,8 +260,7 @@ public class RepositoryManager implements RepositoryManagerInterface {
     private void initializeDefaultRepositories(Map<String, RepositoryConfig> repositoryConfigs) {
         String sparqlRepositoryUrl = this.config.getEnvironmentConfig().getSparqlEndpoint();
         if (repositoryConfigs.containsKey(DEFAULT_REPOSITORY_ID)) {
-            // Do nothing: the repository will be initialized in the standard sequence
-            // from a Turtle file
+            initializeRepository(repositoryConfigs.get(DEFAULT_REPOSITORY_ID), false);
         } else if (!StringUtils.isEmpty(sparqlRepositoryUrl)) {
             logger.info("Initializing HTTP Sparql Repository with URL: {}.", sparqlRepositoryUrl);
             RepositoryConfig repConfig = RepositoryManager.createSPARQLRepositoryConfigForEndpoint(sparqlRepositoryUrl);

--- a/src/main/java/org/researchspace/repository/sparql/CustomSPARQLConnection.java
+++ b/src/main/java/org/researchspace/repository/sparql/CustomSPARQLConnection.java
@@ -27,8 +27,10 @@ import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
  */
 public class CustomSPARQLConnection extends SPARQLConnection {
 
-    public CustomSPARQLConnection(SPARQLRepository repository, SPARQLProtocolSession client, boolean quadMode) {
+    public CustomSPARQLConnection(SPARQLRepository repository, SPARQLProtocolSession client, boolean quadMode,
+            boolean isSilentMode) {
         super(repository, client, quadMode);
+        this.enableSilentMode(isSilentMode);
     }
 
     public CustomSPARQLConnection(SPARQLRepository repository, SPARQLProtocolSession client) {

--- a/src/main/java/org/researchspace/repository/sparql/CustomSPARQLRepository.java
+++ b/src/main/java/org/researchspace/repository/sparql/CustomSPARQLRepository.java
@@ -44,6 +44,13 @@ public class CustomSPARQLRepository extends org.eclipse.rdf4j.repository.sparql.
      */
     private boolean isWritable;
 
+    /**
+     * True if SILENT modifier should be used for GRAPH commands
+     * 
+     * see https://github.com/eclipse-rdf4j/rdf4j/issues/956
+     */
+    private boolean isSilentMode;
+
     public CustomSPARQLRepository(String endpointUrl) {
         super(endpointUrl);
     }
@@ -65,6 +72,14 @@ public class CustomSPARQLRepository extends org.eclipse.rdf4j.repository.sparql.
     @Override
     public boolean isWritable() throws RepositoryException {
         return this.isWritable;
+    }
+
+    public boolean isSilentMode() {
+        return isSilentMode;
+    }
+
+    public void setSilentMode(boolean isSilentMode) {
+        this.isSilentMode = isSilentMode;
     }
 
     @Override
@@ -102,6 +117,6 @@ public class CustomSPARQLRepository extends org.eclipse.rdf4j.repository.sparql.
         if (!isInitialized()) {
             init();
         }
-        return new CustomSPARQLConnection(this, createHTTPClient(), this.quadMode);
+        return new CustomSPARQLConnection(this, createHTTPClient(), this.quadMode, this.isSilentMode);
     }
 }

--- a/src/main/java/org/researchspace/repository/sparql/DefaultMpSPARQLRepositoryFactory.java
+++ b/src/main/java/org/researchspace/repository/sparql/DefaultMpSPARQLRepositoryFactory.java
@@ -67,6 +67,7 @@ public class DefaultMpSPARQLRepositoryFactory extends AbstractMpSPARQLRepository
                 result = new CustomSPARQLRepository(httpConfig.getQueryEndpointUrl());
             }
             result.setWritable(config.isWritable());
+            result.setSilentMode(config.isSilentMode());
         } else {
             throw new RepositoryConfigException("Invalid configuration class: " + config.getClass());
         }

--- a/src/main/java/org/researchspace/repository/sparql/MpSPARQLRepositoryConfig.java
+++ b/src/main/java/org/researchspace/repository/sparql/MpSPARQLRepositoryConfig.java
@@ -44,6 +44,7 @@ public class MpSPARQLRepositoryConfig extends SPARQLRepositoryConfig {
 
     private boolean usingQuads = true;
     private boolean writable = true;
+    private boolean silentMode = false;
 
     public MpSPARQLRepositoryConfig() {
         super();
@@ -75,11 +76,20 @@ public class MpSPARQLRepositoryConfig extends SPARQLRepositoryConfig {
         this.writable = writable;
     }
 
+    public boolean isSilentMode() {
+        return silentMode;
+    }
+
+    public void setSilentMode(boolean silentMode) {
+        this.silentMode = silentMode;
+    }
+
     @Override
     public Resource export(Model model) {
         Resource implNode = super.export(model);
         model.add(implNode, MpRepositoryVocabulary.QUAD_MODE, vf.createLiteral(usingQuads));
         model.add(implNode, MpRepositoryVocabulary.WRITABLE, vf.createLiteral(writable));
+        model.add(implNode, MpRepositoryVocabulary.SILENT_MODE, vf.createLiteral(silentMode));
         return implNode;
     }
 
@@ -92,6 +102,8 @@ public class MpSPARQLRepositoryConfig extends SPARQLRepositoryConfig {
                     .ifPresent(lit -> setUsingQuads(lit.booleanValue()));
             Models.objectLiteral(model.filter(implNode, MpRepositoryVocabulary.WRITABLE, null))
                     .ifPresent(lit -> setWritable(lit.booleanValue()));
+            Models.objectLiteral(model.filter(implNode, MpRepositoryVocabulary.SILENT_MODE, null))
+                    .ifPresent(lit -> setSilentMode(lit.booleanValue()));
         } catch (ModelException e) {
             throw new SailConfigException(e.getMessage(), e);
         }

--- a/src/test/java/org/researchspace/repository/SPARQLDigestAuthRepositoryConfigTest.java
+++ b/src/test/java/org/researchspace/repository/SPARQLDigestAuthRepositoryConfigTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.researchspace.junit.TestUtils;
-import org.researchspace.repository.RepositoryConfigUtils;
 import org.researchspace.repository.sparql.SPARQLDigestAuthRepositoryConfig;
 
 /**

--- a/src/test/resources/org/researchspace/repository/test-sparql-basic-auth-repository.ttl
+++ b/src/test/resources/org/researchspace/repository/test-sparql-basic-auth-repository.ttl
@@ -9,4 +9,5 @@
 		<http://www.researchspace.org/resource/system/repository#password> "testpassword";
 		<http://www.researchspace.org/resource/system/repository#quadMode> "true"^^xsd:boolean ;
 		<http://www.researchspace.org/resource/system/repository#writable> "true"^^xsd:boolean ;
+		<http://www.researchspace.org/resource/system/repository#silentMode> "false"^^xsd:boolean ;
 	].

--- a/src/test/resources/org/researchspace/repository/test-sparql-digest-auth-repository.ttl
+++ b/src/test/resources/org/researchspace/repository/test-sparql-digest-auth-repository.ttl
@@ -10,4 +10,5 @@
 		<http://www.researchspace.org/resource/system/repository#realm> "testrealm";
 		<http://www.researchspace.org/resource/system/repository#quadMode> "true"^^xsd:boolean ;
 		<http://www.researchspace.org/resource/system/repository#writable> "true"^^xsd:boolean ;
+		<http://www.researchspace.org/resource/system/repository#silentMode> "false"^^xsd:boolean ;
 	].


### PR DESCRIPTION
# Why

Some RDF databases, like https://github.com/oxigraph/oxigraph return error if one tries to clear graph that doesn't exist. That is acceptable behavior according to standard. 

# What

This change introduce new repository config property `silentMode`. When the value is true, RDF4J will generate `CLEAR SILENT GRAPH` instead of `CLEAR GRAPH` that is generated by default. `silentMode` is false by default and need to be explicitly enabled in the repository config. So it is non breaking change and should not have any side effect.

```
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@prefix sparql: <http://www.openrdf.org/config/repository/sparql#> .
@prefix rep: <http://www.openrdf.org/config/repository#> .
@prefix sail: <http://www.openrdf.org/config/sail#> .
@prefix sr: <http://www.openrdf.org/config/repository/sail#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix mph: <http://www.researchspace.org/resource/system/repository#> .
@prefix ephedra: <http://www.researchspace.org/resource/system/ephedra#> .
@prefix fedsail: <http://www.openrdf.org/config/sail/federation#> .

[] a rep:Repository;
    rep:repositoryID "default";
    rdfs:label "Default G17 HTTP SPARQL Repository";
    rep:repositoryImpl [
        rep:repositoryType "researchspace:SPARQLRepository";
    sparql:query-endpoint <http://oxigraph:7878/query>;
    sparql:update-endpoint <http://oxigraph:7878/update>;
    mph:quadMode true;
    mph:writable true ;
    mph:silentMode true ;
    
    ] .

```

# Meta
Along the way I found a bug in RepositoryManager that prevented initialization when default repository was initialized with `default.ttl` and there is a custom repository that proxies requests to default. It is also fixed.

# How To Test

see https://github.com/researchspace/researchspace-docker-compose/issues/3 here setup with oxigraph. 