### PR TITLE
Modify drop down delete for authority documents to use the form as a …

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FResourceDropdownActions.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FResourceDropdownActions.html
@@ -697,23 +697,10 @@
     {{/default}}
   {{/switch}}
 
-  {{#if (or allowResourceDelete imageAnnotation)}} 
-    {{#if (eq resourceConfig "http://www.researchspace.org/resource/system/resource_configurations_container/data/Authority_document")}}
-      <hr>
-      <bs-menu-item>
-        <rs-icon icon-type="rounded" icon-name="delete" class="icon-left" symbol="true"></rs-icon>            
-        <mp-graph-store-action title="Delete" 
-                                action="DELETE" 
-                                graphuri="{{iri}}" 
-                                graph-description="{{label.value}}">
-          <span>Delete</span>          
-        </mp-graph-store-action>
-      </bs-menu-item>
-    {{else}}
+  {{#if (or allowResourceDelete imageAnnotation)}}     
       {{#if (not (eq resourceConfig "http://www.researchspace.org/resource/system/resource_configurations_container/data/User"))}}
         <hr>
         [[> deleteButton resourceFormIRI=resourceFormIRI]]
-      {{/if}}
     {{/if}}
   {{/if}}
   
@@ -795,6 +782,7 @@
                                       "viewId": "{{iri}}",
                                       "mode": "edit",
                                       "editable": true,
+                                      "resourceConfig":"{{resourceConfig}}",
                                       "node": "{{iri}}"
                           }'>
         </inline-template> 


### PR DESCRIPTION
# Why

Currently the contextual menu delete available for AuthorityDocuments uses mp-graph-store-action; we modify this to use the same mechanism as the other resources using a trigger to a hidden inline form; This way if an authority document also has a file under ldp/authorities in runtime-data it is correctly removed on delete.

# Test

Edit and delete an authority document. Both the database and the file system should reflect the resource has been removed.

