### PR TITLE
Knowledge pattern table fix

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2FPC144_joined_with%2FP144.1_kind_of_member.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2FPC144_joined_with%2FP144.1_kind_of_member.trig
@@ -3,7 +3,7 @@
 
   <http://www.researchspace.org/pattern/system/PC144_joined_with/P144.1_kind_of_member> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Role";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Role"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/user> ;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/group> ;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC144_joined_with>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2FPC144_joined_with%2Fjoining_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2FPC144_joined_with%2Fjoining_range.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-85b8b57dc0e64d73934629c68168d6b9-er89v;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-85b8b57dc0e64d73934629c68168d6b9-pkc7q9;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC144_joined_with>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Joined with - range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Joined with - range"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-85b8b57dc0e64d73934629c68168d6b9-fktom9;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Facquisition%2Fmethod.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Facquisition%2Fmethod.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c13650fb389d4c188b2e377408a704a7-gsczdr;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Acquisition method";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Acquisition method"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/acquisition>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E8_Acquisition>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Facquisition%2Ftransferred_title_from.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Facquisition%2Ftransferred_title_from.trig
@@ -45,7 +45,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-7acaf41c8a894901b89f98223319fd7f-h7t2e;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E8_Acquisition>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-7acaf41c8a894901b89f98223319fd7f-uvwhfz;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Transferred title from";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Transferred title from"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-03T18:30:51.523+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Facquisition%2Ftransferred_title_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Facquisition%2Ftransferred_title_of.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-260f785f57634b0fa206eb6f685d8821-1u04c9;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/acquisition>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-260f785f57634b0fa206eb6f685d8821-ul75wt;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Transferred title of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Transferred title of"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-260f785f57634b0fa206eb6f685d8821-f7mjsn;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E8_Acquisition>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E70_Thing>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Facquisition%2Ftransferred_title_to.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Facquisition%2Ftransferred_title_to.trig
@@ -21,7 +21,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-13946b5d14e143d58603d408d29a5bb7-q4ah2;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-13946b5d14e143d58603d408d29a5bb7-druf4n;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/acquisition>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Transferred title to";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Transferred title to"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-13946b5d14e143d58603d408d29a5bb7-jzj1b;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-13946b5d14e143d58603d408d29a5bb7-pbmma4;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-13946b5d14e143d58603d408d29a5bb7-6t57lb;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2FPC14_carried_out_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2FPC14_carried_out_by.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-b6b3bc83175e4b4187d1de7d8ff39f68-ixnrv;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b6b3bc83175e4b4187d1de7d8ff39f68-oe7lfd;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2FPC16_used_specific_object.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2FPC16_used_specific_object.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Use of material or immaterial things in a way essential to the performance or the outcome of the activity.";
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific object";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific object"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC16_used_specific_object>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2FPC19_was_intended_use_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2FPC19_was_intended_use_of.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC19_was_intended_use_of>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended use of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended use of"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f8898c1c280441bfa655266815457b32-lxwhnx;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fat_some_time_within_currentDateTime.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fat_some_time_within_currentDateTime.trig
@@ -4,7 +4,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3f1a2592c2be445186c0c3b1479723bc-zx4sx9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Activity at currentDateTime";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Activity at currentDateTime"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#dateTime>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3f1a2592c2be445186c0c3b1479723bc-v8gr94;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcarried_out_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcarried_out_by.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e6e35b7368034afcbcffed77b680656e-irhl3;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e6e35b7368034afcbcffed77b680656e-q6qkoi;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcontinued_activity.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcontinued_activity.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-3f843d4fa4a340e9b258ccd42950cd9a-308xnk;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Continued";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Continued"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3f843d4fa4a340e9b258ccd42950cd9a-z54vd3;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3f843d4fa4a340e9b258ccd42950cd9a-18dp8o;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcontinued_data_transfer.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcontinued_data_transfer.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.ics.forth.gr/isl/CRMdig/D12_Data_Transfer_Event>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Activity continued data transfer";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Activity continued data transfer"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-20d51ecb417847c7bf09c380af18d72b-ln4kkt;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcontinued_data_transfer_min1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcontinued_data_transfer_min1.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.ics.forth.gr/isl/CRMdig/D12_Data_Transfer_Event>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Activity continued data transfer min1";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Activity continued data transfer min1"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-1df6aa8fb3aa46dea1eafc0bfac8f25e-gmvy8;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcurrent_status.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fcurrent_status.trig
@@ -22,7 +22,7 @@
     <http://www.cidoc-crm.org/cidoc-crm/E12_Production>,
     <http://www.cidoc-crm.org/cidoc-crm/E11_Modification>,
     <http://www.cidoc-crm.org/cidoc-crm/E10_Transfer_of_Custody>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Status";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Status"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ee7f124425144f128fd86eb4697b6da2-pnp6we;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fhad_general_purpose_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fhad_general_purpose_type.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.w3.org/2000/01/rdf-schema#comment> """Enter an intentional relationship between the activity and some general goal or purpose (defined as Type).
 No occurrence of an event is implied as the purpose (in that case use Activity done in preparation of).""";
-    <http://www.w3.org/2000/01/rdf-schema#label> "General purpose (type)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "General purpose (type)"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3e25fe20c1604110ac34daab4da427dc-kqqp55;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fhad_specific_purpose_event.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fhad_specific_purpose_event.trig
@@ -17,7 +17,7 @@
   <http://www.researchspace.org/pattern/system/activity/had_specific_purpose_event>
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Done in preparation of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Done in preparation of"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-54aae775be764736a2442f00e9d9d7ec-x1p82g;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Finfluenced_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Finfluenced_by.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Influenced by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Influenced by"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-978bda3bca624f0dac29dc4239a22c6e-bvsnnn;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-03T16:42:38.089+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fmotivated_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fmotivated_by.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Motivated by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Motivated by"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e179d8f6c0b64c84b3b892fe316983a4-c9dn56;
     <http://www.w3.org/2000/01/rdf-schema#comment> "An item or items that are regarded as a reason for carrying out the activity.";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fpriority.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fpriority.trig
@@ -56,7 +56,7 @@
     <http://www.researchspace.org/resource/system/category/type_assignment_search>,
     <http://www.researchspace.org/resource/system/category/type_creation_search>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-0a22da334e2c4f45983e234aeb11393c-w9c087;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Priority";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Priority"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-0a22da334e2c4f45983e234aeb11393c-9qonn;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fresearch_question.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fresearch_question.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Research question";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Research question"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-d382a39b795447b9a108a7d4d39474fc-1mon8u;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fused_general_technique.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fused_general_technique.trig
@@ -17,7 +17,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-29692d3372964e8aa6267a5d8c6098be-itbbg;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used technique";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used technique"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fused_object_of_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fused_object_of_type.trig
@@ -56,7 +56,7 @@
     <http://www.researchspace.org/resource/system/category/type_creation_search>;
     <http://www.w3.org/2000/01/rdf-schema#comment> """Enter the kind of objects used in the activity.
 """;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used object of type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used object of type"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c8bbd4f5a46c44bfbd1c5f56f9c2d179-gotdgb;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-22T19:34:12.026+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fused_specific_technique.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fused_specific_technique.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-363a118aaae44553bc8df73872590f78-7faxl;
     <http://www.w3.org/2000/01/rdf-schema#comment> """Enter the specific documented plan (Design or Procedure) used to carry out the activity or parts of it. Typical examples would include instructions, intervention plans for conservation or the construction plans of a building.
 """;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific procedure";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific procedure"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-05T12:18:35.566+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fwas_continued_by_activity.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factivity%2Fwas_continued_by_activity.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/activity/was_continued_by_activity> a
       <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was continued by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was continued by"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-1f161e34a39e4538b091ffa42b09ab13-644x9;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2FPC107_has_current_or_former_member_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2FPC107_has_current_or_former_member_range.trig
@@ -5,7 +5,7 @@
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC107_has_current_or_former_member>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is member of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is member of"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2FPC11_participated_in_event.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2FPC11_participated_in_event.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/actor/PC11_participated_in_event> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-1306c7b28b744738ba30b5a5f3e712fa-72qhc;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participated in";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participated in"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC11_had_participant>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2FPC14_carried_out_by_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2FPC14_carried_out_by_range.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/actor/PC14_carried_out_by_range/context> {
   <http://www.researchspace.org/pattern/system/actor/PC14_carried_out_by_range> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out / performed";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out / performed"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC14_carried_out_by>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Facquired_title_through.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Facquired_title_through.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-eb17467034e843868ea54912f88b266d-b87qie;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Acquired title through";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Acquired title through"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E8_Acquisition>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-eb17467034e843868ea54912f88b266d-gz41p6;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-eb17467034e843868ea54912f88b266d-ez6v8;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2FalsoKnownAs.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2FalsoKnownAs.trig
@@ -16,7 +16,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-5a6968d55cf642faba1d68271b65d5d9-2ivvdn;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Also known as";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Also known as"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-5a6968d55cf642faba1d68271b65d5d9-a1lgmoh;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fcurrent_keeper_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fcurrent_keeper_of.trig
@@ -22,7 +22,7 @@
   
   <http://www.researchspace.org/pattern/system/actor/current_keeper_of> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Current keeper of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Current keeper of"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f18cb6715b7443c3adda5c81a0f17fbf-8sy16g;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fcurrent_owner_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fcurrent_owner_of.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f1a764db7abc4940b8e545d0bba94122-u0whgf;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f1a764db7abc4940b8e545d0bba94122-uttafp;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Current owner of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Current owner of"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-f1a764db7abc4940b8e545d0bba94122-vca8h;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fformer_or_current_curator_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fformer_or_current_curator_of.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e8dd71677cbf4eb28590880989673fb2-xlsfan;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Curator of collection";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Curator of collection"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e8dd71677cbf4eb28590880989673fb2-ml1ig;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e8dd71677cbf4eb28590880989673fb2-a7vg6;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fformer_or_current_keeper_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fformer_or_current_keeper_of.trig
@@ -25,7 +25,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6293e5d3a0ca4689a21b7e2e928af15f-wvssy0b;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-6293e5d3a0ca4689a21b7e2e928af15f-3ejrs;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current keeper of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current keeper of"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-6293e5d3a0ca4689a21b7e2e928af15f-ien0ys;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-6293e5d3a0ca4689a21b7e2e928af15f-rpdjmt;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fformer_or_current_owner_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fformer_or_current_owner_of.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/actor/former_or_current_owner_of> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-3d9a87aae9a040e1b83667e617549f34-raxnig;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current owner of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current owner of"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fhas_current_or_former_residence.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fhas_current_or_former_residence.trig
@@ -2,7 +2,7 @@
   <http://www.researchspace.org/pattern/system/actor/has_current_or_former_residence>
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Residence";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Residence"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fhas_right_on.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fhas_right_on.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E72_Legal_Object>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-3b981f013af64420a6f2ced340326d3f-kv07z;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has right on";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has right on"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3b981f013af64420a6f2ced340326d3f-7gfhoe;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-10T11:19:28.718+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fis_current_or_former_member_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fis_current_or_former_member_of.trig
@@ -27,7 +27,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-4d4a7af1cb094ca5aa807cbc1c5e7558-reard;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-4d4a7af1cb094ca5aa807cbc1c5e7558-d91sd9;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-4d4a7af1cb094ca5aa807cbc1c5e7558-49lu5;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is member of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is member of"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-10T17:40:11.013+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fjoined_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fjoined_by.trig
@@ -36,7 +36,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E85_Joining>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Joining / becoming member of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Joining / becoming member of"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-21b5ba4efb3c443d9109256a79f0874c-oa2iyu;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-21b5ba4efb3c443d9109256a79f0874c-wlz3j;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fjoined_by_Min1Max1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fjoined_by_Min1Max1.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-24d5d01cd1c946bb857175ffabc83fa6-xa8nzl;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-24d5d01cd1c946bb857175ffabc83fa6-jtwrod;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Joining / becoming member of (mandatory)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Joining / becoming member of (mandatory)"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E85_Joining>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-24d5d01cd1c946bb857175ffabc83fa6-y6gvw;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fleaving_group.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fleaving_group.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-91e4f377bdd948469c09c0810446f8f2-ezhx4f;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Leaving / left a group";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Leaving / left a group"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E86_Leaving>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-91e4f377bdd948469c09c0810446f8f2-olenj;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fnationality.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fnationality.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/actor/nationality> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-0687584e70f042ce969f83365fa2ef34-qe2bx;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Nationality";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Nationality"@en;
     <http://www.researchspace.org/resource/system/fields/treePatterns> """{
   \"type\": \"simple\",
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/nationality> .\"

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fpossesses_right.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fpossesses_right.trig
@@ -21,7 +21,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3e580107f3e345dfb3e90d2b0e0c63cc-hj51nd;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E30_Right>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Possesses right";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Possesses right"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-3e580107f3e345dfb3e90d2b0e0c63cc-lh3c19;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3e580107f3e345dfb3e90d2b0e0c63cc-2vkbq9;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Freceived_custody_through.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Freceived_custody_through.trig
@@ -4,7 +4,7 @@
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-2ff0e4afa01541049113e5418819c202-t4up8t;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Received custody through";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Received custody through"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E10_Transfer_of_Custody>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fsurrendered_custody_through.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fsurrendered_custody_through.trig
@@ -4,7 +4,7 @@
       <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-89cc7c8e627b4d3f9a036a2493a7cab0-tltrt9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Surrendered custody through";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Surrendered custody through"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-89cc7c8e627b4d3f9a036a2493a7cab0-yl8pwc;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fsurrendered_title_through.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Factor%2Fsurrendered_title_through.trig
@@ -33,7 +33,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-6a9cd64125ad449cbaf63c723100715c-kd5qwv;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E8_Acquisition>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6a9cd64125ad449cbaf63c723100715c-sshj37;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Surrendered title through";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Surrendered title through"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-6a9cd64125ad449cbaf63c723100715c-7moglc;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-09T15:01:32.161+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fappellation%2FPC139_has_alternative_form.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fappellation%2FPC139_has_alternative_form.trig
@@ -4,7 +4,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-612104a4d2754fca8c58782f705dfbc2-blbkg;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Alternative form";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Alternative form"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/appellation>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fappellation%2Falternative_form.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fappellation%2Falternative_form.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/appellation/alternative_form/context> {
   <http://www.researchspace.org/pattern/system/appellation/alternative_form> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Alternative form";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Alternative form"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/appellation>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fappellation%2Fidentifies.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fappellation%2Fidentifies.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-431a01daefd343a984d814b85e105155-e3lf2d;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Identifies";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Identifies"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-431a01daefd343a984d814b85e105155-w2updo;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E41_Appellation>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fappellation%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fappellation%2Ftype.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-3b08b380f2b84d8fab04707f561f7481-geuvmj;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-3b08b380f2b84d8fab04707f561f7481-qerbb3;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Appellation type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Appellation type"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3b08b380f2b84d8fab04707f561f7481-jk1zf3;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E41_Appellation>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3b08b380f2b84d8fab04707f561f7481-iwnb6t;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fattribute_assignment%2Fassigned_entity.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fattribute_assignment%2Fassigned_entity.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-b4d01502f5b940559e59de9cdae016be-o7vc09;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b4d01502f5b940559e59de9cdae016be-mgx34l;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b4d01502f5b940559e59de9cdae016be-jzc0vxvs;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fattribute_assignment%2Fassigned_to.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fattribute_assignment%2Fassigned_to.trig
@@ -58,7 +58,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a747c4c277d04b31a9a1ddbeafba3d5e-ssxq0d;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned to";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned to"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/attribute_assignment>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-a747c4c277d04b31a9a1ddbeafba3d5e-bw63so;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fauthority_document%2Flists.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fauthority_document%2Flists.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/authority_document/lists/context> {
   <http://www.researchspace.org/pattern/system/authority_document/lists> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "List of resources";
+    <http://www.w3.org/2000/01/rdf-schema#label> "List of resources"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-05203a2b212445669c9eee4a7eccd6bb-awwx0t;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-05203a2b212445669c9eee4a7eccd6bb-g1nrsn;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-05203a2b212445669c9eee4a7eccd6bb-gtavx;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fauthority_document%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fauthority_document%2Ftype.trig
@@ -17,7 +17,7 @@
   \"type\": \"simple\",
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/authority_document_type>\"
 }"""^^<http://www.researchspace.org/resource/system/syntheticJson>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Authority document type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Authority document type"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-08-23T17:37:54.658+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbeginning_of_existence%2Fbrought_into_existence_actor.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbeginning_of_existence%2Fbrought_into_existence_actor.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-be2313f47513425c99fe77a64db00857-i53djr;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E63_Beginning_of_Existence>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-be2313f47513425c99fe77a64db00857-uyucc;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Brought into existence actor";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Brought into existence actor"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbeginning_of_existence%2Fbrought_into_existence_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbeginning_of_existence%2Fbrought_into_existence_thing.trig
@@ -38,7 +38,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/beginning_of_existence>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Brought into existence thing";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Brought into existence thing"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e4a0aa44d25748e3ac8b2fbdefa4789b-qpglu;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e4a0aa44d25748e3ac8b2fbdefa4789b-eavah5;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e4a0aa44d25748e3ac8b2fbdefa4789b-v95xpr;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbirth%2Fbrought_into_life.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbirth%2Fbrought_into_life.trig
@@ -9,7 +9,7 @@
   <http://www.researchspace.org/pattern/system/birth/brought_into_life> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E21_Person>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Birth brought into life";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Birth brought into life"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-b386c87e9a0c4cc3849f26c0846d5991-njk50e;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbirth%2Fby_mother.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbirth%2Fby_mother.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E67_Birth>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-b844f17f27bf45caa6c448e477b8e003-erxtq;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Birth by mother";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Birth by mother"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b844f17f27bf45caa6c448e477b8e003-3opsg;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/birth>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-b844f17f27bf45caa6c448e477b8e003-168bzl;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbirth%2Ffrom_father.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fbirth%2Ffrom_father.trig
@@ -31,7 +31,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E67_Birth>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-0c15968617b84c469bda5917e08f8063-9jkrwm;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Birth from father";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Birth from father"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-0c15968617b84c469bda5917e08f8063-w806bk;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-0c15968617b84c469bda5917e08f8063-havzoc;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/birth>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Factivity_domain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Factivity_domain.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-283aab5b3e804fbbba6d2f1d997df208-ru3mh;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-283aab5b3e804fbbba6d2f1d997df208-5qaora;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - activity domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - activity domain"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-283aab5b3e804fbbba6d2f1d997df208-9j576b;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-09T11:49:41.705+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Factor_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Factor_range.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC14_carried_out_by>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - actor range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - actor range"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-fa739c1c0d5b40a09a699729dbb76a24-1n82tb;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-fa739c1c0d5b40a09a699729dbb76a24-vqizp;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fgroup_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fgroup_range.trig
@@ -2,7 +2,7 @@
   <http://www.researchspace.org/pattern/system/carried_out_by/group_range> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-6216d9fddf074ed4b01181ee3fddc826-wwgo57;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - group range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - group range"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-6216d9fddf074ed4b01181ee3fddc826-50jw6;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fhas_domain_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fhas_domain_type.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/carried_out_by/has_domain_type> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - has domain type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - has domain type"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b01c76f89cb54e40bef20999c754d06a-xryk7u;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/project>,
       <http://www.researchspace.org/resource/system/category/activity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fhas_range_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fhas_range_type.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/project>,
       <http://www.researchspace.org/resource/system/category/activity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - has range type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - has range type"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-21c6287039d047589cb3d6075cf6f1e6-7i8rai;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fis_domain_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fis_domain_of.trig
@@ -14,7 +14,7 @@
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - is domain of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - is domain of"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC14_carried_out_by>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>,

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fperson_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fperson_range.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC14_carried_out_by>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - person range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - person range"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-a543f1e84fa4497e92e66b2e3dd089d2-g7iklt;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a543f1e84fa4497e92e66b2e3dd089d2-opqnqk;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fproject_domain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Fproject_domain.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-2a463824039047bf8189839945b2dc88-4h3mx9;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-2a463824039047bf8189839945b2dc88-15n06g;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - project domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - project domain"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-2a463824039047bf8189839945b2dc88-thvo52h;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-2a463824039047bf8189839945b2dc88-jadkh;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Frange.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/carried_out_by/range/context> {
   <http://www.researchspace.org/pattern/system/carried_out_by/range> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - range"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC14_carried_out_by>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Frole.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcarried_out_by%2Frole.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC14_carried_out_by>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a1393a567612427cbca39846afa06cd4-3tdv0h;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - role";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried out by - role"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-09T11:51:03.331+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcollection%2Fcurator.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcollection%2Fcurator.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Current or former curator";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Current or former curator"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.w3.org/2000/01/rdf-schema#comment> "This field does not allow a history of curation to be recorded. This would require use of a Curation Activity (in the event section) initiating a curator being responsible for a collection.";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b2514bf900c44da19ffba6c9360ce55a-jplch;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcollection%2Fwas_curated_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcollection%2Fwas_curated_by.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/collection/was_curated_by/context> {
   <http://www.researchspace.org/pattern/system/collection/was_curated_by> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was curated by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was curated by"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E78_Curated_Holding>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/curated_collection>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fconceptual_object%2Fcreated_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fconceptual_object%2Fcreated_by.trig
@@ -32,7 +32,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e93943629beb4310bf4824f317f31d4c-keoa1f;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Created by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Created by"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e93943629beb4310bf4824f317f31d4c-15w4yh;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e93943629beb4310bf4824f317f31d4c-s1a8q;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/conceptual_object>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_assessment%2Fconcerned_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_assessment%2Fconcerned_physical_thing.trig
@@ -22,7 +22,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-5ca43c7d2489493b9ef805d31b51c6d5-jj7oo8;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-5ca43c7d2489493b9ef805d31b51c6d5-2w07e;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Concerned/assessed";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Concerned/assessed"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-5ca43c7d2489493b9ef805d31b51c6d5-wwb8yp;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E14_Condition_Assessment>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_assessment%2Fidentified_condition_state.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_assessment%2Fidentified_condition_state.trig
@@ -16,7 +16,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-b34c45e83d7049b4b32e0c71705f4c2f-jdtut1;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b34c45e83d7049b4b32e0c71705f4c2f-juedon;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b34c45e83d7049b4b32e0c71705f4c2f-8obkp;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Identified condition state";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Identified condition state"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E3_Condition_State>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-b34c45e83d7049b4b32e0c71705f4c2f-5bdm5;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E14_Condition_Assessment>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_state%2Fcondition_of_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_state%2Fcondition_of_physical_thing.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-b1fe43a4b8a34d38924ada57f6fb0e3c-0m42sq;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/condition_state>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b1fe43a4b8a34d38924ada57f6fb0e3c-62bzkc;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Condition of physical thing";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Condition of physical thing"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b1fe43a4b8a34d38924ada57f6fb0e3c-osefl;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-b1fe43a4b8a34d38924ada57f6fb0e3c-5unrjn;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_state%2Fconsist_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_state%2Fconsist_of.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-da3a6590530d435ebae0cdf486a6c8d6-ddulmf;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/condition_state>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-da3a6590530d435ebae0cdf486a6c8d6-2u7b6;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Consist of condition state";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Consist of condition state"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-da3a6590530d435ebae0cdf486a6c8d6-b6fdtx;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E3_Condition_State>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-da3a6590530d435ebae0cdf486a6c8d6-qwnnn4;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_state%2Fforms_part_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_state%2Fforms_part_of.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-4fe262720a2042fd8eecc0a8172b5257-ujqmz;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-4fe262720a2042fd8eecc0a8172b5257-qpwf0m;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-4fe262720a2042fd8eecc0a8172b5257-gvcc7h;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Forms part of condition state";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Forms part of condition state"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E3_Condition_State>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-02T17:45:10.815+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_state%2Fidentified_by_assessment.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcondition_state%2Fidentified_by_assessment.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/condition_state>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-9a51967586f64016bf116b82c8d81e8c-jrvr8k;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-9a51967586f64016bf116b82c8d81e8c-nmcl2x;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Identified by condition assessment";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Identified by condition assessment"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E14_Condition_Assessment>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-9a51967586f64016bf116b82c8d81e8c-kqzxb;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E3_Condition_State>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcontact_point%2Ftext.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcontact_point%2Ftext.trig
@@ -2,7 +2,7 @@
 
   <http://www.researchspace.org/pattern/system/contact_point/text> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Contact point text";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Contact point text"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-32e0665017234b6f83edd841a05e7835-yudwjw;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>,
       <http://www.researchspace.org/resource/system/category/person>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcontact_point%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcontact_point%2Ftype.trig
@@ -17,7 +17,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8aa05ce1cbeb4b2c81a7565e8c2060a5-li5qpp;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Contact point type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Contact point type"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-8aa05ce1cbeb4b2c81a7565e8c2060a5-2qact9;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-8aa05ce1cbeb4b2c81a7565e8c2060a5-lhjvt7;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcreation%2Fhas_created.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcreation%2Fhas_created.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E28_Conceptual_Object>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-fef3e4130b2145f4a96cc099d98ddaba-um2az9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Created";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Created"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-fef3e4130b2145f4a96cc099d98ddaba-g4ccj;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-04T11:17:08.340+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcuration_activity%2Fcurated_collection.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcuration_activity%2Fcurated_collection.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-46211d71233b466dba98c27d7fe3912d-jb7ze5;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Curated collection";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Curated collection"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-46211d71233b466dba98c27d7fe3912d-kmhvy;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E87_Curation_Activity>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-46211d71233b466dba98c27d7fe3912d-rpk3o;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcurrency%2Fcurrency_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fcurrency%2Fcurrency_of.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-41d2ebdc5664491d8d3896782c9676eb-clczsn;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/currency>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-41d2ebdc5664491d8d3896782c9676eb-ow67c;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Currency of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Currency of"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E97_Monetary_Amount>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E98_Currency>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-41d2ebdc5664491d8d3896782c9676eb-fwu4ul;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdeath%2Fdeath_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdeath%2Fdeath_of.trig
@@ -29,7 +29,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E69_Death>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-75071e660fc64503b5977bcbf67703d7-frio4;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-75071e660fc64503b5977bcbf67703d7-nf7dy9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Death of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Death of"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-75071e660fc64503b5977bcbf67703d7-gapb27;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-05T15:51:00.748+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdepicts%2Fdomain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdepicts%2Fdomain.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-263cef7c31064247bcf5acf35731964c-5a8e4;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Depicts - domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Depicts - domain"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-263cef7c31064247bcf5acf35731964c-lgoq7q;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-263cef7c31064247bcf5acf35731964c-tmidhv;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdepicts%2Fmode_of_depiction.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdepicts%2Fmode_of_depiction.trig
@@ -13,7 +13,7 @@
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/mode_of_depiction> . \"
 }"""^^<http://www.researchspace.org/resource/system/syntheticJson>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8090e93b60d94dc1930ae2a3d118a286-9gcnp;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Mode of depiction";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Mode of depiction"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8090e93b60d94dc1930ae2a3d118a286-r7ep4d;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-29T12:23:57.603+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdepicts%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdepicts%2Frange.trig
@@ -39,7 +39,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-0a05671cbcf8476b808b338433ab83a0-24ur3r;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-0a05671cbcf8476b808b338433ab83a0-nsi9ge;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Depicts range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Depicts range"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-29T12:22:31.900+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdesign_or_procedure%2FPC69_is_associated_with.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdesign_or_procedure%2FPC69_is_associated_with.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-6aeca6d67bab455798954bfff039ef3c-8zmyp;
     <http://www.w3.org/2000/01/rdf-schema#comment> "This property generalises relationships like whole-part, sequence, prerequisite or inspired by between instances of Design or Procedure.";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC69_is_associated_with>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is associated with";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is associated with"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-25T16:32:23.539+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdesign_or_procedure%2Fforesees_use_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdesign_or_procedure%2Fforesees_use_of.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-5e1c9cc4099e4938bce147c5718555b9-493hzt;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Foresees use of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Foresees use of"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E29_Design_or_Procedure>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-5e1c9cc4099e4938bce147c5718555b9-ohvmx4;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdesign_or_procedure%2Fis_associated_with_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdesign_or_procedure%2Fis_associated_with_range.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E29_Design_or_Procedure>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3d02f8ade99b479a932292e678942c3e-vbos;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3d02f8ade99b479a932292e678942c3e-31i38;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is associated with - design or procedure range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is associated with - design or procedure range"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC69_is_associated_with>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-25T17:13:12.842+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdesign_or_procedure%2Fused_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdesign_or_procedure%2Fused_by.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/design_or_procedure>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-71f278ca52474b40b048b60a63272772-avm3i;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-71f278ca52474b40b048b60a63272772-j11vb;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used by"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdestruction%2Fdestruction_destroyed.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdestruction%2Fdestruction_destroyed.trig
@@ -29,7 +29,7 @@
       <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f61ba8f9b5c64f39a475c0d11c0907bd-aqfe6j;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Destroyed";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Destroyed"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/destruction>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fdimension_of_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fdimension_of_thing.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/dimension>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E70_Thing>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension of"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-77ca680ab7bd44c1a71d595bef1bf828-kt05x7;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-02T11:20:12.789+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fduration_of_timespan.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fduration_of_timespan.trig
@@ -19,7 +19,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E54_Dimension>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-8e23632ea28c45e295e776da88ee2557-rwqbow;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Duration of timespan";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Duration of timespan"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/dimension>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8e23632ea28c45e295e776da88ee2557-o9m3n;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Flower_value.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Flower_value.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c73a815da1e5400c9565eba9d3ccdd17-upma9;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c73a815da1e5400c9565eba9d3ccdd17-mpcn19;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Lower value";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Lower value"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/dimension>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c73a815da1e5400c9565eba9d3ccdd17-yl5ji3;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fobserved_in.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fobserved_in.trig
@@ -21,7 +21,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-329ef0bf45804489b0cf13785bd921b0-jdafyd;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/dimension>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-329ef0bf45804489b0cf13785bd921b0-dpx6u;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Observed in measurement";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Observed in measurement"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-329ef0bf45804489b0cf13785bd921b0-42t7fp;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-02T11:10:49.384+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Ftype.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ae692110d41747d39d8484b45789edef-qrukrq;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E54_Dimension>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension type"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-ae692110d41747d39d8484b45789edef-6xanjj;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-ae692110d41747d39d8484b45789edef-ysveze;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Funit.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Funit.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/dimension/unit/context> {
   <http://www.researchspace.org/pattern/system/dimension/unit> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension unit";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension unit"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-31bb8b57ffd443878e142e7a1c9088cd-v5dvr7;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-31bb8b57ffd443878e142e7a1c9088cd-23fffe;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E54_Dimension>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fupper_value.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fupper_value.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#decimal>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E54_Dimension>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Upper value";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Upper value"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-0232cb5b293b423985d1ff0a9a3d8b51-zsjdup;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/dimension>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fvalue.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fvalue.trig
@@ -4,7 +4,7 @@
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#decimal>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E54_Dimension>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension value";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension value"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3b60424a898543e3b2ea80eb6a6969e5-q8qauq;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3b60424a898543e3b2ea80eb6a6969e5-q80wtt;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdissolution%2Fdissolved.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdissolution%2Fdissolved.trig
@@ -26,7 +26,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-33d7082931b843b48e12f293ff08f780-9b61aq;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Dissolved";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Dissolved"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/dissolution>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdocument%2Fabstract.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdocument%2Fabstract.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c328a2cb97084c1aaa0b682d9c5742aa-i5m5a;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Document abstract";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Document abstract"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c328a2cb97084c1aaa0b682d9c5742aa-a0tm4yt;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdocument%2Fdocuments.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdocument%2Fdocuments.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/document>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource documented";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource documented"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-2e02e079664d40faa41646ee58e50a4c-ulf5f;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-2e02e079664d40faa41646ee58e50a4c-kwu3m5;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdocument%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdocument%2Ftype.trig
@@ -18,7 +18,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-4ddbaf04f4054a20bbb0bcf4e73cb215-9x3j7i;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-4ddbaf04f4054a20bbb0bcf4e73cb215-js5m9c;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-4ddbaf04f4054a20bbb0bcf4e73cb215-7ra0v;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Document type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Document type"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2023-10-24T16:41:43.989+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fend_of_existence%2Ftook_out_of_existence_actor.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fend_of_existence%2Ftook_out_of_existence_actor.trig
@@ -24,7 +24,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e8cca5dbd28d4df1aac38a09e8b19305-izsl3f;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Took out of existence actor";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Took out of existence actor"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e8cca5dbd28d4df1aac38a09e8b19305-e4nci;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e8cca5dbd28d4df1aac38a09e8b19305-reotm;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fend_of_existence%2Ftook_out_of_existence_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fend_of_existence%2Ftook_out_of_existence_thing.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-a00047679ec94933878a0f4e2a9336b6-u3mbd;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a00047679ec94933878a0f4e2a9336b6-35ssyb;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-a00047679ec94933878a0f4e2a9336b6-4sorlu;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Took out of existence thing";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Took out of existence thing"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a00047679ec94933878a0f4e2a9336b6-oki2lw;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E70_Thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2FPC137_exemplifies.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2FPC137_exemplifies.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-674264b257bc41f39c13686556a2f790-km5bml;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-674264b257bc41f39c13686556a2f790-338d7o;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Entity exemplifier type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Entity exemplifier type"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-24T10:15:20.099+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fassigned_by_attribute_assignment.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fassigned_by_attribute_assignment.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-6eab20a58e1e425aa10bf30c7cd58748-qypreq;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6eab20a58e1e425aa10bf30c7cd58748-kg0qwg;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-6eab20a58e1e425aa10bf30c7cd58748-tay9ao;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned by"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-6eab20a58e1e425aa10bf30c7cd58748-fi3cfr;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fattributed_by_attribute_assignment.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fattributed_by_attribute_assignment.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-1d7717b29c124dd793904c545fdea21f-pvq3bs;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Attributed by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Attributed by"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-1d7717b29c124dd793904c545fdea21f-10mm5d;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-1d7717b29c124dd793904c545fdea21f-p2si6u;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fdepicted_by_human_made_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fdepicted_by_human_made_thing.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Entity depicted by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Entity depicted by"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-711c357324234b2cb9f2830edba56bfb-8p52os;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-711c357324234b2cb9f2830edba56bfb-vajbj;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-711c357324234b2cb9f2830edba56bfb-eokpyr;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fdepicts_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fdepicts_range.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c1daf6ee2b2d47bc8cafda54e4db99d6-42ac2c;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Depicted by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Depicted by"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c1daf6ee2b2d47bc8cafda54e4db99d6-m9efqg;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c1daf6ee2b2d47bc8cafda54e4db99d6-bwzro2;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fdocuments.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fdocuments.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/entity/documents> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Document";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Document"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-d999f0c602c1434baad12711686bdb91-hrvr8e;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Ffile_URLidentifier.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Ffile_URLidentifier.trig
@@ -17,7 +17,7 @@
   <http://www.researchspace.org/pattern/system/entity/file_URLidentifier> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Enter embed URL (e.g. for Youtube video go to Share > Embed video and select the src value in <iframe>)";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Web URL embed";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Web URL embed"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-f1906af4838245a19e5f8ea19b1b6d75-hkpqlh;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Ffile_identifier.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Ffile_identifier.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-257e937ebb0048a1bbc883bca823f1c0-u1m22;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "File identifier";
+    <http://www.w3.org/2000/01/rdf-schema#label> "File identifier"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-257e937ebb0048a1bbc883bca823f1c0-hvfos;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Ffile_identifierMin0.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Ffile_identifierMin0.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-9e01112b7920425dab8182ac1a8a5c56-76s8cn;
-    <http://www.w3.org/2000/01/rdf-schema#label> "File identifier Min0";
+    <http://www.w3.org/2000/01/rdf-schema#label> "File identifier Min0"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-9e01112b7920425dab8182ac1a8a5c56-vsx03;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9e01112b7920425dab8182ac1a8a5c56-krtxgm;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2FformRecord.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2FformRecord.trig
@@ -1,7 +1,7 @@
 <http://www.researchspace.org/pattern/system/entity/formRecord/context> {
   <http://www.researchspace.org/pattern/system/entity/formRecord> a <http://www.researchspace.org/resource/system/fields/Field>,
   <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-  <http://www.w3.org/2000/01/rdf-schema#label> "Entity form record";
+  <http://www.w3.org/2000/01/rdf-schema#label> "Entity form record"@en;
   <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
   <http://www.researchspace.org/resource/system/fields/range> <http://www.ics.forth.gr/isl/CRMdig/D1_Digital_Object>;
   <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fhas_all_types.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fhas_all_types.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c8777840d60e48888bd9fe8a3e6f7b71-fnhxqj;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c8777840d60e48888bd9fe8a3e6f7b71-tp4k7c;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Entity has type (all)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Entity has type (all)"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-01T13:59:35.055+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fhas_representation.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fhas_representation.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-ef96f9e8c6e2499181f4477f9e7f0e00-2w0aor;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Entity has representation";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Entity has representation"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E36_Visual_Item>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-ef96f9e8c6e2499181f4477f9e7f0e00-hyyz5;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fhas_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fhas_type.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/entity/has_type> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Entity type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Entity type"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-b042c5ea71b8440c8ca96ad1d29e92a6-e12p2h;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fidentifier.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fidentifier.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-46355fc8a4b64b9ba125560dd5791488-o5xwk;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E41_Appellation>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-46355fc8a4b64b9ba125560dd5791488-j3tzfl;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Other identifier";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Other identifier"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-29T19:42:42.757+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fidentifier_min1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fidentifier_min1.trig
@@ -4,7 +4,7 @@
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-52127c67c84b494b93e29dc5a1bb8bfd-rd7j8k;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Other identifier - mandatory";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Other identifier - mandatory"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Finfluenced_activity.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Finfluenced_activity.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c7dc8e1092014b5dad4005ddba650fc6-mlhi8d;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Influenced";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Influenced"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c7dc8e1092014b5dad4005ddba650fc6-m2vae3;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c7dc8e1092014b5dad4005ddba650fc6-gatl6;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fis_listed_in.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fis_listed_in.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> " is listed in";
+    <http://www.w3.org/2000/01/rdf-schema#label> "is listed in"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-df5757a68fd44fb8ac71c4afc33354a0-4x6m4;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fmeasurement.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fmeasurement.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-1241888ee4014b0b91a31af2e734de41-et6w;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-1241888ee4014b0b91a31af2e734de41-53312;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Measured by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Measured by"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-03-25T18:30:41.640Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fmotivated_activity.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fmotivated_activity.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/entity/motivated_activity> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Motivated";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Motivated"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-1130e3e1f95544328687f9d4de42ab1e-p45v5;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-1130e3e1f95544328687f9d4de42ab1e-kchkbc;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fpreferred_identifier.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fpreferred_identifier.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-19237d0a8741479889bcc25c58b40695-n1p0o;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-19237d0a8741479889bcc25c58b40695-vpqk1i;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-19237d0a8741479889bcc25c58b40695-uok4gq;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Preferred identifier";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Preferred identifier"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fpreferred_identifier_min1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fpreferred_identifier_min1.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E42_Identifier>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8bbd97f558084a6cbb6b1ed2fe2d794d-k2ro5n;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Preferred identifier - mandatory";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Preferred identifier - mandatory"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8bbd97f558084a6cbb6b1ed2fe2d794d-5mfbvh;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-8bbd97f558084a6cbb6b1ed2fe2d794d-miio;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fprimary_appellation.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fprimary_appellation.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-9bcafa80b38a42228e2335c3ea4a6777-pe6rc;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Name/appellation";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Name/appellation"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-9bcafa80b38a42228e2335c3ea4a6777-3hcpa;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Freferred_to_by_propositional_object.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Freferred_to_by_propositional_object.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c94910f67c0b4f79814d62acb0a5d532-69yrqe;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-c94910f67c0b4f79814d62acb0a5d532-nmox1;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Entity referred to by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Entity referred to by"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c94910f67c0b4f79814d62acb0a5d532-nhzvs;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c94910f67c0b4f79814d62acb0a5d532-lnjc9q;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Frefers_to_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Frefers_to_range.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Referred to by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Referred to by"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-367df65c65fc4bb1ad2e03f5373cf23a-1k94y;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-367df65c65fc4bb1ad2e03f5373cf23a-evaf8i;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Frepresents_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Frepresents_range.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC138_represents>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-5ba8c28a906646ef987cbd00acbd1bdf-x2jmnh;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Represents range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Represents range"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-5ba8c28a906646ef987cbd00acbd1bdf-k6f91u;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fresource_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fresource_type.trig
@@ -13,7 +13,7 @@
   \"type\": \"simple\",
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/system/vocab/resource_type> .\"
 }"""^^<http://www.researchspace.org/resource/system/syntheticJson>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-30T13:25:26.966+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fskos_scopeNote.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fskos_scopeNote.trig
@@ -20,7 +20,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-2fc1decfe6f24421b82921fffa15b121-cshqoq;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-2fc1decfe6f24421b82921fffa15b121-3q3bg;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Skos scope note";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Skos scope note"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-26T18:34:17.507+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fsubject_of_3Dmodel.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fsubject_of_3Dmodel.trig
@@ -9,7 +9,7 @@
   <http://www.researchspace.org/pattern/system/entity/subject_of_3Dmodel> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "3D model";
+    <http://www.w3.org/2000/01/rdf-schema#label> "3D model"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-83d8ba9004494d0ca9389242b3a949bb-p9fvhe;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-83d8ba9004494d0ca9389242b3a949bb-a425bs;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-83d8ba9004494d0ca9389242b3a949bb-m0yjm7;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fsubject_of_audio.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fsubject_of_audio.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3a5bafe8d21e4cd78a2aaee5b20ca4ea-rxrbvuo;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
-    <http://www.w3.org/2000/01/rdf-schema#label> "audio";
+    <http://www.w3.org/2000/01/rdf-schema#label> "audio"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://iflastandards.info/ns/fr/frbr/frbroo/F26_Recording>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fsubject_of_propositional_object.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fsubject_of_propositional_object.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-11d51cc25fbb4166a6b9e2f8d242c0b1-81w5mb;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Subject of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Subject of"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-11d51cc25fbb4166a6b9e2f8d242c0b1-jfrj2;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fsubject_of_video.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fsubject_of_video.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/entity/subject_of_video> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Video";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Video"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e325bfa403d742e39c46404b4fd4ae18-helch6;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fweb_URL_embed.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fweb_URL_embed.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/entity/web_URL_embed/context> {
   <http://www.researchspace.org/pattern/system/entity/web_URL_embed> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Web URL";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Web URL"@en;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Any web URL link related to the resource (e.g. data folder link, webpage, online document, etc.) ";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3245d19087de4b76a988e8dc15c3e0ab-53ss59;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fweb_URL_embed_Max1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fentity%2Fweb_URL_embed_Max1.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/entity/web_URL_embed_Max1/context> {
   <http://www.researchspace.org/pattern/system/entity/web_URL_embed_Max1> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Web URL";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Web URL"@en;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Enter embed URL (e.g. for Youtube video go to Share > Embed video and select the src value in <iframe>)";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/entity>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3245d19087de4b76a988e8dc15c3e0ab-53ss59;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2FentityFormRecord%2FformRecord_modification.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2FentityFormRecord%2FformRecord_modification.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-db8b156926344c57ac354d008c7c3c0c-46it1;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Entity form Record modification";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Entity form Record modification"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.ics.forth.gr/isl/CRMdig/D1_Digital_Object>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-db8b156926344c57ac354d008c7c3c0c-t5ow48;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2FentityFormRecordModification%2Fhad_output_record.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2FentityFormRecordModification%2Fhad_output_record.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-13e9f50a4ecf4d6597e59cfc748b441a-jfmj3o;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> " Form record modification output";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Form record modification output"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.ics.forth.gr/isl/CRMdig/D7_Digital_Machine_Event>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.ics.forth.gr/isl/CRMdig/D1_Digital_Object>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-13e9f50a4ecf4d6597e59cfc748b441a-9pspko;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fevent%2Foccurred_in_the_presence_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fevent%2Foccurred_in_the_presence_of.trig
@@ -16,7 +16,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E77_Persistent_Item>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E5_Event>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Occurred in the presence of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Occurred in the presence of"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-13c56451ec224fbb8b723619e14ab704-0uimyt;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-13c56451ec224fbb8b723619e14ab704-ysxwu;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fevent%2Foccurred_in_the_presence_of_actor.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fevent%2Foccurred_in_the_presence_of_actor.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-eeb51f5ec8684e17906d481c1fd51735-68pnh;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-eeb51f5ec8684e17906d481c1fd51735-ocvfdc;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-eeb51f5ec8684e17906d481c1fd51735-utdlyr;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Occurred in the presence of actor";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Occurred in the presence of actor"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-05T14:51:38.557+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fevent%2Foccurred_in_the_presence_of_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fevent%2Foccurred_in_the_presence_of_thing.trig
@@ -4,7 +4,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/event>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Occurred in the presence of thing";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Occurred in the presence of thing"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fevent%2Fpurpose_of_activity.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fevent%2Fpurpose_of_activity.trig
@@ -26,7 +26,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E5_Event>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-666dae180c9146f684ae9cee4e4967a1-ve3rwn;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Purpose of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Purpose of"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-03T10:55:45.638+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fexemplifies%2Fdomain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fexemplifies%2Fdomain.trig
@@ -2,7 +2,7 @@
   <http://www.researchspace.org/pattern/system/exemplifies/domain> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Exemplifies - entity domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Exemplifies - entity domain"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:t8100;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:t8102;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fexemplifies%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fexemplifies%2Frange.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f081771406064e679ca8f51cb168e1ca-mtgrz;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-f081771406064e679ca8f51cb168e1ca-yorc;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Exemplifies range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Exemplifies range"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-24T10:34:36.624+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fexemplifies%2Ftaxonomic_role.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fexemplifies%2Ftaxonomic_role.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6980be4af49f42ccafe572f89ddc3993-50o6m;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Taxonomic role";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Taxonomic role"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC137_exemplifies>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-6980be4af49f42ccafe572f89ddc3993-sdo19db;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fformation%2Fformed.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fformation%2Fformed.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/formation>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Formation formed";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Formation formed"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-61f3ab5138f34ad8b3c82d51575519ad-l22beb;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-61f3ab5138f34ad8b3c82d51575519ad-30tk8k;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-61f3ab5138f34ad8b3c82d51575519ad-z6w0tr;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fformation%2Fformed_from.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fformation%2Fformed_from.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/formation/formed_from> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-2203ae0542614e29b145e865531871dc-hofz9h;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Formation formed from";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Formation formed from"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2FPC107_has_current_or_former_member_domain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2FPC107_has_current_or_former_member_domain.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b1736293a7f24fcc85b4c704062a6548-b20jin;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/group>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has member";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has member"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b1736293a7f24fcc85b4c704062a6548-5ve39w;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-09T11:32:19.507+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fdissolved_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fdissolved_by.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-1b1c33ffc2904f8c8963734cd7c76d32-5s1hle;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-1b1c33ffc2904f8c8963734cd7c76d32-2je6g;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-1b1c33ffc2904f8c8963734cd7c76d32-b3iyd;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Dissolved by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Dissolved by"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E68_Dissolution>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/group>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-1b1c33ffc2904f8c8963734cd7c76d32-rg44r;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fformed_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fformed_by.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-2e4d3f43c2aa40efab35e1d8d9df5074-5cgu0h;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Formed by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Formed by"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-2e4d3f43c2aa40efab35e1d8d9df5074-oko6kg;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fgained_member_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fgained_member_by.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/group/gained_member_by> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-126dee9049e345b4a71b981c0190c3d7-l1dka9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Gained member by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Gained member by"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-126dee9049e345b4a71b981c0190c3d7-sdyk0de;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-126dee9049e345b4a71b981c0190c3d7-dgch8o;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fhas_current_or_former_member.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fhas_current_or_former_member.trig
@@ -4,7 +4,7 @@
       <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-69481d3cd3bb44ff8fa99c57699a0b85-7tg63d;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has current or former member";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has current or former member"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Flost_member_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Flost_member_by.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/group/lost_member_by> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-009e1b6f07ec43df80edd01a3ed96967-jmgh3;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Lost member by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Lost member by"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fparticipated_in_formation.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fgroup%2Fparticipated_in_formation.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e27ca7b7e80d45f089b5d6120afa97d6-ohpvbd;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e27ca7b7e80d45f089b5d6120afa97d6-9i9kta;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participated in formation";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participated in formation"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e27ca7b7e80d45f089b5d6120afa97d6-mktmsn;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E66_Formation>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e27ca7b7e80d45f089b5d6120afa97d6-nadkc;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_alternative_form%2Falternative_form_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_alternative_form%2Falternative_form_type.trig
@@ -15,7 +15,7 @@
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/appellation_alternative_form> . \"
 }"""^^<http://www.researchspace.org/resource/system/syntheticJson>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-d02c9df048844d6782b67424f6e70ada-k5hgt8;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Alternative form type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Alternative form type"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-25T14:47:05.985+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_alternative_form%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_alternative_form%2Frange.trig
@@ -18,7 +18,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-7a0cab1c34734e7491e80622d777664a-cq71i5;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-7a0cab1c34734e7491e80622d777664a-vnvek;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E41_Appellation>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has alternative form - range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has alternative form - range"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-25T14:49:21.227+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Factor_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Factor_range.trig
@@ -22,7 +22,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-f98d78e4db554c989d1264fbcef0ff0c-a3dt6d;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f98d78e4db554c989d1264fbcef0ff0c-3kpjgfq;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has member - actor range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has member - actor range"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-09T11:37:22.481+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fgroup_domain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fgroup_domain.trig
@@ -15,7 +15,7 @@
   <http://www.researchspace.org/pattern/system/has_member/group_domain> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8fdd903469f64f2fa642e350c4e917c1-52gy72;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has member - group domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has member - group domain"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-8fdd903469f64f2fa642e350c4e917c1-oxgobd;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fgroup_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fgroup_range.trig
@@ -1,7 +1,7 @@
 <http://www.researchspace.org/pattern/system/has_member/group_range/context> {
   <http://www.researchspace.org/pattern/system/has_member/group_range> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Member group_range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Member group_range"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a2acf1d0a32e4fc5bfb6000c101111ae-11hexn;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fhas_domain_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fhas_domain_type.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC107_has_current_or_former_member>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-2286cd792b0e4c98a3df729bb3e4f14b-nlhk4c;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Member has_domain_type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Member has_domain_type"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-2286cd792b0e4c98a3df729bb3e4f14b-iiddgw;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fhas_range_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fhas_range_type.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC107_has_current_or_former_member>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3f4adffc630448739d20767421b77e7f-3gn8br;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Member has_range_type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Member has_range_type"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3f4adffc630448739d20767421b77e7f-1pzlaa;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fkind_of_member.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fkind_of_member.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC107_has_current_or_former_member>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Member - kind of member";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Member - kind of member"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-d4ffbd71f5d24d8f90adfb500d79d53b-p2nyyi;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-d4ffbd71f5d24d8f90adfb500d79d53b-xd0ipv;
     <http://www.researchspace.org/resource/system/fields/treePatterns> """{

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fperson_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_member%2Fperson_range.trig
@@ -2,7 +2,7 @@
   <http://www.researchspace.org/pattern/system/has_member/person_range> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E21_Person>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Member person_range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Member person_range"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-42946886a5544b9c9b81183d699065f5-bxgeqn;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC107_has_current_or_former_member>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_title%2Fdomain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_title%2Fdomain.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e991f97ceca442efb8f555e6cd0dd958-zfvbgf;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has title domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has title domain"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e991f97ceca442efb8f555e6cd0dd958-otxc5;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e991f97ceca442efb8f555e6cd0dd958-ny9he;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e991f97ceca442efb8f555e6cd0dd958-p8zh0h;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_title%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_title%2Frange.trig
@@ -10,7 +10,7 @@
   
   <http://www.researchspace.org/pattern/system/has_title/range> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has title - range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has title - range"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E35_Title>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_title%2Ftitle_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhas_title%2Ftitle_type.trig
@@ -13,7 +13,7 @@
 }"""^^<http://www.researchspace.org/resource/system/syntheticJson>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-df6d14cf32154ff4ba4f63261e54645e-0fuhkh;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-df6d14cf32154ff4ba4f63261e54645e-eq7tsr;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Title type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Title type"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC102_has_title>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-17T12:41:02.169+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhuman-made_thing%2FPC102_has_title.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhuman-made_thing%2FPC102_has_title.trig
@@ -19,7 +19,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b161886234314258a5b72d1f472c8e84-4505nx;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b161886234314258a5b72d1f472c8e84-qphhjk;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Title";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Title"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC102_has_title>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/human_made_thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhuman-made_thing%2Ftitle.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhuman-made_thing%2Ftitle.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-dbcf7f4dc221464aa6ac3479701f7fdd-be63qk;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-dbcf7f4dc221464aa6ac3479701f7fdd-lxwkj9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Human-made thing title";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Human-made thing title"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-dbcf7f4dc221464aa6ac3479701f7fdd-j5h23;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/human_made_thing>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-dbcf7f4dc221464aa6ac3479701f7fdd-utksrr;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhuman-made_thing%2Fwas_intended_for.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhuman-made_thing%2Fwas_intended_for.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-46c9e31c681d460c8196034a6546e720-u60rl6;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended for";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended for"@en;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Relation between specific human-made things to types of intended methods and techniques of use.";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/human_made_thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhuman-made_thing%2Fwas_intended_use_of_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fhuman-made_thing%2Fwas_intended_use_of_range.trig
@@ -11,7 +11,7 @@
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E71_Human-Made_Thing>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a636cb74cfa74303b960bb7e8fa932b0-fjfjt;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Made for";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Made for"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a636cb74cfa74303b960bb7e8fa932b0-kxrj0n;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier%2Fassigned_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier%2Fassigned_by.trig
@@ -19,7 +19,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-1f197d1c3c90464caf78da50f60a0a02-aqacio;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-1f197d1c3c90464caf78da50f60a0a02-2pmgt;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned by"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E42_Identifier>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-1f197d1c3c90464caf78da50f60a0a02-k9iikj;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-1f197d1c3c90464caf78da50f60a0a02-tlaqfq;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier%2Fdeassigned_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier%2Fdeassigned_by.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-76378f47e7a84dbf9d45d2682d545818-cr831;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Deassigned by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Deassigned by"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E42_Identifier>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-76378f47e7a84dbf9d45d2682d545818-l8dgq;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/identifier>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier%2Fidentifier_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier%2Fidentifier_type.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-955f8d88f85d43788303af9c1a3ed2da-rvdb5;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Identifier type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Identifier type"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-955f8d88f85d43788303af9c1a3ed2da-cw6tah;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E42_Identifier>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-955f8d88f85d43788303af9c1a3ed2da-krn6e;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier%2Fpreferred_identifier_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier%2Fpreferred_identifier_of.trig
@@ -40,7 +40,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Preferred identifier of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Preferred identifier of"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E42_Identifier>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-d87eae89b60a42f38fd0450020315c70-0a3dm;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier_assignment%2Fassigned.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier_assignment%2Fassigned.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-1f83295cf31d4f088cb3e5f1226194e7-zfc6x9;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E42_Identifier>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-1f83295cf31d4f088cb3e5f1226194e7-ku7ql8;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-1f83295cf31d4f088cb3e5f1226194e7-kzp2xl;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/identifier_assignment>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier_assignment%2Fdeassigned.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier_assignment%2Fdeassigned.trig
@@ -19,7 +19,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-d53429722d97418aa9b0bba0b84a3801-41i6j7;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Deassigned";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Deassigned"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E42_Identifier>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-d53429722d97418aa9b0bba0b84a3801-1sqqpe;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/identifier_assignment>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier_assignment%2Fused_constituent.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fidentifier_assignment%2Fused_constituent.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-35f71b87630a4545a012ab8210054e9f-s5l957;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/identifier_assignment>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-35f71b87630a4545a012ab8210054e9f-or3d9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used constituent";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used constituent"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-05T18:55:16.926+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage%2Fis_main_representation.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage%2Fis_main_representation.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-d8d3e9c58fca4f8ba6fba0a3db2ae41e-k48hw;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.researchspace.org/ontology/EX_Digital_Image>, <http://www.researchspace.org/ontology/EX_Digital_Image_Region>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-d8d3e9c58fca4f8ba6fba0a3db2ae41e-95wvtf;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Image is main representation";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Image is main representation"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-03T15:14:45.081+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage%2Foverlay_created_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage%2Foverlay_created_by.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-37efe6b41c694bbab0cf875c01bd2878-zgr8g;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Overlay created by user";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Overlay created by user"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-37efe6b41c694bbab0cf875c01bd2878-ahnr5d;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.researchspace.org/ontology/EX_Digital_Image>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/image_search>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage%2Frepresents.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage%2Frepresents.trig
@@ -33,7 +33,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-af74def5674944b6afd55b2f174f9c4d-zibgl5;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-af74def5674944b6afd55b2f174f9c4d-6jtoai;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Image represents";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Image represents"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.researchspace.org/ontology/EX_Digital_Image>, <http://www.researchspace.org/ontology/EX_Digital_Image_Region>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-af74def5674944b6afd55b2f174f9c4d-gp1ym;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage%2Ftype.trig
@@ -19,7 +19,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a98875e5c2774b57b46b3350871aafd9-25mevj;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.researchspace.org/ontology/EX_Digital_Image>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a98875e5c2774b57b46b3350871aafd9-j76oxc;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Image type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Image type"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-07T10:38:49.949+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage_annotation%2FboundingBox.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage_annotation%2FboundingBox.trig
@@ -6,7 +6,7 @@
   <http://www.researchspace.org/pattern/system/image_annotation/boundingBox> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.researchspace.org/ontology/EX_Digital_Image_Region>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Annotation bounding box";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Annotation bounding box"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9461b158666e43f7b3ca5e394bd2b844-zw288;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-9461b158666e43f7b3ca5e394bd2b844-zp1ggfo;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage_annotation%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage_annotation%2Ftype.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/category/image_annotation> ,
     <http://www.researchspace.org/resource/system/category/image_annotation_search>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e0a773b7ae724dd3b9856f13ff838602-ztmwqf;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Image annotation type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Image annotation type"@en;
     <http://www.researchspace.org/resource/system/fields/treePatterns> """{
   \"type\": \"simple\",
   \"schemePattern\": \"?item a crm:E55_Type .\\n?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/image_annotation_type> .\",

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage_annotation%2Fvalue.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage_annotation%2Fvalue.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/image_annotation/value> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.researchspace.org/ontology/EX_Digital_Image_Region>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Annotation svg";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Annotation svg"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-1ae98230f45e43e2851b520e748e4ae1-ferigm;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-1ae98230f45e43e2851b520e748e4ae1-u5adox;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/image_annotation>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage_annotation%2Fviewport.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimage_annotation%2Fviewport.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.researchspace.org/ontology/EX_Digital_Image_Region>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Annotation viewport";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Annotation viewport"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/image_annotation>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:t19998;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:t19999;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimport_from_external_source%2FsourceURI.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fimport_from_external_source%2FsourceURI.trig
@@ -2,7 +2,7 @@
   <http://www.researchspace.org/pattern/system/import_from_external_source/sourceURI> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-8d131569855a4911acabfad19e147a92-j4527;
-    <http://www.w3.org/2000/01/rdf-schema#label> "External source URI";
+    <http://www.w3.org/2000/01/rdf-schema#label> "External source URI"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8d131569855a4911acabfad19e147a92-x7054ji;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Finformation_object%2Fincorporates.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Finformation_object%2Fincorporates.trig
@@ -25,7 +25,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-706a2ebcdcd44f1e87b63bd46ece8d29-udy8bi;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Incorporates";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Incorporates"@en;
     <http://www.w3.org/2000/01/rdf-schema#comment> """This property associates an Information Object with a Symbolic Object that was included in it. It accounts for many cultural facts that are quite frequent and significant: the inclusion of a poem in an anthology, the re-use of an operatic aria in a new opera, the use of a reproduction of a painting for a book cover or a CD booklet, the integration of textual quotations, the presence of lyrics in a song that sets those lyrics to music, the presence of the text of a play in a movie based on that play, etc.
 In particular, this property allows for modelling relationships of different levels of symbolic specificity, such as the natural language words making up a particular text, the characters making up the words and punctuation, the choice of fonts and page layout for the characters.""";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/information_object>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Finscription%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Finscription%2Ftype.trig
@@ -17,7 +17,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a0b7c463bbd24898ac06e4c68b53b4e8-x08uaj;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E34_Inscription>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a0b7c463bbd24898ac06e4c68b53b4e8-sh5jb;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Inscription type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Inscription type"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a0b7c463bbd24898ac06e4c68b53b4e8-ce46uo;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-03T13:54:00.647+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fis_associated_with%2Fassociation_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fis_associated_with%2Fassociation_type.trig
@@ -5,7 +5,7 @@
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-bd44309134c1404185b3fb518833c927-871k74;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Association type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Association type"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fis_associated_with%2Fdesign_or_procedure_domain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fis_associated_with%2Fdesign_or_procedure_domain.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E29_Design_or_Procedure>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8cd93a22fde34ca18497d130f2c3628e-cn6j2j;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is associated with - design or procedure domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is associated with - design or procedure domain"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8cd93a22fde34ca18497d130f2c3628e-r5x1fl;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-8cd93a22fde34ca18497d130f2c3628e-takh9g;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fis_associated_with%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fis_associated_with%2Frange.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E29_Design_or_Procedure>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-30fe521148e84b1db020f56d6acc72dc-cc5jo;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is associated with - range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is associated with - range"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-30fe521148e84b1db020f56d6acc72dc-98x4yj;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-30fe521148e84b1db020f56d6acc72dc-kmx4tb;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fjoining%2Fdomain_PC144.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fjoining%2Fdomain_PC144.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/joining/domain_PC144/context> {
   <http://www.researchspace.org/pattern/system/joining/domain_PC144> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Joining - domain PC144";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Joining - domain PC144"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/joining>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b86fc3d25d3246449350e06ec0a6f414-mad9g;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b86fc3d25d3246449350e06ec0a6f414-qbti7e;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fjoining%2Fdomain_PC144_Min1Max1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fjoining%2Fdomain_PC144_Min1Max1.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/joining>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Joining - domain PC144 Min1Max1";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Joining - domain PC144 Min1Max1"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC144_joined_with>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-83782a6a37d8472ba647beb35e3287f8-ao03d;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-83782a6a37d8472ba647beb35e3287f8-r3n2v6;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fjoining%2Fjoined.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fjoining%2Fjoined.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-64b76124d48147e8a6bcf6668ddbc513-km5g69;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-64b76124d48147e8a6bcf6668ddbc513-bpswda;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E85_Joining>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Joining - joined";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Joining - joined"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-64b76124d48147e8a6bcf6668ddbc513-dnv7q;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-04T13:30:30.497+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flanguage%2Flanguage_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flanguage%2Flanguage_of.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f0e576da4cdc4037b54ff8b638484cb9-75s4zm;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-f0e576da4cdc4037b54ff8b638484cb9-qto8y;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-f0e576da4cdc4037b54ff8b638484cb9-xwaex;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Language of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Language of"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f0e576da4cdc4037b54ff8b638484cb9-ae30fa;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-29T17:59:17.871+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fleaving%2Fseparated.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fleaving%2Fseparated.trig
@@ -24,7 +24,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-913a70ffb36b4ba984e3e656bf3474ef-7l866;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E86_Leaving>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Separated";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Separated"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-913a70ffb36b4ba984e3e656bf3474ef-403tbk;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-913a70ffb36b4ba984e3e656bf3474ef-kixnf;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fleaving%2Fseparated_from.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fleaving%2Fseparated_from.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f1483b3b294a4557b7d83f2cc1189b27-hf0pj2n;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Leaving - separated from";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Leaving - separated from"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E86_Leaving>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-04T15:09:30.299+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flegal_object%2Fright_held_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flegal_object%2Fright_held_by.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-83d486ff700e44559a1bb0aa41cfb365-0ajmmf;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E72_Legal_Object>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-83d486ff700e44559a1bb0aa41cfb365-26ixm;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Right held by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Right held by"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-83d486ff700e44559a1bb0aa41cfb365-4hq7pa;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-17T15:48:28.125+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flegal_object%2Fsubject_to_right.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flegal_object%2Fsubject_to_right.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E30_Right>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-5404cfdc7e5a40b79ea4e219c4fd6fb2-4tb6gk;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Legal rights";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Legal rights"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E72_Legal_Object>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-5404cfdc7e5a40b79ea4e219c4fd6fb2-h6m99n;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Enter the legal privileges concerning the object, such as reproduction and property rights (eg. copyright, ownership rights).";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flinguistic_object%2Fhas_language.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flinguistic_object%2Fhas_language.trig
@@ -35,7 +35,7 @@
     <http://www.cidoc-crm.org/cidoc-crm/E34_Inscription>,
     <http://www.cidoc-crm.org/cidoc-crm/E35_Title>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6d48a84c32f845719b5019ca61693f09-c5e845;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Language";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Language"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-6d48a84c32f845719b5019ca61693f09-q641uy;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-30T15:49:37.799+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flinguistic_object%2Fhas_translation.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flinguistic_object%2Fhas_translation.trig
@@ -25,7 +25,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E33_Linguistic_Object>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E33_Linguistic_Object>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Translation";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Translation"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c66ae54271614d05bc10d2b21ee9497d-uwgeg;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-c66ae54271614d05bc10d2b21ee9497d-zj60g;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flinguistic_object%2Fis_translation_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flinguistic_object%2Fis_translation_of.trig
@@ -28,7 +28,7 @@
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/linguistic_object>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-ffb2dad2f8da4c1eae8318b687989d61-y2up8j;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is translation of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is translation of"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flinguistic_object%2Ftranslation.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Flinguistic_object%2Ftranslation.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#langString>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Translation";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Translation"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-9610537a23c84c04ad0eb8e552b44b30-src4ge;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E33_Linguistic_Object>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9610537a23c84c04ad0eb8e552b44b30-l5896;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmark%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmark%2Ftype.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/category> 
     <http://www.researchspace.org/resource/system/category/mark>,
     <http://www.researchspace.org/resource/system/category/mark_search>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Mark type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Mark type"@en;
     <http://www.researchspace.org/resource/system/fields/treePatterns> """{
   \"type\": \"simple\",
   \"schemePattern\": \"?item a crm:E55_Type .\\n?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/mark_type> .\",

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmaterial%2Femployed_in.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmaterial%2Femployed_in.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-3ad70d6db9864ad2a6652713cf36657b-zyi66r;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/material>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E11_Modification>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was employed in";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was employed in"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-23T19:42:36.135+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmaterial%2Fincorporated_in.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmaterial%2Fincorporated_in.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-acca7de1c1b14a7fbe038566d46c24c4-n1hm6;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-acca7de1c1b14a7fbe038566d46c24c4-brtymj;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-acca7de1c1b14a7fbe038566d46c24c4-u8iu1l;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Constituent of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Constituent of"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E57_Material>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-acca7de1c1b14a7fbe038566d46c24c4-shesh;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmeasurement%2Fmeasured.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmeasurement%2Fmeasured.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-be24298b502d46e18f32229a3135aeda-gzq2y;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-be24298b502d46e18f32229a3135aeda-rmuusn;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Measured";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Measured"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-be24298b502d46e18f32229a3135aeda-zquy8l;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/measurement>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmeasurement%2Fobserved_dimension.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmeasurement%2Fobserved_dimension.trig
@@ -30,7 +30,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E16_Measurement>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-00a08e953fde4ebca00b24acc605f108-3ie9q;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Observed dimension";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Observed dimension"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-00a08e953fde4ebca00b24acc605f108-r2rly2;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-00a08e953fde4ebca00b24acc605f108-hj4b0f;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/measurement>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmeasurement_unit%2Fis_unit_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmeasurement_unit%2Fis_unit_of.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/measurement_unit/is_unit_of/context> {
   <http://www.researchspace.org/pattern/system/measurement_unit/is_unit_of> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is unit of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is unit of"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-85902455b33945eeabcf0b4e28579c89-gim74f;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmodification%2Femployed_material.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmodification%2Femployed_material.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/modification/employed_material/context> {
   <http://www.researchspace.org/pattern/system/modification/employed_material> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Employed material";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Employed material"@en;
     <http://www.researchspace.org/resource/system/fields/domain>
         <http://www.cidoc-crm.org/cidoc-crm/E11_Modification>,
     <http://www.cidoc-crm.org/cidoc-crm/E79_Part_Addition>,

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmodification%2Fhas_modified_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmodification%2Fhas_modified_physical_thing.trig
@@ -23,7 +23,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/modification>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a38d3ebe49d34c4489940d25f071a4fd-g9h1s;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "has modified";
+    <http://www.w3.org/2000/01/rdf-schema#label> "has modified"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a38d3ebe49d34c4489940d25f071a4fd-94ej9c;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-a38d3ebe49d34c4489940d25f071a4fd-jhhcld;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmonetary_amount%2Fcurrency.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmonetary_amount%2Fcurrency.trig
@@ -22,7 +22,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E98_Currency>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Currency";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Currency"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-b7e1365fd54e41419f97da6ffeb299da-kxn3t9;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/monetary_amount>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-b7e1365fd54e41419f97da6ffeb299da-gz6q8o;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmonetary_amount%2Fsales_price_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmonetary_amount%2Fsales_price_of.trig
@@ -17,7 +17,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/monetary_amount>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E96_Purchase>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9788a5e963af41dcaf404867be10f659-hswey3;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Sales price of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Sales price of"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-9788a5e963af41dcaf404867be10f659-bcva9u;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-10-15T11:43:02.484+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmove%2Ffrom_place.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmove%2Ffrom_place.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-0e142036cbab4ea6b38b043d122f75f1-3z63k6;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E9_Move>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-0e142036cbab4ea6b38b043d122f75f1-gi5daa;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Move from place";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Move from place"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-04T15:50:35.066+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmove%2Fmoved_physical_object.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmove%2Fmoved_physical_object.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/move/moved_physical_object/context> {
   <http://www.researchspace.org/pattern/system/move/moved_physical_object> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Moved physical object";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Moved physical object"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-212d31a9fa2645a5ba93dd648e4496e2-ydwp2o;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmove%2Fto_place.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fmove%2Fto_place.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-252add75aa2b416a9925268d9d771e40-wzljfu;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Move to place";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Move to place"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-252add75aa2b416a9925268d9d771e40-cvjs0g;
     <http://www.researchspace.org/resource/system/fields/category>
     <http://www.researchspace.org/resource/system/category/move>,

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Fbroader_resource_configuration.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Fbroader_resource_configuration.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-1f32fb22047942c5ba812a408e89f0a9-6fcrv6;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource finder broader item";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource finder broader item"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/navigation_item>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Fmenu_section_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Fmenu_section_type.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c34756b0b4684b2096dda9df392684f8-hubpee;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c34756b0b4684b2096dda9df392684f8-wcegtvq;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c34756b0b4684b2096dda9df392684f8-1tzd1ph;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource finder section";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource finder section"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/navigation_item>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Forder_in_menu_section.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Forder_in_menu_section.trig
@@ -4,7 +4,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-d7cdabd58f1c4129a29c70f56783bce7-ar4pig;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource finder order in the section";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource finder order in the section"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-d7cdabd58f1c4129a29c70f56783bce7-tjtued;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Fresource_configuration.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Fresource_configuration.trig
@@ -3,7 +3,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Navigation item - resource configuration";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Navigation item - resource configuration"@en;
     <http://www.researchspace.org/resource/system/fields/treePatterns> """{
   \"type\": \"simple\",
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/system/resource_configurations_container> .\"

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Fresource_icon.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fnavigation_item%2Fresource_icon.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/navigation_item/resource_icon/context> {
   <http://www.researchspace.org/pattern/system/navigation_item/resource_icon> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Navigation item icon";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Navigation item icon"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-63dde15c24dc4738bf8cece0cc4aaa78-nlpy1;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fontology%2Fobject_property_has_ontology.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fontology%2Fobject_property_has_ontology.trig
@@ -6,7 +6,7 @@
   <http://www.researchspace.org/pattern/system/ontology/object_property_has_ontology>
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Property from ontology";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Property from ontology"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.w3.org/2002/07/owl#Ontology>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b87db8fc23b6466b992b41cd0e3c8d82-8rs054;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.w3.org/2002/07/owl#ObjectProperty>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fontology%2Fobject_property_has_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fontology%2Fobject_property_has_range.trig
@@ -18,7 +18,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e88661459cd3433a8ac38f2cd2c2bce8-ijh1ii;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Property has range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Property has range"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpart_addition%2Fadded_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpart_addition%2Fadded_physical_thing.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/part_addition>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-2fbd8c32e75d4f90b81eb50a6bd4be82-il51bm;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-2fbd8c32e75d4f90b81eb50a6bd4be82-gp7fco;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Added physical thing";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Added physical thing"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-08T11:43:44.395+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpart_addition%2Faugmented_physical_human-made_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpart_addition%2Faugmented_physical_human-made_thing.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Object/thing augmented";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Object/thing augmented"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/part_addition>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-34e47a006e8f482e9cb06531ae242767-on9zo;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-34e47a006e8f482e9cb06531ae242767-qoqyrl;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpart_removal%2Fdiminished_physical_human-made_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpart_removal%2Fdiminished_physical_human-made_thing.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-0f87075b7c7b423ab4871767931c0c30-6x85di;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Object/thing  diminished";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Object/thing  diminished"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E80_Part_Removal>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-0f87075b7c7b423ab4871767931c0c30-pdqib;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-0f87075b7c7b423ab4871767931c0c30-zb8ljs;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpart_removal%2Fremoved_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpart_removal%2Fremoved_physical_thing.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-c0b806fd345e46c6adeba0da32d7849d-ol07na;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c0b806fd345e46c6adeba0da32d7849d-xko4dx;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Removed physical thing";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Removed physical thing"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E80_Part_Removal>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Factivity.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Factivity.trig
@@ -1,7 +1,7 @@
 <http://www.researchspace.org/pattern/system/participant/activity/context> {
   <http://www.researchspace.org/pattern/system/participant/activity> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participant activity";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participant activity"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-81c72c1276724bfe9efd6c76e2723286-5cx3kk;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-81c72c1276724bfe9efd6c76e2723286-eruh9;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/actor>,

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Factor.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Factor.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-fd780a7842b44323b3113883c47be918-q9y0od;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participant actor";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participant actor"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-fd780a7842b44323b3113883c47be918-vhlple;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-fd780a7842b44323b3113883c47be918-yyg1kq;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fevent.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fevent.trig
@@ -13,7 +13,7 @@
   
   <http://www.researchspace.org/pattern/system/participant/event> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participant - domain event";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participant - domain event"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC11_had_participant>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-04c9a77fc75c4bbd9d6737f324b24ac8-31v0xv;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fgroup.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fgroup.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f6682c2824774dc5a16694eeb1287828-crzpyo;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participant group";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participant group"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-f6682c2824774dc5a16694eeb1287828-nv6lx9;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f6682c2824774dc5a16694eeb1287828-dpfrd5;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fhas_domain_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fhas_domain_type.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6635f0b6060b4e34b373a933751aa3fd-xp4mml;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-6635f0b6060b4e34b373a933751aa3fd-0fxult;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-6635f0b6060b4e34b373a933751aa3fd-xn60j;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participant has_domain_type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participant has_domain_type"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-01-22T16:25:18.511Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fhas_range_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fhas_range_type.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b0d123a1c1c7411b9962a6a51a363950-fv0rih;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participant has range type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participant has range type"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-b0d123a1c1c7411b9962a6a51a363950-2tt9g;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b0d123a1c1c7411b9962a6a51a363950-n4j2ee;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fperson.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Fperson.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-2d7d7a1e0ea8478d8f0680f8dddc25ec-u4mx3w;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participant person";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participant person"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-02-19T15:21:46.378Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Frange.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-dc4c0adfb8294cbdb0eb4a4c1b576f00-95olim;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-dc4c0adfb8294cbdb0eb4a4c1b576f00-q8mfdt;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participant range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participant range"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-dc4c0adfb8294cbdb0eb4a4c1b576f00-vlac2q;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-dc4c0adfb8294cbdb0eb4a4c1b576f00-qrq9ee;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Frole.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fparticipant%2Frole.trig
@@ -20,7 +20,7 @@
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/actor_role> .\"
 }"""^^<http://www.researchspace.org/resource/system/syntheticJson>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Participant role";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Participant role"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-09T11:59:07.762+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperiod%2Fconsist_of_period.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperiod%2Fconsist_of_period.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-31b3c507d6854224bdfbe042c8476035-gg3lzm;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E4_Period>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-31b3c507d6854224bdfbe042c8476035-z2kowl;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Consists of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Consists of"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-31b3c507d6854224bdfbe042c8476035-aopda;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-02T15:25:14.859+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperiod%2Fforms_part_of_period.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperiod%2Fforms_part_of_period.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b6618238f31c45978f7ebeaf44dd1a50-kfn9hu7;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b6618238f31c45978f7ebeaf44dd1a50-9jg3mm;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Forms part of period";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Forms part of period"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E4_Period>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-b6618238f31c45978f7ebeaf44dd1a50-09fzta;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperiod%2Ftook_place_at_place.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperiod%2Ftook_place_at_place.trig
@@ -66,7 +66,7 @@
     <http://www.researchspace.org/resource/system/category/type_creation_search>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Place";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Place"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-928a09bf9b014f2c8067650f607d57f1-lu0hum;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-928a09bf9b014f2c8067650f607d57f1-bu5csf;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperiod%2Ftook_place_on_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperiod%2Ftook_place_on_physical_thing.trig
@@ -23,7 +23,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-141fed28f69c42dfa130dde2ac5fa62b-a6j2pvi;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Took place on or within";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Took place on or within"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-141fed28f69c42dfa130dde2ac5fa62b-h13f4j;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-141fed28f69c42dfa130dde2ac5fa62b-y8j8fd;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpersistent_item%2Fbrought_into_existence_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpersistent_item%2Fbrought_into_existence_by.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Brought into existence by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Brought into existence by"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e1bcba9305f54d50a82813c31d6939ff-dimvpr;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E77_Persistent_Item>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e1bcba9305f54d50a82813c31d6939ff-zqtjvs;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpersistent_item%2Fpresent_at.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpersistent_item%2Fpresent_at.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E5_Event>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3b30c171664c41358fde91bebb6bbf8f-kqzxye;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Present at";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Present at"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E77_Persistent_Item>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3b30c171664c41358fde91bebb6bbf8f-uxy7tj;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Select event where the actor had an active or passive presence, without implying any specific role.";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpersistent_item%2Ftaken_out_of_existence_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpersistent_item%2Ftaken_out_of_existence_by.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Taken out of existence by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Taken out of existence by"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3ee056b579c64ef5ba1b7e95020a84ef-lvoz4n;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E77_Persistent_Item>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-3ee056b579c64ef5ba1b7e95020a84ef-b45jl4;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fdeath.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fdeath.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a1d7f4c2f98347bc80ba1fc27540b271-ss2pal;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-a1d7f4c2f98347bc80ba1fc27540b271-fidph;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Death";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Death"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E21_Person>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E69_Death>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Ffamily_name.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Ffamily_name.trig
@@ -26,7 +26,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/person>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-0991b6554fad40ccaa52009358faad8b-q23ewm;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Family name";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Family name"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-10T18:55:18.591+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fgave_birth.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fgave_birth.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/person>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e90bcadb84964e4d955e19f80361d795-thr6kh;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e90bcadb84964e4d955e19f80361d795-vlz84;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Gave birth";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Gave birth"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e90bcadb84964e4d955e19f80361d795-v51wp;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e90bcadb84964e4d955e19f80361d795-c4b0o2;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e90bcadb84964e4d955e19f80361d795-bdtdr;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fgender.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fgender.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/person>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Gender";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Gender"@en;
     <http://www.researchspace.org/resource/system/fields/treePatterns> """{
   \"type\": \"simple\",
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/person_gender> .\"

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fis_parent_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fis_parent_of.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/person/is_parent_of> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E21_Person>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is parent of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is parent of"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-71c9046c7ff84301a9a2c84c4cc0d236-azwcsc;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fname_native_language.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fname_native_language.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/person/name_native_language/context> {
   <http://www.researchspace.org/pattern/system/person/name_native_language> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Name in native language";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Name in native language"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6ce631cf061148e8b508e19649570007-09rnc7;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#langString>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fparent.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fparent.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E21_Person>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-282dbe3d470641a3af13258c6fdb7ed5-4g19c;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has parent";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has parent"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/person>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-282dbe3d470641a3af13258c6fdb7ed5-9ne2r9;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-282dbe3d470641a3af13258c6fdb7ed5-v17npx;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fprofession.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fprofession.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/person/profession> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-87de487d933647c088c10bba18235336-du8mod;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Profession";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Profession"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fwas_father_for.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fperson%2Fwas_father_for.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/person/was_father_for/context> {
   <http://www.researchspace.org/pattern/system/person/was_father_for> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was father for";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was father for"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E67_Birth>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-967e6ae3f8e540c88415c0ee927fe54c-tlxpya;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_feature%2Fis_found_on.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_feature%2Fis_found_on.trig
@@ -15,7 +15,7 @@
   <http://www.researchspace.org/pattern/system/physical_feature/is_found_on> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is found on";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is found on"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-9d5122ca1ad84fd981b18612eb5433e2-6rcc8r;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-9d5122ca1ad84fd981b18612eb5433e2-24072wv;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2FPC62_depicts.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2FPC62_depicts.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E24_Physical_Human-Made_Thing>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.w3.org/2000/01/rdf-schema#comment> "Depicting is meant in the sense that a physical human-made thing intentionally shows, through its optical qualities or form, a representation of the entity depicted. Photographs are by default regarded as being intentional in this sense. Anything that is designed to change the properties of the depiction, such as an e-book reader, is specifically excluded. The property does not pertain to inscriptions or any other information encoding.";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Depicts";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Depicts"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a3e464fdbb884b559ae6217024eb0b8c-ztrnmx;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a3e464fdbb884b559ae6217024eb0b8c-54dik;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC62_depicts>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Faugmented_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Faugmented_by.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E24_Physical_Human-Made_Thing>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-22ba46d520fb4f7bab839b4e96ce5429-5gno8;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Augmented by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Augmented by"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E79_Part_Addition>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-22ba46d520fb4f7bab839b4e96ce5429-lgfkue;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-22ba46d520fb4f7bab839b4e96ce5429-5ip50a;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Fdepicts.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Fdepicts.trig
@@ -14,7 +14,7 @@
     <http://www.w3.org/2000/01/rdf-schema#comment> "Depicting is meant in the sense that a physical human-made thing intentionally shows, through its optical qualities or form, a representation of the entity depicted. Photographs are by default regarded as being intentional in this sense. Anything that is designed to change the properties of the depiction, such as an e-book reader, is specifically excluded. The property does not pertain to inscriptions or any other information encoding.";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-f82a04d18d4b409a86d541597c949673-qpujz;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Depicts";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Depicts"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-18T17:47:24.237+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Fdiminished_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Fdiminished_by.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E80_Part_Removal>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-122fd60bd0d947ab8e636799cc59f4dd-mrl5v;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-122fd60bd0d947ab8e636799cc59f4dd-qbgqz;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Diminished by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Diminished by"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-18T15:28:29.590+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Fproduced_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Fproduced_by.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_human_made_thing>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E24_Physical_Human-Made_Thing>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Produced by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Produced by"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-320bb5cc0785431781571579fdac9691-84wj2o;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-320bb5cc0785431781571579fdac9691-a48map;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-320bb5cc0785431781571579fdac9691-ywitbj;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Fshows_visual_item.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_human-made_thing%2Fshows_visual_item.trig
@@ -28,7 +28,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E24_Physical_Human-Made_Thing>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E36_Visual_Item>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Shows visual item";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Shows visual item"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-424afda7f24f4a9db935149f243b42d8-zfveua;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-424afda7f24f4a9db935149f243b42d8-y2v15;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-424afda7f24f4a9db935149f243b42d8-xvantn;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fbears_feature.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fbears_feature.trig
@@ -4,7 +4,7 @@
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Bears feature";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Bears feature"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.w3.org/2000/01/rdf-schema#comment> "A physical feature can only exist on one object. One object may bear more than one feature. A site should be considered as a physical feature on the surface of the Earth.";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E26_Physical_Feature>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fcurrent_location.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fcurrent_location.trig
@@ -24,7 +24,7 @@
   
   <http://www.researchspace.org/pattern/system/physical_object/current_location> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Current location";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Current location"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ec72a48d24ce415a98872003a5ef4732-pd3yf;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-ec72a48d24ce415a98872003a5ef4732-umfvc4;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fcurrent_permanent_location.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fcurrent_permanent_location.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-9fd7dcbffe614f5dbdd26f13d63fc6bc-gbsjlp;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Current permanent location";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Current permanent location"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9fd7dcbffe614f5dbdd26f13d63fc6bc-pmgx7c;
     <http://www.researchspace.org/resource/system/fields/category> 
     <http://www.researchspace.org/resource/system/category/physical_object>,

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fformat.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fformat.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-abdf223177854fef83275d24a13369ac-1wqxz;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-abdf223177854fef83275d24a13369ac-9yy44r;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Object format";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Object format"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-abdf223177854fef83275d24a13369ac-47chwl;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fmedia.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fmedia.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3887d723459d4f359eb2ccf2d4b87d4d-war9bh;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Media";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Media"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E19_Physical_Object>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-30T11:46:15.856+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fmoved_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fmoved_by.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-fbd759093ec74f3d88a613502b97d86a-muy1a;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-fbd759093ec74f3d88a613502b97d86a-stpb9;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_object>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Moved by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Moved by"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-fbd759093ec74f3d88a613502b97d86a-xb292q;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E19_Physical_Object>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fnumber_of_parts.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Fnumber_of_parts.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a38dd8fb21c8476dba4b41fdcb2660aa-o5d627;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a38dd8fb21c8476dba4b41fdcb2660aa-eal51kd;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Number of components/parts";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Number of components/parts"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a38dd8fb21c8476dba4b41fdcb2660aa-k8kgz;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_object>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#integer>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_object%2Ftype.trig
@@ -4,7 +4,7 @@
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-41c565f6c98c42c18008814e0159fd1d-e08tto;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Object type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Object type"@en;
     <http://www.researchspace.org/resource/system/fields/treePatterns> """{
   \"type\": \"simple\",
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/object_type> .\"

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcarries_symbolic_object.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcarries_symbolic_object.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-9aac0cf5f640444c802b9da23fa93175-lluwdq;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9aac0cf5f640444c802b9da23fa93175-wv63ee;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-9aac0cf5f640444c802b9da23fa93175-c6chi9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carries";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carries"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-9aac0cf5f640444c802b9da23fa93175-ulo8al;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcomposed_of_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcomposed_of_physical_thing.trig
@@ -23,7 +23,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-644940b1b76c4827b4d9fd1916c80b58-voljoo;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-644940b1b76c4827b4d9fd1916c80b58-fqbl25;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Component";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Component"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-644940b1b76c4827b4d9fd1916c80b58-a0mw6c;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcurrent_keeper.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcurrent_keeper.trig
@@ -6,7 +6,7 @@
 """;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-70b799887c7242479bb908ed21403b54-aazxn;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Current keeper";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Current keeper"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcurrent_owner.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcurrent_owner.trig
@@ -23,7 +23,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-9264edda785d499890fb07d5aea7400e-ifd66;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Current owner";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Current owner"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-9264edda785d499890fb07d5aea7400e-8s8h0o;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-9264edda785d499890fb07d5aea7400e-3aptt;
     <http://www.w3.org/2000/01/rdf-schema#comment> """The owner at the time of validity of the record.

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fformer_keeper.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fformer_keeper.trig
@@ -13,7 +13,7 @@
     <http://www.w3.org/2000/01/rdf-schema#comment> """Actors who have or have had custody at some time.  Former or current keeper leaves open the question as to whether the specified keepers are current.
 """;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-7bcb155e679242b3aa57b8c03123fa3a-7ik6f;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current keeper";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current keeper"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-7bcb155e679242b3aa57b8c03123fa3a-n1ljqd;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fformer_owner.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fformer_owner.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-7299a340d449427d985962a8c800371a-uk3t7v;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-7299a340d449427d985962a8c800371a-ca0juh;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-7299a340d449427d985962a8c800371a-ql8t4o;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Former owner";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Former owner"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-7299a340d449427d985962a8c800371a-aospq;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fhas_condition.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fhas_condition.trig
@@ -24,7 +24,7 @@
     <http://www.cidoc-crm.org/cidoc-crm/E22_Human-Made_Object>,
     <http://www.cidoc-crm.org/cidoc-crm/E78_Curated_Holding>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-2b6933920e834d528fbf485c7cb3d994-9smay4;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has condition";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has condition"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fhas_section.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fhas_section.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8ad95368ffb94259904f3f81a9c2f8bb-cbb0v;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-8ad95368ffb94259904f3f81a9c2f8bb-j7gj2;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has section";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has section"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-8ad95368ffb94259904f3f81a9c2f8bb-0j46x;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Flocation.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Flocation.trig
@@ -30,7 +30,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-ddc602f9231c419b88ec77334dd0f431-pwykc;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-ddc602f9231c419b88ec77334dd0f431-av06ed;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current location";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current location"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ddc602f9231c419b88ec77334dd0f431-22dhqs;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-ddc602f9231c419b88ec77334dd0f431-lt22u;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fmaterial.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fmaterial.trig
@@ -19,7 +19,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-7f3b326bc44c452bbec7b66908d56809-kxp7dh;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E57_Material>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Material";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Material"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-7f3b326bc44c452bbec7b66908d56809-lzi724h;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-7f3b326bc44c452bbec7b66908d56809-g0iowg;
     <http://www.researchspace.org/resource/system/fields/category> 

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fmodified_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fmodified_by.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Modified by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Modified by"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f084703b75f547cca8720dc9d14884b7-s3iorw;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-f084703b75f547cca8720dc9d14884b7-z1vv4r;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-f084703b75f547cca8720dc9d14884b7-xripze;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Foccupies.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Foccupies.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-2bd8455f7c184bd1bebfffd2bdf4ff83-vkbdgh;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-2bd8455f7c184bd1bebfffd2bdf4ff83-q5dkrv;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-2bd8455f7c184bd1bebfffd2bdf4ff83-wquc8;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Occupies space";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Occupies space"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fpart_of_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fpart_of_physical_thing.trig
@@ -5,7 +5,7 @@
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-83cb4c7d2d46441481d3c0e9feb75e6c-7nzo9b;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Part of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Part of"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-83cb4c7d2d46441481d3c0e9feb75e6c-sux615;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Faddress_line1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Faddress_line1.trig
@@ -3,7 +3,7 @@
 
   <http://www.researchspace.org/pattern/system/place/address_line1> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Address line 1";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Address line 1"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/organisation> ;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place> ;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Faddress_line2.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Faddress_line2.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/organisation>,
       <http://www.researchspace.org/resource/system/category/place>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Address line 2";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Address line 2"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-69c4856284084a19aa9a6adda6761140-w75tj9;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-69c4856284084a19aa9a6adda6761140-r32vt;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fapproximated_by_place.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fapproximated_by_place.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Approximated by place";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Approximated by place"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Place which is defined in the same reference space, and which is used to approximate the former";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9054d3111a6b4ff485741354203893b1-biton;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fapproximates_place.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fapproximates_place.trig
@@ -16,7 +16,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-80aaa135ab7d4c3b948e8e50020268fb-i5zys;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Place which is defined in the same reference space, and which is used to approximate the former";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Approximates place";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Approximates place"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-80aaa135ab7d4c3b948e8e50020268fb-5loor;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-80aaa135ab7d4c3b948e8e50020268fb-t3orxb;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fborders_with_place.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fborders_with_place.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-c7d416a1112a455c95c2ee0422d3beca-vlrm4;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Borders with place";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Borders with place"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-03-27T10:10:51.889Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcity.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcity.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/place/city> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
 
-    <http://www.w3.org/2000/01/rdf-schema#label> "City";
+    <http://www.w3.org/2000/01/rdf-schema#label> "City"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/organisation> ;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place> ;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcontains_geo_coordinates.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcontains_geo_coordinates.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Contains geographic coordinates";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Contains geographic coordinates"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-da731475531147f5879835461a29652d-nuf0ef;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcontains_place.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcontains_place.trig
@@ -25,7 +25,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f89aa564f7ae454f8971922843735afd-uikos;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Contains place";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Contains place"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-03-26T18:14:24.417Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcountry.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcountry.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/place/country> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
 
-    <http://www.w3.org/2000/01/rdf-schema#label> "Country";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Country"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/organisation> ;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place> ;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcounty.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcounty.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/place/county/context> {
   <http://www.researchspace.org/pattern/system/place/county> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "State/province";
+    <http://www.w3.org/2000/01/rdf-schema#label> "State/province"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/organisation> ;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place> ;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcurrent_permanent_location_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcurrent_permanent_location_of.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Current permanent location of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Current permanent location of"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-28c8e9cfeec54ac5a86725b5af91bd49-3e0oge;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-28c8e9cfeec54ac5a86725b5af91bd49-40pvk15;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcurrently_holds.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fcurrently_holds.trig
@@ -25,7 +25,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E19_Physical_Object>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f974cd11cecc4348a2ce3fad0b9114d1-jll75mi;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-f974cd11cecc4348a2ce3fad0b9114d1-ngx51;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Currently holds";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Currently holds"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-f974cd11cecc4348a2ce3fad0b9114d1-l9s3i;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-03-27T17:24:21.453Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fdestination_of_move.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fdestination_of_move.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f0e159a60f64475196ac1eeeae23d771-0uqlzk;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E9_Move>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Destination of move";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Destination of move"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-f0e159a60f64475196ac1eeeae23d771-i18w38;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-f0e159a60f64475196ac1eeeae23d771-t7tl9l;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Ffalls_within_place.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Ffalls_within_place.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Falls within place";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Falls within place"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-d4e23a7000794beabb6780056d98ef0d-y62px;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-d4e23a7000794beabb6780056d98ef0d-7pefjn;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fformer_location_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fformer_location_of.trig
@@ -22,7 +22,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-a53493b979904dc5bc307ca5018e4e26-jd59k;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a53493b979904dc5bc307ca5018e4e26-4pa4a;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current location of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Former or current location of"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a53493b979904dc5bc307ca5018e4e26-h0yyb;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fis_at_rest_relative_to.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fis_at_rest_relative_to.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-760c1cd76d6e49998c3b11960fc03a25-3lgqo;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "At rest relative to";
+    <http://www.w3.org/2000/01/rdf-schema#label> "At rest relative to"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-760c1cd76d6e49998c3b11960fc03a25-di0gm;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-760c1cd76d6e49998c3b11960fc03a25-6f9o49;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Flocated_on_or_within.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Flocated_on_or_within.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-6f3702fea0b94d08ad14d7a6aaee9971-aw373;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-6f3702fea0b94d08ad14d7a6aaee9971-wu0kse;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Located on or within";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Located on or within"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-6f3702fea0b94d08ad14d7a6aaee9971-j09feh;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6f3702fea0b94d08ad14d7a6aaee9971-j7wvft9;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Foccupied_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Foccupied_by.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-fb97654755ff439583f53b9d8dd57c18-6a7egc;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-fb97654755ff439583f53b9d8dd57c18-h70un;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Occupied by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Occupied by"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-03-27T17:27:14.966Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Forigin_of_move.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Forigin_of_move.trig
@@ -8,7 +8,7 @@
   
   <http://www.researchspace.org/pattern/system/place/origin_of_move> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Origin of move";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Origin of move"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fosm_geo_coordinates.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fosm_geo_coordinates.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-21c5bc7af59c4aa096b102269c80085e-gp6syf;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Geographic coordinates (OpenStreetMap)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Geographic coordinates (OpenStreetMap)"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-21c5bc7af59c4aa096b102269c80085e-0z25xk;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Foverlaps_with_place.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Foverlaps_with_place.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-3646fdbc4fb64468b79500443325fa7f-wbmpxd;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3646fdbc4fb64468b79500443325fa7f-8l91nn;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Overlaps with place";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Overlaps with place"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3646fdbc4fb64468b79500443325fa7f-82iaqp;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3646fdbc4fb64468b79500443325fa7f-r66s99;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fpostcode.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fpostcode.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/place/postcode/context> {
   <http://www.researchspace.org/pattern/system/place/postcode> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Postcode";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Postcode"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/organisation> ;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place> ;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E53_Place>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fresidence_of_actor.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fresidence_of_actor.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-105c809dcc2048778942f561062f94bf-kx87xu;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-105c809dcc2048778942f561062f94bf-uurat4;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Residence of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Residence of"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-105c809dcc2048778942f561062f94bf-ywvhc;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-03-26T18:27:26.572Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Ftype.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Place type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Place type"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-7644001fd52f42aea8b697eb514f37de-dm8d2f;
     <http://www.researchspace.org/resource/system/fields/category> 
     <http://www.researchspace.org/resource/system/category/place>,

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fwithin_geo_coordinates.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fwithin_geo_coordinates.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/place>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Within geographic coordinates";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Within geographic coordinates"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-5a497111df7e4e5ab63ae4ff0c28332b-9zj11;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-5a497111df7e4e5ab63ae4ff0c28332b-geegv;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fwitnessed_period.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fplace%2Fwitnessed_period.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-440eebf1e648426c9692f860d11bc504-u0ylk;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E4_Period>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-440eebf1e648426c9692f860d11bc504-nfeuvv;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Witnessed period";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Witnessed period"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-03-26T18:51:10.487Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fproduct_type%2Fproduction_plan.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fproduct_type%2Fproduction_plan.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Production plan";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Production plan"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a4560f6b8f8c43a78df03f80c5d7ff88-5yew8;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Design or Procedure that completely determines the production of instances of things. The resulting things are considered exemplars of this instance of Product Type when the process specified is correctly executed. The  Design or Procedure may require the use of tools or models unique to the product type. The same Product Type may be associated with several variant plans.";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a4560f6b8f8c43a78df03f80c5d7ff88-4c3xu;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fproduct_type%2Frequires_production_tool.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fproduct_type%2Frequires_production_tool.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ddbb2479f084482c9f862a321b0ecbf7-zi3r04;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Requires production tool";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Requires production tool"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-ddbb2479f084482c9f862a321b0ecbf7-q60eqq;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E19_Physical_Object>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E99_Product_Type>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fproduction%2Fhas_produced_physical_human-made_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fproduction%2Fhas_produced_physical_human-made_thing.trig
@@ -31,7 +31,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/production>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-917445690c7e4ac0b1350cce0e698a5e-mb4rhj;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has produced";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has produced"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-917445690c7e4ac0b1350cce0e698a5e-fjpsnl;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-08T12:01:01.202+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fproject%2Fproject_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fproject%2Fproject_type.trig
@@ -32,7 +32,7 @@
   \"relationPattern\": \"?item crm:P127_has_broader_term ?parent .\"
 }"""^^<http://www.researchspace.org/resource/system/syntheticJson>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Project type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Project type"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-08T15:21:34.000+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpropositional_object%2FPC67_refers_to.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpropositional_object%2FPC67_refers_to.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9084e233a0e54abca4c8b966c12676af-d1gus;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Refers to";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Refers to"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC67_refers_to>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-9084e233a0e54abca4c8b966c12676af-whs4uh;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-9084e233a0e54abca4c8b966c12676af-p6uaf;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpropositional_object%2Fhas_component.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpropositional_object%2Fhas_component.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a63db7e651184f1eaec4f5c6f09c0a8c-gq2bk;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a63db7e651184f1eaec4f5c6f09c0a8c-2cb5r;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Components";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Components"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/propositional_object>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpropositional_object%2Fis_about.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpropositional_object%2Fis_about.trig
@@ -33,7 +33,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-871a5ea129a94075ac4521343c74a79e-3of26p;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object>;
     <http://www.w3.org/2000/01/rdf-schema#comment> "This differs from refers to in that it describes the primary subject or subjects of a the item.";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is about";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is about"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-871a5ea129a94075ac4521343c74a79e-8ac8g;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/propositional_object>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpropositional_object%2Fis_component_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpropositional_object%2Fis_component_of.trig
@@ -28,7 +28,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-b3615828b2714ee2aa4a3ebcf6155ff0-hiwill;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b3615828b2714ee2aa4a3ebcf6155ff0-gf6g6;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Part of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Part of"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b3615828b2714ee2aa4a3ebcf6155ff0-6p74a;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-b3615828b2714ee2aa4a3ebcf6155ff0-zzobxq;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E89_Propositional_Object>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpublication%2Fpublication_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpublication%2Fpublication_type.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Publication type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Publication type"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3354068febea4936ac4626470b5d8e73-t0u18;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3354068febea4936ac4626470b5d8e73-3e0nqi;
     <http://www.researchspace.org/resource/system/fields/domain> <http://iflastandards.info/ns/fr/frbr/frbroo/F22_Self-Contained_Expression>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpurchase%2Fsale_price.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fpurchase%2Fsale_price.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8c8ab1f0bfac45bfa6d116c46a2f94f1-z78ibfg;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Sale price";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Sale price"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-8c8ab1f0bfac45bfa6d116c46a2f94f1-gatj15;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-8c8ab1f0bfac45bfa6d116c46a2f94f1-mllilr;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8c8ab1f0bfac45bfa6d116c46a2f94f1-qckgi;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frefers_to%2Fdomain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frefers_to%2Fdomain.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-0e6c86854e264b669190b1735eb0c059-9l38p;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Refers to - domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Refers to - domain"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-0e6c86854e264b669190b1735eb0c059-eb57i;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-0e6c86854e264b669190b1735eb0c059-yn06yb;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frefers_to%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frefers_to%2Frange.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b7bd5cedc68e4ea5ac4a9616eb16f9fb-5mytc;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-b7bd5cedc68e4ea5ac4a9616eb16f9fb-icqtzl;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Refers to range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Refers to range"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC67_refers_to>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-b7bd5cedc68e4ea5ac4a9616eb16f9fb-stdlb5;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frefers_to%2Ftype_of_reference.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frefers_to%2Ftype_of_reference.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Type of reference";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Type of reference"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-231a72f9330449c4b358c881b782f113-4cf9f;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC67_refers_to>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frelationship%2Fbound_to_person.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frelationship%2Fbound_to_person.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-7fe7b6e765534bf19500fe8ebc201c78-ftwbpv;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Relationship to person";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Relationship to person"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-7fe7b6e765534bf19500fe8ebc201c78-8bs2sb;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-7fe7b6e765534bf19500fe8ebc201c78-drsvqm;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-7fe7b6e765534bf19500fe8ebc201c78-vooh8;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frelationship%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frelationship%2Ftype.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-ba2c26ae65354dc19a32aa2c973dc5d0-xca7z4;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-ba2c26ae65354dc19a32aa2c973dc5d0-ao20j;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.researchspace.org/ontology/Relationship>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Person relationship type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Person relationship type"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ba2c26ae65354dc19a32aa2c973dc5d0-licv0q;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frepresents%2Fdomain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frepresents%2Fdomain.trig
@@ -20,7 +20,7 @@
   
   <http://www.researchspace.org/pattern/system/represents/domain> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Represents domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Represents domain"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-581aaaa006dd4debad10414161de386d-1amtun;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frepresents%2Fmode_of_representation.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frepresents%2Fmode_of_representation.trig
@@ -9,7 +9,7 @@
   \"schemePattern\": \"?item crm:P71i_is_listed_in <http://www.researchspace.org/resource/vocab/mode_of_representation> . \"
 }"""^^<http://www.researchspace.org/resource/system/syntheticJson>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b418b24fea2f4d87a5b6cf6deab406c3-qdw1ga;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Mode of representation";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Mode of representation"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frepresents%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Frepresents%2Frange.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-cbfffd511e1d4fb0989603dc4fee0cc9-gorgso;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC138_represents>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-cbfffd511e1d4fb0989603dc4fee0cc9-rngsde;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Represents range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Represents range"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-03T15:03:23.961+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource%2Frecord_created_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource%2Frecord_created_by.trig
@@ -169,7 +169,7 @@
     <http://www.researchspace.org/ontology/EX_Digital_Image>,
     <http://www.researchspace.org/ontology/EX_Digital_Image_Region>,
     <http://www.w3.org/2004/02/skos/core#Concept>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Record created by user";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Record created by user"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3cdc7e4ad4aa478db5469369a38003a3-nxfay;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource%2Fwas_attributed_to.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource%2Fwas_attributed_to.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-8664d43fedf34934b39734a880cfdb78-3p5zrh;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8664d43fedf34934b39734a880cfdb78-nzhkl;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Modified by user";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Modified by user"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.ics.forth.gr/isl/CRMdig/D1_Digital_Object>,
       <http://iflastandards.info/ns/fr/frbr/frbroo/F2_Expression>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fconfiguration_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fconfiguration_type.trig
@@ -5,7 +5,7 @@
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/resource_configuration>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-af5d2e7e26bf4f029c5ec43c4df1e19e-3992hn;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource configuration type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource configuration type"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#boolean>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fhas_navigation_menu.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fhas_navigation_menu.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource has navigation menu";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource has navigation menu"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#boolean>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-f7fcd79cbfc74772a9450f671e6bd1be-ltfjje;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f7fcd79cbfc74772a9450f671e6bd1be-slc1a;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fmenu_item_config.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fmenu_item_config.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-7765443391f6423b94002c4d8559f242-l217rq;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Menu item config";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Menu item config"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2023-12-06T14:29:49.446Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Freferred_to_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Freferred_to_by.trig
@@ -18,7 +18,7 @@ $value <http://www.cidoc-crm.org/cidoc-crm/P67_refers_to> $subject .
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-eec77f68036c41d89a7b404fbbde21c9-k9vsg;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "refers to resource configuration";
+    <http://www.w3.org/2000/01/rdf-schema#label> "refers to resource configuration"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-eec77f68036c41d89a7b404fbbde21c9-chsxf;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Freferred_to_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Freferred_to_by.trig
@@ -4,6 +4,8 @@
     <http://spinrdf.org/sp#text> """DELETE {  $value <http://www.cidoc-crm.org/cidoc-crm/P67_refers_to> $subject .
 }  WHERE {
   $value <http://www.cidoc-crm.org/cidoc-crm/P67_refers_to> $subject .
+  $value a Platform:FinderNavigationItem .
+  $value crm:P71i_is_listed_in <http://www.researchspace.org/resource/system/resource_configurations_container/data/Finder/navigation_menu> .
   }""" .
   
   _:genid-eec77f68036c41d89a7b404fbbde21c9-chsxf a <http://spinrdf.org/sp#Query>;
@@ -29,6 +31,8 @@ $value <http://www.cidoc-crm.org/cidoc-crm/P67_refers_to> $subject .
   _:genid-eec77f68036c41d89a7b404fbbde21c9-6ou3ee a <http://spinrdf.org/sp#Query>;
     <http://spinrdf.org/sp#text> """SELECT ?value WHERE {
   $value <http://www.cidoc-crm.org/cidoc-crm/P67_refers_to> $subject .
+  $value a Platform:FinderNavigationItem .
+  $value crm:P71i_is_listed_in <http://www.researchspace.org/resource/system/resource_configurations_container/data/Finder/navigation_menu> .
 }""" .
   
   <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_broader_property.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_broader_property.trig
@@ -25,7 +25,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.w3.org/2000/01/rdf-schema#comment> "Enter a property that define the relation with a broader resource (e.g. skos:broader, crm:P127_has_broader_term, crm:P89_falls_within, etc.)";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-44da63cad8be45de9b9ff838b773cc02-ksuek9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Broader resource property";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Broader resource property"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2023-10-17T11:32:00.915+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_card_icon.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_card_icon.trig
@@ -5,7 +5,7 @@
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/resource_configuration>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-b012828f6a9248cfa16df0ea3b9c78fd-l56era;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource card icon";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource card icon"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_description.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_description.trig
@@ -5,7 +5,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/resource_configuration>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource description";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource description"@en;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Enter the resource description";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_form.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_form.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-7c5ef99775f74b06a78e8c62f7604d0d-1im3ue;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource form";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource form"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-03-06T18:45:02.012Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_in_finder.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_in_finder.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#boolean>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource in finder";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource in finder"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c342af8e473d4a80b3a93cfbf8256284-m2da3;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c342af8e473d4a80b3a93cfbf8256284-cxc97r;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_label_sparql_pattern.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_label_sparql_pattern.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-7972728f7fe842e68dec3486ab1922ee-ql8z8l;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-7972728f7fe842e68dec3486ab1922ee-iwycal;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource label (SPARQL pattern)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource label (SPARQL pattern)"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/2000/01/rdf-schema#comment> "Enter a SPARQL pattern for the resource label. The pattern should have ?item as subject variable and ?label as label literal (e.g. ?item crm:P1_is_identified_by / crm:P190_has_symbolic_content ?label . )";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/resource_configuration>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_list_in_authority.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_list_in_authority.trig
@@ -4,7 +4,7 @@
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/resource_configuration> ;
      
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource list in authority";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource list in authority"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#boolean>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_membership_property.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_membership_property.trig
@@ -20,7 +20,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e557b147cfcd4230bcf9bee2677a1ae5-v7meew;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e557b147cfcd4230bcf9bee2677a1ae5-8uotxd;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource membership in the authority document";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource membership in the authority document"@en;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Enter a property that define the membership of the resource in the authority (e.g. skos:inScheme, crm:P71i_is_listed_in, etc.)";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2023-10-17T11:29:48.697+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_name.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_name.trig
@@ -3,7 +3,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/resource_configuration>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "resource name";
+    <http://www.w3.org/2000/01/rdf-schema#label> "resource name"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c0808b1201ed4b9e923678de2a183464-xqrtc;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_order_sparql_pattern.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_order_sparql_pattern.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/resource_configuration>;
      
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource list order (SPARQL pattern)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource list order (SPARQL pattern)"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-64ad0e5109fe4337a58e1e3bdfd3af49-3akrp7;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2022-05-23T15:21:07.130+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_restriction_sparql_pattern.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_restriction_sparql_pattern.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/resource_configuration/resource_restriction_sparql_pattern>
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource restriction (SPARQL pattern)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource restriction (SPARQL pattern)"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-53c73dcfcf824d47a2348cacfbb0aa7b-36cy6;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_facet_kpCategory.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_facet_kpCategory.trig
@@ -16,7 +16,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-f5021286dac948d99df9c5bb90869f6c-yy4z2e;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f5021286dac948d99df9c5bb90869f6c-a8h1f;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Knowledge pattern category";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Knowledge pattern category"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f5021286dac948d99df9c5bb90869f6c-115c29;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.w3.org/2004/02/skos/core#Concept>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-f5021286dac948d99df9c5bb90869f6c-ngdg2v;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-bdc8295190b24e789e8575e692ca8be9-k535bf;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "List view column";
+    <http://www.w3.org/2000/01/rdf-schema#label> "List view column"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-bdc8295190b24e789e8575e692ca8be9-293gho;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column1.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-24344996284f4edca02987eb8f23e083-ykhxua;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search list view column 1";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search list view column 1"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-06-19T10:54:25.905+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column2.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column2.trig
@@ -18,7 +18,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search list view column 2";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search list view column 2"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-06-19T10:56:41.523+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column3.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column3.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search list view column 3";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search list view column 3"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a6d43f96c3484042836c3e4aca5c936e-fbhnes;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a6d43f96c3484042836c3e4aca5c936e-qhm1m;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column4.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_listView_column4.trig
@@ -19,7 +19,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-2ee8eb162ca9437ab93e8b6f01915a83-0ccnjw;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-2ee8eb162ca9437ab93e8b6f01915a83-97pmva;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search list view column 4";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search list view column 4"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-06-19T10:57:33.988+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_view_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_search_view_type.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3d66d36a2d84403d8b0d8fa07c1daa40-y9aq8w;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3d66d36a2d84403d8b0d8fa07c1daa40-8gsklo;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search view";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource search view"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3d66d36a2d84403d8b0d8fa07c1daa40-h3ghfn;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-16T14:39:00.601+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_configuration%2Fresource_type.trig
@@ -16,7 +16,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-95dbdc56d4ff4c41a4201e05c8c529b9-1pfzda;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/2000/01/rdf-schema#comment> "Additional type to be associated to the resource. This is not editable for a System Resource Configuration.";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_search_listView_column%2Fcontent_sparql_pattern.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_search_listView_column%2Fcontent_sparql_pattern.trig
@@ -7,7 +7,7 @@
     <http://www.w3.org/2000/01/rdf-schema#comment> "Enter a SPARQL pattern for the column content. The pattern should have ?item as subject variable, ?label as label literal, ?itemIri as  URI for content of type link (e.g. ?item crm:P1_is_identified_by / crm:P190_has_symbolic_content ?label . )";
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8ea9b9bd8465405da4ef2136fcef148b-326v;
-    <http://www.w3.org/2000/01/rdf-schema#label> "List view column content (SPARQL pattern)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "List view column content (SPARQL pattern)"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8ea9b9bd8465405da4ef2136fcef148b-zkl03;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_search_listView_column%2Fcontent_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_search_listView_column%2Fcontent_type.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a898653366bf4d83847c216771774e2b-rdt15c;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a898653366bf4d83847c216771774e2b-ezxy2e;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "List view column content type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "List view column content type"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a898653366bf4d83847c216771774e2b-ueoae;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-a898653366bf4d83847c216771774e2b-d9109w;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_search_listView_column%2Forder.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_search_listView_column%2Forder.trig
@@ -4,7 +4,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/resource_configuration>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "List view column order";
+    <http://www.w3.org/2000/01/rdf-schema#label> "List view column order"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-db697febdb40448cab5b873e9b73f7a5-vtfefn;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-db697febdb40448cab5b873e9b73f7a5-msxo1q;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-db697febdb40448cab5b873e9b73f7a5-chj54u;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_search_listView_column%2Ftitle.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fresource_search_listView_column%2Ftitle.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-edfbb368fe8b483388c3b0fc62f574fe-19j16;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-edfbb368fe8b483388c3b0fc62f574fe-l4gewj;
-    <http://www.w3.org/2000/01/rdf-schema#label> "List view column title";
+    <http://www.w3.org/2000/01/rdf-schema#label> "List view column title"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-edfbb368fe8b483388c3b0fc62f574fe-agiltl;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fright%2Fapplies_to.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fright%2Fapplies_to.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e170e62f77ab42ac87990d6aa5903666-5dey9r;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e170e62f77ab42ac87990d6aa5903666-zg86gn;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Applies to";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Applies to"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E72_Legal_Object>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E30_Right>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e170e62f77ab42ac87990d6aa5903666-1jzlpv;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fright%2Fis_possessed_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fright%2Fis_possessed_by.trig
@@ -23,7 +23,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-2f301cfc9247477db9362256d5b3022f-pfs36;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E30_Right>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is possessed by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is possessed by"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-2f301cfc9247477db9362256d5b3022f-p0mfyn;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-2f301cfc9247477db9362256d5b3022f-9ngctm;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/right>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fshows_features_of%2Fdomain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fshows_features_of%2Fdomain.trig
@@ -25,7 +25,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-c1c2477968a6428f9723839256e30b0d-u394tm;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c1c2477968a6428f9723839256e30b0d-cfxr9;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Shows features of - domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Shows features of - domain"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-c1c2477968a6428f9723839256e30b0d-ozv2ho;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c1c2477968a6428f9723839256e30b0d-kxg6d;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c1c2477968a6428f9723839256e30b0d-bsfu47;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fshows_features_of%2Fkind_of_similarity.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fshows_features_of%2Fkind_of_similarity.trig
@@ -15,7 +15,7 @@
 }"""^^<http://www.researchspace.org/resource/system/syntheticJson>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-7796358203d5423691145dd988f9445b-v8njh9;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-7796358203d5423691145dd988f9445b-effefh;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Shows features of - kind of similarity";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Shows features of - kind of similarity"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-16T16:16:12.475+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fshows_features_of%2Frange.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fshows_features_of%2Frange.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/shows_features_of/range/context> {
   <http://www.researchspace.org/pattern/system/shows_features_of/range> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Shows features of - range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Shows features of - range"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC130_shows_features_of>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-4c6eb07fc215491da224ef09fc92a934-3vkd9;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-4c6eb07fc215491da224ef09fc92a934-q1nzu;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fcarried_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fcarried_by.trig
@@ -29,7 +29,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/symbolic_object>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-25fd6a75c8db423b929f870ef09956a7-h84jah;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Carried by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Carried by"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-24T16:16:42.042+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fcomposed_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fcomposed_of.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-40f149f5de7f4bca94a10ea7b5834bb7-y3fiw7;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Components";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Components"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-40f149f5de7f4bca94a10ea7b5834bb7-555ap;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-40f149f5de7f4bca94a10ea7b5834bb7-xfoe9;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/symbolic_object>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fhas_symbolic_content.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fhas_symbolic_content.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E90_Symbolic_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-367c48f33d6a423b85d52bc8d8afd02e-khxi3;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has symbolic content";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has symbolic content"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-367c48f33d6a423b85d52bc8d8afd02e-braaed;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/symbolic_object>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fhas_symbolic_contentMin1Max1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fhas_symbolic_contentMin1Max1.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E90_Symbolic_Object>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/symbolic_object>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Name/value";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Name/value"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-756c0c4a88c042659ed12695f7f2edb6-l94xuy;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fincorporated_in.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fincorporated_in.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ba36ec376a5a4f4ca6c315ea553a73bd-y8xdko;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/symbolic_object>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Incorporated in";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Incorporated in"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-ba36ec376a5a4f4ca6c315ea553a73bd-hl0bw4;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-ba36ec376a5a4f4ca6c315ea553a73bd-kjtjv;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-ba36ec376a5a4f4ca6c315ea553a73bd-pojj6;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fpart_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fpart_of.trig
@@ -30,7 +30,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E90_Symbolic_Object>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Part of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Part of"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-73670360346b4971baa5898a5fabf584-rivs04;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/symbolic_object>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-73670360346b4971baa5898a5fabf584-e14d3a;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fused_in.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsymbolic_object%2Fused_in.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E90_Symbolic_Object>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used in";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used in"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-06c7e79c63f64e1daeff468c27224e24-f7fglg;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/symbolic_object>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsystem_activity%2Fdate.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsystem_activity%2Fdate.trig
@@ -41,7 +41,7 @@
       <http://www.cidoc-crm.org/cidoc-crm/E3_Condition_State>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-295008e500fd48f09eef077802c417d7-apj01p;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "System activity date";
+    <http://www.w3.org/2000/01/rdf-schema#label> "System activity date"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-295008e500fd48f09eef077802c417d7-c9wu5c;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#date>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsystem_activity%2Fresource_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsystem_activity%2Fresource_type.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c7ae5f84b45a4163a50575d599795f99-in4ut;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c7ae5f84b45a4163a50575d599795f99-41xm8e;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/domain> 
     <http://iflastandards.info/ns/fr/frbr/frbroo/F22_Self-Contained_Expression>,

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsystem_activity%2Fwas_attributed_to.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsystem_activity%2Fwas_attributed_to.trig
@@ -1,7 +1,7 @@
 <http://www.researchspace.org/pattern/system/system_activity/was_attributed_to/context> {
   <http://www.researchspace.org/pattern/system/system_activity/was_attributed_to> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource created/modified by user";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource created/modified by user"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/category> 
     <http://www.researchspace.org/resource/system/category/system_activity_search>,

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsystem_vocabulary%2Frefers_to_resourceConfig.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fsystem_vocabulary%2Frefers_to_resourceConfig.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-258f571a9d484a02b6376e1001d8381c-9s679m;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-258f571a9d484a02b6376e1001d8381c-6566mc;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type (System vocabulary)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type (System vocabulary)"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-258f571a9d484a02b6376e1001d8381c-enzs49;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-258f571a9d484a02b6376e1001d8381c-zrfxu;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fcomposite_timespan.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fcomposite_timespan.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/temporal_entity/composite_timespan/context> {
   <http://www.researchspace.org/pattern/system/temporal_entity/composite_timespan> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan (composite)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan (composite)"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E2_Temporal_Entity>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fhas_timespan.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fhas_timespan.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/temporal_entity/has_timespan/context> {
   <http://www.researchspace.org/pattern/system/temporal_entity/has_timespan> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan/date";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan/date"@en;
     <http://www.researchspace.org/resource/system/fields/category> 
     <http://www.researchspace.org/resource/system/category/temporal_entity>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-077625c7dd514a0d909d89653235f021-uzhnxn;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fhas_timespan_date.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fhas_timespan_date.trig
@@ -40,7 +40,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-df2183d40f49493e9c197d8a546434b6-7bcfmr;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-df2183d40f49493e9c197d8a546434b6-hzw1a3;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Date";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Date"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-df2183d40f49493e9c197d8a546434b6-69o8g;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#date>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fhas_timespan_end.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fhas_timespan_end.trig
@@ -38,7 +38,7 @@
       <http://www.researchspace.org/resource/system/category/birth_search>, <http://www.researchspace.org/resource/system/category/transformation_search>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-135bb26bdb9b48798aaa0b7ad4b9dc8e-ehynkl;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "End date";
+    <http://www.w3.org/2000/01/rdf-schema#label> "End date"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-135bb26bdb9b48798aaa0b7ad4b9dc8e-vaw8uoh;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#date>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fhas_timespan_start.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftemporal_entity%2Fhas_timespan_start.trig
@@ -41,7 +41,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c72251352e054fd89193bef1cac5fa5c-bd48an;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c72251352e054fd89193bef1cac5fa5c-b663h;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Start date";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Start date"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#date>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fterm%2Frelated_term.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fterm%2Frelated_term.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-7d1865ff8f6e4b5fbebc5824437ec0b7-b53ha;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-7d1865ff8f6e4b5fbebc5824437ec0b7-7aj44j;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.w3.org/2004/02/skos/core#Concept>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Related term";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Related term"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-02-19T18:45:32.667Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2FPC130_shows_features_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2FPC130_shows_features_of.trig
@@ -12,7 +12,7 @@
   
   <http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Shows features of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Shows features of"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E70_Thing>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8d8fbd71d0f4426191cdf87ac0b4b12f-wpe6kg;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8d8fbd71d0f4426191cdf87ac0b4b12f-k4adeo;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2FPC130_shows_features_of_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2FPC130_shows_features_of_range.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a8afe943d32243f8b1fedddb63e05372-44b9t;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a8afe943d32243f8b1fedddb63e05372-z0d0vh;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a8afe943d32243f8b1fedddb63e05372-vsaj5s;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Has features of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Has features of"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC130_shows_features_of>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-16T16:50:27.563+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2Fdimension.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2Fdimension.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9a4433364ec949e889e88425bd43f21d-k4h1re;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Dimension"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/thing>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-9a4433364ec949e889e88425bd43f21d-d01edl;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2Fhad_as_general_use.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2Fhad_as_general_use.trig
@@ -86,7 +86,7 @@
     <http://www.researchspace.org/resource/system/category/site_search>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-317110e1074b422788a67365edb79a01-vjmm8b;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-317110e1074b422788a67365edb79a01-ysjkc8;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Had as general use";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Had as general use"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-317110e1074b422788a67365edb79a01-1ldgcj;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-16T11:54:43.687+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2Fused_specific_object_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2Fused_specific_object_range.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/thing>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-5479cce290b647a78f66c2f41d19e2f4-4qw77s;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used for";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used for"@en;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Typically applies to tools, instruments, moulds, raw materials and items embedded in a product. It implies that the presence of the object in question was a necessary condition for the action.";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC16_used_specific_object>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-5479cce290b647a78f66c2f41d19e2f4-sah23;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2Fwas_used_for.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fthing%2Fwas_used_for.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/thing>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Thing was used for";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Thing was used for"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-aa5f9205b62642b786918fb4d90837aa-i2fr4;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-aa5f9205b62642b786918fb4d90837aa-whaeyw;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Typically applies to tools, instruments, moulds, raw materials and items embedded in a product. It implies that the presence of the object in question was a necessary condition for the action.";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fbegin_of_the_begin.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fbegin_of_the_begin.trig
@@ -9,7 +9,7 @@
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-481f29cf02e2453dace170217a45bfcb-ngxx;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Start date";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Start date"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-481f29cf02e2453dace170217a45bfcb-b9qyf;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-481f29cf02e2453dace170217a45bfcb-ltpmz;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fbegin_of_the_end.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fbegin_of_the_end.trig
@@ -15,7 +15,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#dateTime>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/timespan>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-38d913c9c1f046d7b3164761d2fe8420-cauak;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Begin of the end";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Begin of the end"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-38d913c9c1f046d7b3164761d2fe8420-mg5owe;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fbeginning.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fbeginning.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-99e2e8b72e7a472cb7d9d2eec7c9369e-qz83gg;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-99e2e8b72e7a472cb7d9d2eec7c9369e-knmnue;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan beginning";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan beginning"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/timespan>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fcontains_timespan.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fcontains_timespan.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e5dd69a968cd4b239d27a43a94ad47d0-x94p3g;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/timespan>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Contains timespan";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Contains timespan"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e5dd69a968cd4b239d27a43a94ad47d0-q1f9og;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e5dd69a968cd4b239d27a43a94ad47d0-6rkng6;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fduration.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fduration.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/timespan/duration/context> {
   <http://www.researchspace.org/pattern/system/timespan/duration> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Duration";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Duration"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fend.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fend.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-28efbae3061643b7974e0113f6dc5372-lv1rroh;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan end";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan end"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/timespan>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-28efbae3061643b7974e0113f6dc5372-vzc2sm;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fend_of_the_begin.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fend_of_the_begin.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/timespan>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-baf426dedc5a4eff9791d50e3e982f37-u35ifj;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
-    <http://www.w3.org/2000/01/rdf-schema#label> "End of the begin";
+    <http://www.w3.org/2000/01/rdf-schema#label> "End of the begin"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-03-26T15:25:55.649Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fend_of_the_end.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fend_of_the_end.trig
@@ -3,7 +3,7 @@
   
   <http://www.researchspace.org/pattern/system/timespan/end_of_the_end> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "End date";
+    <http://www.w3.org/2000/01/rdf-schema#label> "End date"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/timespan>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Ffalls_within_timespan.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Ffalls_within_timespan.trig
@@ -19,7 +19,7 @@
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-dbca61ba01714810a7b8838e01506343-iktw7t;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-dbca61ba01714810a7b8838e01506343-3hi162;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Falls within timespan";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Falls within timespan"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fis_time-span_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fis_time-span_of.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is timespan of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is timespan of"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-ee8257db3870412b8ac108c9bd852977-f2l2ek;
     <http://www.researchspace.org/resource/system/fields/category> 
     <http://www.researchspace.org/resource/system/category/timespan>,

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fongoing_throughout.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Fongoing_throughout.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/timespan/ongoing_throughout> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan ongoing throughout";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan ongoing throughout"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-7a5db74e64ef4cdda4ee3b88562c8ea9-sbs64u;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/timespan>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Ftime_appellation.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Ftime_appellation.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/timespan>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-d9b6c37cf9f54609ad31547db9ef5dbd-y2q1la;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Date/timespan (text value)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Date/timespan (text value)"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-d9b6c37cf9f54609ad31547db9ef5dbd-ns0o6;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Ftime_primitive_appellationMin1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftimespan%2Ftime_primitive_appellationMin1.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/timespan>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan (text value)";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Timespan (text value)"@en;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8333e397677948cb810d9b651539b202-91ghmi;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftitle%2Fhas_title_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftitle%2Fhas_title_range.trig
@@ -6,7 +6,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ffc96eecca6143118ab5456d0a239366-v6833m;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Title range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Title range"@en;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E35_Title>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-ffc96eecca6143118ab5456d0a239366-z4001d;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransfer_of_custody%2Fcustody_received_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransfer_of_custody%2Fcustody_received_by.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E10_Transfer_of_Custody>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-0444d763ede24c9091e1798fba16c795-mjfi09;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Custody received by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Custody received by"@en;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/transfer_of_custody>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-0444d763ede24c9091e1798fba16c795-ompyip;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransfer_of_custody%2Fcustody_surrendered_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransfer_of_custody%2Fcustody_surrendered_by.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-d908f3415284413d97527d2b52d4b585-qptct;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E10_Transfer_of_Custody>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-d908f3415284413d97527d2b52d4b585-w061vr;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Custody surrendered by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Custody surrendered by"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-d908f3415284413d97527d2b52d4b585-aw836m;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/transfer_of_custody>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransfer_of_custody%2Ftransferred_custody_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransfer_of_custody%2Ftransferred_custody_of.trig
@@ -14,7 +14,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-97c9c8fb8bab42cb9945ac89a7723b3e-xd65b;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/transfer_of_custody>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Transferred custody of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Transferred custody of"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-05T10:55:04.828+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransformation%2Fresulted_in_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransformation%2Fresulted_in_physical_thing.trig
@@ -4,7 +4,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e837c0f88575431db61d233a0eed02ae-zs3xkq;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resulted in thing";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resulted in thing"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransformation%2Ftransformed_physical_thing.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftransformation%2Ftransformed_physical_thing.trig
@@ -4,7 +4,7 @@
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3f03fd8d4e0f4b098b5bf2d28092adfd-zfzjpo;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Transformed thing";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Transformed thing"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3f03fd8d4e0f4b098b5bf2d28092adfd-zosagi;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2FPC137_exemplifies_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2FPC137_exemplifies_range.trig
@@ -21,7 +21,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-c4026d7e8b044d408d43b605ed522770-i90l;
     <http://www.w3.org/2000/01/rdf-schema#comment> "Define the entity that has been declared to be a particularly characteristic example of this type. The taxonomic role renders the specific relationship of this example to the type.";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is exemplified by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is exemplified by"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c4026d7e8b044d408d43b605ed522770-q8utuq;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-24T10:52:09.254+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fbroader.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fbroader.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/type>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-21a90e405e3c4914a4d18be4b8050061-p6jzdj;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Broader type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Broader type"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-21a90e405e3c4914a4d18be4b8050061-bflzb3;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-21a90e405e3c4914a4d18be4b8050061-efh1yp;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fis_exemplified_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fis_exemplified_by.trig
@@ -23,7 +23,7 @@
   
   <http://www.researchspace.org/pattern/system/type/is_exemplified_by> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is exemplified by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is exemplified by"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-aec0de88be1a4e73968f060d0d277f04-keq96t;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fis_type_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fis_type_of.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-2303c488caee4351bc62b4d1192a942d-bj68rt;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-2303c488caee4351bc62b4d1192a942d-2itrnh;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Is type of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Is type of"@en;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-2303c488caee4351bc62b4d1192a942d-r4sozk;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-2303c488caee4351bc62b4d1192a942d-n0o0k;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fnarrower.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fnarrower.trig
@@ -4,7 +4,7 @@
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>,
       <http://www.w3.org/2004/02/skos/core#Concept>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Narrower type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Narrower type"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-24bba96803d24db7bc7be3a65b6afb62-rcf46n;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Frelated_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Frelated_type.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-be0551e499a84b7984320439f47b5d9c-m768nr;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-be0551e499a84b7984320439f47b5d9c-emem1s;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Related type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Related type"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-be0551e499a84b7984320439f47b5d9c-1g7ujf;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-be0551e499a84b7984320439f47b5d9c-30k0g;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Ftypical_parts_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Ftypical_parts_of.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e00fb49d22094fe2a54811a4a21bbcd9-5wa2xt;
     <http://www.w3.org/2000/01/rdf-schema#comment> "It allows types to be organised into hierarchies based on one type describing a typical part of another. For example car motors (type) defines typical parts of cars (type)";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Typical parts of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Typical parts of"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e00fb49d22094fe2a54811a4a21bbcd9-7zesmn;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e00fb49d22094fe2a54811a4a21bbcd9-jnpfic;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Ftypical_wholes_for.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Ftypical_wholes_for.trig
@@ -3,7 +3,7 @@
   <http://www.researchspace.org/pattern/system/type/typical_wholes_for> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Typical wholes for";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Typical wholes for"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ab35d11a7cbc4408b576b6ea2c2b59b0-g4kdyi;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_assigned_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_assigned_by.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E17_Type_Assignment>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e86354188aee49958fd6cec378c07ac3-ru2ryc;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was assigned by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was assigned by"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e86354188aee49958fd6cec378c07ac3-5qyqib;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-23T18:37:53.119+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_created_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_created_by.trig
@@ -17,7 +17,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/type>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was created by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was created by"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-33e471167bd44967ad38d24a33e1de7a-5ozegh;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-33e471167bd44967ad38d24a33e1de7a-q0frav;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_intention_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_intention_of.trig
@@ -31,7 +31,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-1437bbfd0cf44d02901c14a82e8d3a5b-7fz45j;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-1437bbfd0cf44d02901c14a82e8d3a5b-9cygt4;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-1437bbfd0cf44d02901c14a82e8d3a5b-a4lnq;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was intention of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was intention of"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E71_Human-Made_Thing>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-23T18:15:36.848+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_purpose_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_purpose_of.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was purpose of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was purpose of"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-5fdb666854e4416987b6c684b56ef0de-kos5gv;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/type>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_technique_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_technique_of.trig
@@ -12,7 +12,7 @@
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-0f406acf2de54199994c1e7db2041d9b-ahso4p;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-0f406acf2de54199994c1e7db2041d9b-ie487c;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was technique of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was technique of"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-0f406acf2de54199994c1e7db2041d9b-qoeev;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-23T18:24:54.262+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_type_of_object_used_in.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_type_of_object_used_in.trig
@@ -29,7 +29,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-2c966626580242e5a3c4ae3486122dc4-kbsmtr;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was type of object used in";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was type of object used in"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-23T18:27:23.285+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_use_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype%2Fwas_use_of.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/type>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-3e24e360c62d416690f289ab154170d3-brgx6;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was use of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was use of"@en;
     <http://www.w3.org/2000/01/rdf-schema#comment> "It allows the relationship between particular things, both physical and immaterial, and the general methods and techniques of real use to be documented. The use of this field is intended to allow the documentation of usage patterns attested in historical records or through scientific investigation (for instance ceramic residue analysis). It should not be used to document the intended, and thus assumed, use of an object.";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E70_Thing>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3e24e360c62d416690f289ab154170d3-3vqtxn;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype_assignment%2Fassigned.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype_assignment%2Fassigned.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-d378e0ae132f47089365238c2c760203-yugzff;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-d378e0ae132f47089365238c2c760203-2ev7ch;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-d378e0ae132f47089365238c2c760203-yf19mn;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Assigned type"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E17_Type_Assignment>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-d378e0ae132f47089365238c2c760203-eplbxa;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-d378e0ae132f47089365238c2c760203-euiqeb;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype_assignment%2Fclassified.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype_assignment%2Fclassified.trig
@@ -13,7 +13,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E17_Type_Assignment>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-61c271239299445c8fd3e2bf08fdef79-jf49kn;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-61c271239299445c8fd3e2bf08fdef79-v2ceqr;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Type assignment classified";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Type assignment classified"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-05T18:14:13.901+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype_creation%2Fcreated_type.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype_creation%2Fcreated_type.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-c08b62e628a34b31b1f8ed45db3bf521-gg1ldk;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Created type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Created type"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E83_Type_Creation>;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-c08b62e628a34b31b1f8ed45db3bf521-zer9wo;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/type_creation>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype_creation%2Fwas_based_on.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Ftype_creation%2Fwas_based_on.trig
@@ -2,7 +2,7 @@
 <http://www.researchspace.org/pattern/system/type_creation/was_based_on/context> {
   <http://www.researchspace.org/pattern/system/type_creation/was_based_on> a <http://www.researchspace.org/resource/system/fields/Field>,
       <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Based on";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Based on"@en;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-8c0a98d198a24601b37593fa60c3b130-rmaqc;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fused_specific_object%2Fdomain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fused_specific_object%2Fdomain.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-50f3af2a01de4cefae72b3b1b9bc493b-elj1j8;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E7_Activity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific object - domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific object - domain"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-50f3af2a01de4cefae72b3b1b9bc493b-8lx9;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-50f3af2a01de4cefae72b3b1b9bc493b-bsgel;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fused_specific_object%2Fmode_of_use.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fused_specific_object%2Fmode_of_use.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific object - mode of use";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific object - mode of use"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-09ed1e4aa8204605908a53cb077be65e-p2hsmk;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/activity>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-09ed1e4aa8204605908a53cb077be65e-bxwzoi;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fused_specific_object%2Fthing_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fused_specific_object%2Fthing_range.trig
@@ -9,7 +9,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-246415d3eea2447ba943a023acca3972-6lpt1q;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-246415d3eea2447ba943a023acca3972-lkd7c;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific object - thing range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Used specific object - thing range"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E70_Thing>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-246415d3eea2447ba943a023acca3972-jvn5o9;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Femail.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Femail.trig
@@ -7,7 +7,7 @@
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
         <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#string>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Email";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Email"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-f55718ffb37f4aa398abd18d709f4cc3-t6747959;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-f55718ffb37f4aa398abd18d709f4cc3-t6747960;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f55718ffb37f4aa398abd18d709f4cc3-t6747958;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Fhas_current_or_former_member.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Fhas_current_or_former_member.trig
@@ -21,7 +21,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-43f9045d57354f4084797682d1081312-wszjob;
-    <http://www.w3.org/2000/01/rdf-schema#label> "User has current or former member";
+    <http://www.w3.org/2000/01/rdf-schema#label> "User has current or former member"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-43f9045d57354f4084797682d1081312-v2hkl3;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/user>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Fis_current_or_former_member_of.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Fis_current_or_former_member_of.trig
@@ -27,7 +27,7 @@
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E39_Actor>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-d770e104bd074986a4d642a3e52ca976-tixuvj;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/user>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "User is current or former member of";
+    <http://www.w3.org/2000/01/rdf-schema#label> "User is current or former member of"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-04-12T17:21:24.648+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Ftype.trig
@@ -18,7 +18,7 @@
       <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-5dea316dc6524e0ca6ba55bcfcfad9aa-b558l9;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-5dea316dc6524e0ca6ba55bcfcfad9aa-mxdxf4;
-    <http://www.w3.org/2000/01/rdf-schema#label> "User type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "User type"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-5dea316dc6524e0ca6ba55bcfcfad9aa-1wwl9d;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/user>,
       <http://www.researchspace.org/resource/system/category/user_search>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Ftype_min1.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fuser%2Ftype_min1.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "1";
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E21_Person>,
       <http://www.cidoc-crm.org/cidoc-crm/E74_Group>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "User type min1";
+    <http://www.w3.org/2000/01/rdf-schema#label> "User type min1"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-5fc2fae911af4bb9a9c0f5ec9bd309cc-cbamfa;
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/user>,
       <http://www.researchspace.org/resource/system/category/user_search>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvisual_item%2FPC138_represents.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvisual_item%2FPC138_represents.trig
@@ -10,7 +10,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/PC138_represents>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-d1bdb28f54064bdaaafe322f0cf8d46d-gf4w3y;
-    <http://www.w3.org/2000/01/rdf-schema#label> "PC138 represents";
+    <http://www.w3.org/2000/01/rdf-schema#label> "PC138 represents"@en;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E36_Visual_Item>;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-03T14:55:33.677+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvisual_item%2Fshown_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvisual_item%2Fshown_by.trig
@@ -8,7 +8,7 @@
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/visual_item>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-3262a269164f44cd9a4db5ce13e8dcb5-k640m;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
-    <http://www.w3.org/2000/01/rdf-schema#label> "Visual item shown by";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Visual item shown by"@en;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-3262a269164f44cd9a4db5ce13e8dcb5-8b670r;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E36_Visual_Item>;
     <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-3262a269164f44cd9a4db5ce13e8dcb5-zawev;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvisual_item%2Ftype.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvisual_item%2Ftype.trig
@@ -18,7 +18,7 @@
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-2246f140efb94ae4abd353a5e243517b-z8oyqw;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-2246f140efb94ae4abd353a5e243517b-p2lsr4;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E36_Visual_Item>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Visual item type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Visual item type"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2024-05-03T13:50:54.746+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvocabulary%2Frefers_to_resourceConfig.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvocabulary%2Frefers_to_resourceConfig.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-14a22e0f6357483197c9d468e08b14f6-t7d393;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-14a22e0f6357483197c9d468e08b14f6-75nrag;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type"@en;
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
     <http://www.w3.org/ns/prov#generatedAtTime> "2023-11-10T17:24:16.987Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
   

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvocabulary%2Frefers_to_resourceConfig_Min0.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fvocabulary%2Frefers_to_resourceConfig_Min0.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
     <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/authority_document>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-6bd942c327884e8e92b26edcac27da52-bwau79;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resource type"@en;
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E1_CRM_Entity>;
     <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-6bd942c327884e8e92b26edcac27da52-0zsvt9;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6bd942c327884e8e92b26edcac27da52-aak6fa;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fwas_intended_use_of%2Factivity_domain.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fwas_intended_use_of%2Factivity_domain.trig
@@ -11,7 +11,7 @@
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e8df8fd2b72f4d06bae268a72af293ac-q90ykf;
     <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/PC19_was_intended_use_of>;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e8df8fd2b72f4d06bae268a72af293ac-szsj8b;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended use of - domain";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended use of - domain"@en;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e8df8fd2b72f4d06bae268a72af293ac-toputg;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
     <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fwas_intended_use_of%2Fhuman_made_thing_range.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fwas_intended_use_of%2Fhuman_made_thing_range.trig
@@ -9,7 +9,7 @@
   <http://www.researchspace.org/pattern/system/was_intended_use_of/human_made_thing_range>
     a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
       <http://www.w3.org/ns/ldp#Resource>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended use of - human-made thing range";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended use of - human-made thing range"@en;
     <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-5c01bfaaac704d47b3c9f0a6634ca289-jke0ir;
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fwas_intended_use_of%2Fmode_of_use.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fwas_intended_use_of%2Fmode_of_use.trig
@@ -5,7 +5,7 @@
     <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E55_Type>;
     <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-8e5ec9603b6b4d838ef93d8035c94f12-5tk7g;
     <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-8e5ec9603b6b4d838ef93d8035c94f12-i9tylo;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended use of - mode of use";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Was intended use of - mode of use"@en;
     <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
     <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
     <http://www.researchspace.org/resource/system/fields/minOccurs> "0";

--- a/src/main/resources/org/researchspace/apps/system/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fassets%2FLdpKPResources.html
+++ b/src/main/resources/org/researchspace/apps/system/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fassets%2FLdpKPResources.html
@@ -17,9 +17,9 @@
           <mp-selection-toggle selection="resource-selection" tag="{{subject.value}}"></mp-selection-toggle>
           <semantic-context repository='assets'>
             {{#if label}}
-              <semantic-link iri='{{subject.value}}' title='{{label.value}}'>{{label.value}}</semantic-link>
+              <semantic-link iri='{{subject.value}}' title='{{label.value}}' style="text-transform: lowercase;">{{label.value}}</semantic-link>
             {{else}}
-              <semantic-link iri='{{subject.value}}'></semantic-link>
+              <semantic-link iri='{{subject.value}}' style="text-transform: lowercase;"></semantic-link>
             {{/if}}
           </semantic-context>
         </span> 
@@ -45,7 +45,7 @@
         <template id='ontology'>
           <div>
               {{#each bindings}}
-                <div>{{ontologyLabel.value}}</div>
+                <span class="badge badge--secondary">{{ontologyLabel.value}}</span>
               {{/each}}
           </div>
         </template>
@@ -62,7 +62,7 @@
             <div>
               <div style="display: flex; gap:3px; flex-wrap: wrap;">
                 {{#each bindings}}
-                  <mp-label iri='{{type.value}}'></mp-label>
+                <span class="badge badge--secondary"><mp-label iri='{{type.value}}'></mp-label></span>
                 {{/each}}
               </div>
             </div>

--- a/src/main/resources/org/researchspace/apps/system/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2FfieldDefinitionContainer.html
+++ b/src/main/resources/org/researchspace/apps/system/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2FfieldDefinitionContainer.html
@@ -170,7 +170,7 @@
                                                             [[> http://www.researchspace.org/resource/assets/LdpKPResources 
                                                                 container='http://www.researchspace.org/resource/system/fieldDefinitionContainer' 
                                                                 semantic-search=semanticSearch
-                                                                query='SELECT DISTINCT ?subject ?label ?ModificationDate  WHERE { ?subject <http://www.w3.org/ns/prov#generatedAtTime> ?ModificationDate . OPTIONAL { ?subject rdfs:label ?label . FILTER(LANG(?label) = "en")} } ORDER BY ASC(?label) '
+                                                                query='SELECT DISTINCT ?subject ?label ?ModificationDate  WHERE { ?subject <http://www.w3.org/ns/prov#generatedAtTime> ?ModificationDate . OPTIONAL { ?subject rdfs:label ?label . FILTER(LANG(?label) = "en")} } ORDER BY ASC(LCASE(STR(?label))) DESC(?ModificationDate)'
                                                             ]]
                                                         </semantic-search-result>
                                                     </div>

--- a/src/main/resources/org/researchspace/apps/system/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2FfieldDefinitionContainer.html
+++ b/src/main/resources/org/researchspace/apps/system/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2FfieldDefinitionContainer.html
@@ -69,6 +69,7 @@
                             
                             <semantic-context repository='assets'>
                                 <semantic-search optimizer='none'
+                                								limit=3000
                                                 selector-mode='dropdown'
                                                 search-profile='{
                                                             "categories": [


### PR DESCRIPTION
# Why
The Knowledge pattern table in template Platform:fieldDefinitionContainer has the following issues:
- the order of KPs by label declared in the table query doesn't work
- KP filter by keyword doesn't work properly

# What
- All the system KPs were missing the language tag `@en` for their label. This was impacting the query result visualisation and it was inconsistent with KPs from ontologies and new custom KPs that all have a language tag. For this reason `@en` tag has been added to the label of all System KPs.
- LIMIT 3000 has been added to increase n.of results in the table
- css style of KP table has been reviewed