### PR TITLE
Use `--input-border-radius` for large and small inputs.

### DIFF
--- a/src/main/web/styling/_variables.scss
+++ b/src/main/web/styling/_variables.scss
@@ -333,9 +333,6 @@ $alert-danger-border:         #e78d99; //can't be css variable
 /************************* INPUTS ***********************************/
 //  Bootstrap variables override
 $input-border-focus: darken($btn-default-border, 20%);
-$input-border-radius: 0;
-$input-border-radius-large: 0;
-$input-border-radius-small: 0;
 $input-height-base: ($line-height-computed + ($padding-base-vertical * 2));
 
 
@@ -421,6 +418,9 @@ $input-font-size: var(--input-font-size, 14px);
 $input-placeholder-color: var(--input-placeholder-color, $color-base);
 $input-border-color: var(--input-border-color, $color-border);
 $input-border-radius: var(--input-border-radius, 2px);
+$input-border-radius-large: var(--input-border-radius, 2px);
+$input-border-radius-small: var(--input-border-radius, 2px);
+
 
 $input-focused-color: var(--input-focused-color, #05448d);
 $input-focused-color-bg: var(--input-focused-color-bg, #d9e2f0);


### PR DESCRIPTION
# Why
Use the same variable for `lg` and `xs` inputs.
I also removed `input-border-radius` where it was set to 0, it was confusing because later it was overridden with 2.

# How to test

Just add some form to the template and check if input has correct border-radius:

```
<form>
              <div class="form-group form-group-lg">
                <input
                  required
                  class="form-control"
                  placeholder="Search"
                  type="search"
                  name="keyword"
                />
              </div>

</form>
```