### PR TITLE
Configurable label cache.

### DIFF
--- a/src/main/java/org/researchspace/cache/ResourcePropertyCache.java
+++ b/src/main/java/org/researchspace/cache/ResourcePropertyCache.java
@@ -126,7 +126,6 @@ public abstract class ResourcePropertyCache<Key, Property> implements PlatformCa
      * 
      * <ul>
      * <li>maximumSize: 1000</li>
-     * <li>expireAfterAccess: 30 minutes</li>
      * </ul>
      * 
      * <p>

--- a/src/main/java/org/researchspace/config/groups/EnvironmentConfiguration.java
+++ b/src/main/java/org/researchspace/config/groups/EnvironmentConfiguration.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 
 import javax.inject.Inject;
 
+import org.researchspace.cache.LabelCache;
 import org.researchspace.config.ConfigurationParameter;
 import org.researchspace.config.InvalidConfigurationException;
 import org.researchspace.security.SecurityConfigRecord;
@@ -208,6 +209,31 @@ public class EnvironmentConfiguration extends ConfigurationGroupBase {
     @ConfigurationParameter
     public String getAllowedCrossOrigin() {
         return getString("allowedCrossOrigin");
+    }
+
+    /**
+     * In LabelCache, when too many labels are requested at once, 
+     * SPARQL requests will be split in batches of labelsBatchSize per query.
+     * 
+     * With some databases, like QLever, it can be more efficient to send a single query 
+     * instiead of spliting it into batches (like it was with blazegraph). In this case
+     * it makes sense to set this parameter to a very huge number to prevent batch requests.
+     * 
+     * @see LabelCache
+     */
+    @ConfigurationParameter
+    public int getLabelsBatchSize() {
+        return getInteger("labelsBatchSize", 1000);
+    }
+
+    /**
+     * Labels Service cache size.
+     * 
+     * @see LabelCache
+     */
+    @ConfigurationParameter
+    public int getLabelsCacheSize() {
+        return getInteger("labelsCacheSize", 1000);
     }
 
     /****************************** VALIDATION ********************************/

--- a/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FBasicSystemConfiguration.html
+++ b/src/main/resources/org/researchspace/apps/help/data/templates/http%3A%2F%2Fhelp.researchspace.org%2Fresource%2FBasicSystemConfiguration.html
@@ -75,6 +75,16 @@
           <td>Integer</td>
           <td>SPARQL HTTP connection timeout (in seconds). This value is used to set both <code>http.connection.timeout</code> (timeout for establishing the connection) and <code>http.socket.timeout</code> (timeout for waiting for the data) parameters of the Apache HttpClient. Default: null (infinite) </td>
         </tr> 
+        <tr>
+          <td>labelsBatchSize</td>
+          <td>Integer</td>
+          <td>When requesting many labels at once, SPARQL queries will be split into batches of this size. For some databases like QLever, a very large value may be more efficient to prevent batching. Default: 1000</td>
+        </tr>
+        <tr>
+          <td>labelsCacheSize</td>
+          <td>Integer</td>
+          <td>Maximum number of entries to store in the Labels Service cache. Default: 1000</td>
+        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
# Why

1) Adds ability to increase labels cache size.
2) Ability to disable batched labels requests. When using RS with QLever it is much better to send one big request than many small ones. So by setting `labelsBatchSize` to something big like `100000` we can effectively disable batching.
3) Disable time based cache invalidation.

Also updated configuration help page.

# What
Added `labelsCacheSize` and `labelsBatchSize` to `enivronment.prop` config.

# Meta

I guess we can enable/dissable some optimizations based on type of repository used. E.g for qlever labels batching doesn't make any sense because it can deal with huge requests much better than blazegraph.