### PR TITLE
System authority documents - fix on edit form KPs

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FAuthorityDocumentSystem.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FAuthorityDocumentSystem.html
@@ -107,7 +107,6 @@
                                               classtype="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
                                               has_type="http://www.researchspace.org/pattern/system/entity/has_all_types"
                                               rdfs_label="http://www.w3.org/2000/01/rdf-schema#label"
-                                              entity_primary_appellation="http://www.researchspace.org/pattern/system/entity/primary_appellation"
                                               vocabulary_refersto_resourceConfig="http://www.researchspace.org/pattern/system/system_vocabulary/refers_to_resourceConfig"
                                               entity_description="http://www.researchspace.org/pattern/system/entity/description"
                                             ]]'
@@ -117,9 +116,6 @@
                           </semantic-form-hidden-input>
                           <semantic-form-hidden-input for="has_type" default-value='http://www.researchspace.org/resource/system/System_Resource'>
                           </semantic-form-hidden-input>   
-                    [[!--      <semantic-form-hidden-input for="entity_primary_appellation" placeholder="Enter authority document name" label="Name"
-                                                      default-value='{{bindings.0.vocabularyLabel.value}}'>
-                      --]]
                           <semantic-form-hidden-input for="rdfs_label" placeholder="Enter authority document name" label="Name"
                                                       default-value='{{bindings.0.vocabularyLabel.value}}'>
                           </semantic-form-hidden-input>   
@@ -414,12 +410,12 @@
                                                   subject='{{vocabulary.value}}'
                                                   post-action="event"
                                                   fields='[[fieldDefinitions
-                                                        entity_primary_appellation="http://www.researchspace.org/pattern/system/entity/primary_appellation"
-                                                        vocabulary_refersto_resourceConfig="http://www.researchspace.org/pattern/system/vocabulary/refers_to_resourceConfig"
+                                                        rdfs_label="http://www.w3.org/2000/01/rdf-schema#label"
+                                                        vocabulary_refersto_resourceConfig="http://www.researchspace.org/pattern/system/system_vocabulary/refers_to_resourceConfig"
                                                         entity_description="http://www.researchspace.org/pattern/system/entity/description"
                                                   ]]'>
                                     
-                                    <semantic-form-text-input for="entity_primary_appellation" placeholder="Enter authority document name" label="Name"></semantic-form-text-input>   
+                                    <semantic-form-text-input for="rdfs_label" placeholder="Enter authority document name" label="Name"></semantic-form-text-input>   
                                     <semantic-form-text-input for="entity_description" placeholder="Enter authority document description" label="Description" multiline='true'></semantic-form-text-input>
                                     
                                     <div style="display: flex; align-items: baseline; justify-content: space-between;">


### PR DESCRIPTION
# Why
The form available to edit System authority documents doesn't display the existing values.

# What
KPs have been changed in the main form, but the edit form wasn't updated with the same KPs. Now this has been fixed.

# Screenshot
System authority documents - edit form
<img width="1531" alt="Screenshot 2025-03-03 at 15 57 01" src="https://github.com/user-attachments/assets/4af50989-9eca-4ebc-b72b-5a4dd7abb338" />
