### PR TITLE
Prefer compact URL for resolvable URIs in resource navigation.

### DIFF
--- a/src/main/web/api/navigation/Navigation.ts
+++ b/src/main/web/api/navigation/Navigation.ts
@@ -190,27 +190,72 @@ export function constructUrlForResource(
   repository = 'default',
   fragment = ''
 ): Kefir.Property<uri.URI> {
-  return getPrefixedUri(iri).map((mUri) => {
-    const baseQuery = repository === 'default' ? {} : { repository: repository };
-    const resourceUrl = ConfigHolder.getEnvironmentConfig().resourceUrlMapping.value;
-    if (mUri.isJust) {
-      const url = uri(`${resourceUrl}${mUri.get()}`);
-      url.setQuery({ ...baseQuery, ...props });
-      url.fragment(fragment);
-      return url;
-    } else {
-      return construcUrlForResourceSync(iri, props, repository, fragment);
-    }
-  });
+  const simpleUrl = constructSimpleUrl(iri, props, repository, fragment);
+  if (simpleUrl) {
+    return Kefir.constant(simpleUrl);
+  } else {
+    return getPrefixedUri(iri).map((mUri) => {
+      if (mUri.isJust) {
+        const resourcePath = ConfigHolder.getEnvironmentConfig().resourceUrlMapping.value;
+        return constructUrl(`${resourcePath}${mUri.get()}`, props, repository, fragment);
+      } else {
+        return construcUrlForResourceSync(iri, props, repository, fragment);
+      }
+    });
+  }
 }
 
 export function construcUrlForResourceSync(iri: Rdf.Iri, props: {} = {}, repository = 'default', fragment = '') {
+  const simpleUrl = constructSimpleUrl(iri, props, repository, fragment);
+  if (simpleUrl) {
+    return simpleUrl;
+  } else {
+    const resourceUrl = ConfigHolder.getEnvironmentConfig().resourceUrlMapping.value;
+    props = { ...props, uri: iri.value };
+    return constructUrl(`${resourceUrl}`, props, repository, fragment);
+  }
+}
+
+/**
+ * If IRI is a resolvalbe one, which means it starts with platformBaseIri, then we can construct
+ * a simple URL. E.g
+ * http://example.com/resource/123 and platform is actually runnnig on http://example.com/resource.
+ * In this case there is no need to resolve IRI to prefixed IRI or use ?uri query parameter.
+ */
+function constructSimpleUrl(
+  iri: Rdf.Iri,
+  props: {} = {},
+  repository?: string,
+  fragment?: string
+): uri.URI | null {
+  const platformBaseIri = ConfigHolder.getEnvironmentConfig().platformBaseIri;
+  const resourcePath = ConfigHolder.getEnvironmentConfig().resourceUrlMapping.value;
+
+  if (platformBaseIri) {
+    const urlPrefix = platformBaseIri.value + resourcePath;
+    if (iri.value.startsWith(urlPrefix)) {
+      return constructUrl(iri.value.split(platformBaseIri.value)[1], props, repository, fragment);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Construct URL with optional additional query parameters and fragment.
+ * Default repository is omitted in the URL.
+ */
+function constructUrl(
+  url: string,
+  props: {} = {},
+  repository?: string,
+  fragment?: string
+) {
   const baseQuery = repository === 'default' ? {} : { repository: repository };
-  const resourceUrl = ConfigHolder.getEnvironmentConfig().resourceUrlMapping.value;
-  const url = uri(`${resourceUrl}`);
-  url.setQuery({ ...baseQuery, ...props, uri: iri.value });
-  url.fragment(fragment);
-  return url;
+  const url_ = uri(url);
+  url_.setQuery({ ...baseQuery, ...props });
+  url_.fragment(fragment);
+  return url_;
 }
 
 /**

--- a/src/main/web/api/services/config-holder.ts
+++ b/src/main/web/api/services/config-holder.ts
@@ -147,6 +147,7 @@ export class ConfigHolderClass {
 
 export interface EnvironmentConfig {
   readonly resourceUrlMapping?: StringValue;
+  readonly platformBaseIri?: StringValue;
 }
 
 interface RawUIConfig {


### PR DESCRIPTION
# Why

Even when system is configured to have resolvable URIs semantic-link and other components that used internal navigation still generated URL with ?uri or prefixes.

For example in PHAROS URL like https://artresearch.net/resource/zeri/work/99999 was successfully resolved to a proper resource when navigation from a browser directly, but when the same URI was used in semantic link one would  see ugly URL like `https://artresearch.net/resource/?uri=https%3A%2F%2Fartresearch.net%2Fresource%2Fzeri%2Fwork%2F99999`

# What

Requires `platformBaseIri` to be set in environment config.

# How To Test

If testing on localhost:

1) set `platformBaseIri=http://localhost:10214` in the `environment.prop`
2) change default namespace to `Default = http://localhost:10214/resource/` in the `namespaces.prop`
3) then create a test page `http://localhost:10214/resource/test?action=edit` and add some `Hello World!` there.
4) create a second test page `http://localhost:10214/resource/test2?action=edit` and add a link to a first page `<semantic-link iri="http://localhost:10214/resource/test"></semantic-link>`

When you save the second test page and click on a link you should see `http://localhost:10214/resource/test` in browser URL bar, not `http://localhost:10214/resource/Default:test` or `http://localhost:10214/resource/?uri=http%3A%2F%2Flocalhost%3A10214%2Fresource%2Ftest`