### PR TITLE
Update gretty to fix problem with buildZip.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
     id 'java-library'
 
     // To run app in the development mode with jetty container
-    id 'org.gretty' version '3.1.4'
+    id 'org.gretty' version '3.1.5'
 
     // To run webpack-dev-server in the background
     id 'com.github.psxpaul.execfork' version '0.2.2'


### PR DESCRIPTION
# Why

buildZip produced broken bundle because of bug in gretty.

# What

see https://github.com/gretty-gradle-plugin/gretty/pull/314
