### PR TITLE
Disable rememberMe. Don't create session for basic auth requests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,7 +308,7 @@ repositories {
 
 ext {
     RDF4J_VERSION = '3.5.1'
-    LOG4J_VERSION = '2.15.0'
+    LOG4J_VERSION = '2.24.3'
     JERSEY_VERSION = '2.30.1'
     JACKSON_VERSION = '2.10.3'
     GUICE_VERSION = '6.0.0'
@@ -374,6 +374,7 @@ dependencies {
         "org.apache.logging.log4j:log4j-web:${LOG4J_VERSION}",
         "org.apache.logging.log4j:log4j-1.2-api:${LOG4J_VERSION}",
         "org.apache.logging.log4j:log4j-slf4j-impl:${LOG4J_VERSION}",
+        "org.apache.logging.log4j:log4j-slf4j2-impl:${LOG4J_VERSION}",
         "org.apache.logging.log4j:log4j-jul:${LOG4J_VERSION}",
         "org.apache.logging.log4j:log4j-jcl:${LOG4J_VERSION}",
 

--- a/src/main/java/org/researchspace/security/CustomWebSubjectFactory.java
+++ b/src/main/java/org/researchspace/security/CustomWebSubjectFactory.java
@@ -1,0 +1,42 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2025, PHAROS: The International Consortium of Photo Archives
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.researchspace.security;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.subject.SubjectContext;
+import org.apache.shiro.web.mgt.DefaultWebSubjectFactory;
+import org.apache.shiro.web.subject.WebSubjectContext;
+
+/* 
+ * Disable session creation for Basic Auth requests.
+ * It is just an additional overhead that doesn't make any sense.
+ */
+public class CustomWebSubjectFactory extends DefaultWebSubjectFactory {
+    @Override
+    public Subject createSubject(SubjectContext context) {
+        WebSubjectContext wsc = (WebSubjectContext) context;
+        HttpServletRequest request = (HttpServletRequest) wsc.resolveServletRequest();
+        if (OptionalBasicAuthFilter.isAuthorizationAttempt(request)) {
+            wsc.setSessionCreationEnabled(false);
+        }
+
+        return super.createSubject(context);
+    }
+}

--- a/src/main/java/org/researchspace/security/PlatformSecurityManager.java
+++ b/src/main/java/org/researchspace/security/PlatformSecurityManager.java
@@ -121,6 +121,14 @@ public class PlatformSecurityManager extends DefaultWebSecurityManager {
                 ((CachingRealm) r).setCacheManager(_cacheManager);
             }
         }
+
+        setSubjectFactory(new CustomWebSubjectFactory());
+
+        /**
+         * Disable rememberMe functionality, as it is not used in the platform.
+         * And only sets unnecessary cookies.
+         */
+        setRememberMeManager(null);
     }
 
     // If anonymous filter is enabled we initialize anonymous user Subject as soon


### PR DESCRIPTION
# Why

1. shiro was always sending Set-Cookie fol rememberMe to remove it on every successfully login/logout, even for basic auth requests. That messed up with nginx cache, because by default nginx doesn't cache requests that contain Set-Cookie header. We don't use rememberMe functionality of shiro anyway, so I fully disabled it.
2. shiro created a session for every request with basic auth. Which doesn't make any sense, because basic auth is stateless.
3. Added `log4j-slf4j2-impl`, without it all logs from shiro were simply not visible.

# How To Test

1. If you start local dev env before this change and try to send the following curl request:

```
curl -X POST http://localhost:10214/sparql -v  -H 'Content-Type: application/x-www-form-urlencoded' -H 'Authorization: Basic YWRtaW46YWRtaW4='  -d 'query=SELECT%20*%20{%0A%20%3Fs%20%3Fp%20%3Fo%0A}%20LIMIT%201'
```

you will get some `Set-Cookie` in the response headers, e.g:

```
< HTTP/1.1 200 OK
< Date: Thu, 23 Jan 2025 08:50:59 GMT
< Set-Cookie: JSESSIONID=9b9e8d81-4dc9-4cd2-84af-c0a3d948b23f; Path=/; HttpOnly; SameSite=lax
< Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 22-Jan-2025 08:50:59 GMT; SameSite=lax
< Set-Cookie: JSESSIONID=deleteMe; Path=/; Max-Age=0; Expires=Wed, 22-Jan-2025 08:50:59 GMT; SameSite=lax
< Content-Type: application/x-sparqlstar-results+xml;charset=UTF-8
< Transfer-Encoding: chunked
< Server: Jetty(9.4.53.v20231009)
```

2. With this change the same request shouldn't return any `Set-Cookie`:
```
< HTTP/1.1 200 OK
< Date: Thu, 23 Jan 2025 08:53:25 GMT
< Content-Type: application/x-sparqlstar-results+xml;charset=UTF-8
< Transfer-Encoding: chunked
< Server: Jetty(9.4.53.v20231009)
```