### PR TITLE
Created new css class for card when autosize=true

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FResourceCardTemplate.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FResourceCardTemplate.html
@@ -60,7 +60,7 @@
 
   {{#if hideMediaSection}}
   {{else}}
-    <div class="resource-card__media-container" style="{{#if autosize}}height:auto{{else}}max-height:135px;{{/if}}">
+    <div class="resource-card__media-container {{#if autosize}}resource-card__media-container-autosize{{/if}}">
 
       {{#if props}}
         [[!-- for card in KM --]]

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FSemanticNarrativeTemplate.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FSemanticNarrativeTemplate.html
@@ -133,7 +133,7 @@
                                                 "template": "{{> itemCard}}",
                                                 "resizable": true,
                                                 "defaults": {
-                                                  "height": "200px",
+                                                  "height": "190px",
                                                   "width": "155px"
                                                 }
                                               },

--- a/src/main/web/styling/_card.scss
+++ b/src/main/web/styling/_card.scss
@@ -189,12 +189,28 @@
 
         height: 135px;
         min-height: 135px;
+        max-height:135px;
         width: 100%;
         border-bottom: 1px solid $color-border;
         background-color: $color-light;
 
         display: flex;
         align-items: center;
+
+        &.resource-card__media-container-autosize {
+
+            height:calc(100% - 50px);
+            min-height: unset;
+            max-height: unset;
+
+            .image-thumbnail,
+            .resource-card__thumbnail,
+            .resource-card__icon-container {
+                min-height: unset;
+                overflow: hidden;
+            }
+
+        }
     }
     
     .image-thumbnail,


### PR DESCRIPTION
# Why
The icon ares in the Resource card wasn't resizing properly when autosize=true
Currently this is used only in semantic narrative card

# What
Added the new css class resource-card__media-container-autosize
