### PR TITLE
Forms review for subclasses of E18_Physical_Thing

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBiologicalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBiologicalObject.html
@@ -38,6 +38,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
                             
@@ -47,18 +49,27 @@
                             physical_thing_has_section="http://www.researchspace.org/pattern/system/physical_thing/has_section"
                             physical_thing_occupies="http://www.researchspace.org/pattern/system/physical_thing/occupies"
 
-                            physical_object_moved_by="http://www.researchspace.org/pattern/system/physical_object/moved_by"
-                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
-                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
                             persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
+                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
+                            physical_object_moved_by="http://www.researchspace.org/pattern/system/physical_object/moved_by"
                             entity_influenced_activity="http://www.researchspace.org/pattern/system/entity/influenced_activity"
                             entity_motivated_activity="http://www.researchspace.org/pattern/system/entity/motivated_activity"
                             entity_attributed_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/attributed_by_attribute_assignment"
                             entity_assigned_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/assigned_by_attribute_assignment"
                             entity_measurement="http://www.researchspace.org/pattern/system/entity/measurement"
 
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
                             thing_has_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of_range"
@@ -539,6 +550,36 @@
                     </div>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the biological object"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the biological object" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
                                                     placeholder="Select legal rights" 
@@ -596,25 +637,6 @@
 
             <rs-tab event-key="event" title="Events">
 
-                <semantic-form-autocomplete-input   for='physical_object_moved_by' 
-                                                    label="Moved by"
-                                                    placeholder="Select move that moved the biological object" 
-                                                    nested-form-templates='[ 
-                                                        {
-                                                            "label": "Move",
-                                                            "nestedForm": "{{{{raw}}}}
-                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Move\" nested=true editable=true mode=\"new\"}}
-                                                                        {{{{/raw}}}}"
-                                                        }
-                                                    ]'>  
-                </semantic-form-autocomplete-input>
-
-                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
-                                                    label="Modified by" 
-                                                    placeholder="Select modification"
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
-                </semantic-form-autocomplete-input>
-
                 <div class="inline-composite-container">
                     <semantic-form-composite-input  for="thing_used_specific_object_range" 
                                                     label="Used for"
@@ -666,11 +688,18 @@
                     </semantic-form-composite-input>
                 </div>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the biological object had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
                                                     label="Brought into existence by" 
@@ -678,10 +707,106 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
+                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
+                                                    label="Modified by" 
+                                                    placeholder="Select modification"
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the biological object out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the biological object" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the biological object had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='physical_object_moved_by' 
+                                                    label="Moved by"
+                                                    placeholder="Select move that moved the biological object" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Move",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Move\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>  
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
@@ -723,6 +848,18 @@
             </rs-tab>
 
             <rs-tab event-key="thing" title="Things">
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the biological object supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the biological object" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_carries_symbolic_object' 
                                                     label="Carries" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCollection.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCollection.html
@@ -39,6 +39,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
 
@@ -50,19 +52,28 @@
 
                             human-made_thing_was_intended_use_of_range="http://www.researchspace.org/pattern/system/human-made_thing/was_intended_use_of_range"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
                             physical_human-made_thing_produced_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/produced_by"
+                            persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
                             physical_human-made_thing_augmented_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/augmented_by"
                             physical_human-made_thing_diminished_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/diminished_by"
                             physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
-                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
-                            persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
+                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
                             entity_influenced_activity="http://www.researchspace.org/pattern/system/entity/influenced_activity"
                             entity_motivated_activity="http://www.researchspace.org/pattern/system/entity/motivated_activity"
                             entity_attributed_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/attributed_by_attribute_assignment"
                             entity_assigned_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/assigned_by_attribute_assignment"
                             entity_measurement="http://www.researchspace.org/pattern/system/entity/measurement"
 
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
                             thing_has_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of_range"
@@ -549,6 +560,36 @@
                     </div>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the collection"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the collection" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
                                                     placeholder="Select legal rights" 
@@ -708,6 +749,19 @@
                     </semantic-form-composite-input>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_produced_by' 
                                                     label="Produced by" 
                                                     placeholder="Select production"
@@ -719,6 +773,12 @@
                                                                         {{{{/raw}}}}"
                                                         }
                                                     ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
+                                                    label="Brought into existence by" 
+                                                    placeholder="Select event that brought the collection into existence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_augmented_by' 
@@ -753,16 +813,69 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
                 </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the collection had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+               <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
-                                                    label="Brought into existence by" 
-                                                    placeholder="Select event that brought the collection into existence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
@@ -770,6 +883,18 @@
                                                     placeholder="Select event that took the collection out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the collection" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the collection had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
                                                     label="Influenced"
@@ -810,6 +935,18 @@
             </rs-tab>
 
             <rs-tab event-key="thing" title="Things">
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the collection supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the collection" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_carries_symbolic_object' 
                                                     label="Carries" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeFeature.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeFeature.html
@@ -37,6 +37,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
 
@@ -46,13 +48,20 @@
 
                             human-made_thing_was_intended_use_of_range="http://www.researchspace.org/pattern/system/human-made_thing/was_intended_use_of_range"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
                             physical_human-made_thing_produced_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/produced_by"
+                            persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
                             physical_human-made_thing_augmented_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/augmented_by"
                             physical_human-made_thing_diminished_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/diminished_by"
                             physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
-                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
-                            persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
+                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
                             entity_influenced_activity="http://www.researchspace.org/pattern/system/entity/influenced_activity"
                             entity_motivated_activity="http://www.researchspace.org/pattern/system/entity/motivated_activity"
                             entity_attributed_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/attributed_by_attribute_assignment"
@@ -63,6 +72,8 @@
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
                             thing_has_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of_range"
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             entity_depicts_range="http://www.researchspace.org/pattern/system/entity/depicts_range"
                             entity_subject_of="http://www.researchspace.org/pattern/system/entity/subject_of_propositional_object"
                             entity_refers_to_range="http://www.researchspace.org/pattern/system/entity/refers_to_range"
@@ -537,6 +548,36 @@
                     </div>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the human-made feature"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the human-made feature" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
                                                     placeholder="Select legal rights" 
@@ -683,6 +724,19 @@
                     </semantic-form-composite-input>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_produced_by' 
                                                     label="Produced by" 
                                                     placeholder="Select production"
@@ -694,6 +748,12 @@
                                                                         {{{{/raw}}}}"
                                                         }
                                                     ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
+                                                    label="Brought into existence by" 
+                                                    placeholder="Select event that brought the human-made feature into existence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_augmented_by' 
@@ -728,16 +788,69 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
                 </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the human-made feature had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+               <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
-                                                    label="Brought into existence by" 
-                                                    placeholder="Select event that brought the human-made feature into existence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
@@ -745,6 +858,18 @@
                                                     placeholder="Select event that took the human-made feature out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the human-made feature" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the human-made feature had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
                                                     label="Influenced"
@@ -895,6 +1020,18 @@
                     </div>
                     </semantic-form-composite-input>
                 </div>
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the human-made feature supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the human-made feature" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <div class="inline-composite-container">
                     <semantic-form-composite-input  for="entity_depicts_range" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeObject.html
@@ -40,6 +40,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
                             
@@ -51,20 +53,29 @@
 
                             human-made_thing_was_intended_use_of_range="http://www.researchspace.org/pattern/system/human-made_thing/was_intended_use_of_range"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
                             physical_human-made_thing_produced_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/produced_by"
-                            physical_object_moved_by="http://www.researchspace.org/pattern/system/physical_object/moved_by"
+                            persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
                             physical_human-made_thing_augmented_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/augmented_by"
                             physical_human-made_thing_diminished_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/diminished_by"
                             physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
-                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
-                            persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
+                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
+                            physical_object_moved_by="http://www.researchspace.org/pattern/system/physical_object/moved_by"
                             entity_influenced_activity="http://www.researchspace.org/pattern/system/entity/influenced_activity"
                             entity_motivated_activity="http://www.researchspace.org/pattern/system/entity/motivated_activity"
                             entity_attributed_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/attributed_by_attribute_assignment"
                             entity_assigned_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/assigned_by_attribute_assignment"
                             entity_measurement="http://www.researchspace.org/pattern/system/entity/measurement"
 
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
                             thing_has_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of_range"
@@ -611,6 +622,36 @@
                     </div>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the human-made object"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the human-made object" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
                                                     placeholder="Select legal rights" 
@@ -769,6 +810,19 @@
                     </semantic-form-composite-input>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_produced_by' 
                                                     label="Produced by" 
                                                     placeholder="Select production"
@@ -782,17 +836,10 @@
                                                     ]'> 
                 </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input   for='physical_object_moved_by' 
-                                                    label="Moved by"
-                                                    placeholder="Select move that moved the human-made object" 
-                                                    nested-form-templates='[ 
-                                                        {
-                                                            "label": "Move",
-                                                            "nestedForm": "{{{{raw}}}}
-                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Move\" nested=true editable=true mode=\"new\"}}
-                                                                        {{{{/raw}}}}"
-                                                        }
-                                                    ]'>  
+                <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
+                                                    label="Brought into existence by" 
+                                                    placeholder="Select event that brought the human-made object into existence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_augmented_by' 
@@ -827,16 +874,69 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
                 </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the human-made object had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+               <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
-                                                    label="Brought into existence by" 
-                                                    placeholder="Select event that brought the human-made object into existence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
@@ -844,6 +944,31 @@
                                                     placeholder="Select event that took the human-made object out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the human-made object" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='physical_object_moved_by' 
+                                                    label="Moved by"
+                                                    placeholder="Select move that moved the human-made object" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Move",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Move\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>  
+                </semantic-form-autocomplete-input>
+                
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the human-made object had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
                                                     label="Influenced"
@@ -884,6 +1009,18 @@
             </rs-tab>
 
             <rs-tab event-key="thing" title="Things">
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the human-made object supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the human-made object" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_carries_symbolic_object' 
                                                     label="Carries" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalFeature.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalFeature.html
@@ -35,6 +35,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
 
@@ -42,11 +44,18 @@
                             physical_thing_has_section="http://www.researchspace.org/pattern/system/physical_thing/has_section"
                             physical_thing_occupies="http://www.researchspace.org/pattern/system/physical_thing/occupies"
 
-                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
-                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
                             persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
+                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
                             entity_influenced_activity="http://www.researchspace.org/pattern/system/entity/influenced_activity"
                             entity_motivated_activity="http://www.researchspace.org/pattern/system/entity/motivated_activity"
                             entity_attributed_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/attributed_by_attribute_assignment"
@@ -57,6 +66,8 @@
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
                             thing_has_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of_range"
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             entity_depicts_range="http://www.researchspace.org/pattern/system/entity/depicts_range"
                             entity_subject_of="http://www.researchspace.org/pattern/system/entity/subject_of_propositional_object"
                             entity_refers_to_range="http://www.researchspace.org/pattern/system/entity/refers_to_range"
@@ -468,6 +479,36 @@
                     </div>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the physical feature"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the physical feature" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
                                                     placeholder="Select legal rights" 
@@ -512,12 +553,6 @@
             </rs-tab>
 
             <rs-tab event-key="event" title="Events">
-
-                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
-                                                    label="Modified by" 
-                                                    placeholder="Select modification"
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
-                </semantic-form-autocomplete-input>
 
                 <div class="inline-composite-container">
                     <semantic-form-composite-input  for="thing_used_specific_object_range" 
@@ -570,11 +605,18 @@
                     </semantic-form-composite-input>
                 </div>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the physical feature had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
                                                     label="Brought into existence by" 
@@ -582,11 +624,94 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
+                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
+                                                    label="Modified by" 
+                                                    placeholder="Select modification"
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the physical feature out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the physical feature" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the physical feature had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
                                                     label="Influenced"
@@ -737,6 +862,18 @@
                     </div>
                     </semantic-form-composite-input>
                 </div>
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the physical feature supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the physical feature" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <div class="inline-composite-container">
                     <semantic-form-composite-input  for="entity_depicts_range" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalHumanMadeThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalHumanMadeThing.html
@@ -37,6 +37,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
 
@@ -46,19 +48,28 @@
 
                             human-made_thing_was_intended_use_of_range="http://www.researchspace.org/pattern/system/human-made_thing/was_intended_use_of_range"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
                             physical_human-made_thing_produced_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/produced_by"
+                            persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
                             physical_human-made_thing_augmented_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/augmented_by"
                             physical_human-made_thing_diminished_by="http://www.researchspace.org/pattern/system/physical_human-made_thing/diminished_by"
                             physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
-                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
-                            persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
+                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
                             entity_influenced_activity="http://www.researchspace.org/pattern/system/entity/influenced_activity"
                             entity_motivated_activity="http://www.researchspace.org/pattern/system/entity/motivated_activity"
                             entity_attributed_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/attributed_by_attribute_assignment"
                             entity_assigned_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/assigned_by_attribute_assignment"
                             entity_measurement="http://www.researchspace.org/pattern/system/entity/measurement"
 
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
                             thing_has_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of_range"
@@ -537,6 +548,36 @@
                     </div>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the physical human-made thing"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the physical human-made thing" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
                                                     placeholder="Select legal rights" 
@@ -683,6 +724,19 @@
                     </semantic-form-composite-input>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_produced_by' 
                                                     label="Produced by" 
                                                     placeholder="Select production"
@@ -694,6 +748,12 @@
                                                                         {{{{/raw}}}}"
                                                         }
                                                     ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
+                                                    label="Brought into existence by" 
+                                                    placeholder="Select event that brought the physical human-made thing into existence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_augmented_by' 
@@ -728,16 +788,69 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
                 </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the physical human-made thing had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+               <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
-                                                    label="Brought into existence by" 
-                                                    placeholder="Select event that brought the physical human-made thing into existence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
@@ -745,6 +858,18 @@
                                                     placeholder="Select event that took the physical human-made thing out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the physical human-made thing" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the physical human-made thing had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
                                                     label="Influenced"
@@ -785,6 +910,18 @@
             </rs-tab>
 
             <rs-tab event-key="thing" title="Things">
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the physical human-made thing supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the physical human-made thing" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_carries_symbolic_object' 
                                                     label="Carries" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalObject.html
@@ -38,6 +38,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
                             
@@ -47,18 +49,27 @@
                             physical_thing_has_section="http://www.researchspace.org/pattern/system/physical_thing/has_section"
                             physical_thing_occupies="http://www.researchspace.org/pattern/system/physical_thing/occupies"
 
-                            physical_object_moved_by="http://www.researchspace.org/pattern/system/physical_object/moved_by"
-                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
-                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
                             persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
+                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
+                            physical_object_moved_by="http://www.researchspace.org/pattern/system/physical_object/moved_by"
                             entity_influenced_activity="http://www.researchspace.org/pattern/system/entity/influenced_activity"
                             entity_motivated_activity="http://www.researchspace.org/pattern/system/entity/motivated_activity"
                             entity_attributed_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/attributed_by_attribute_assignment"
                             entity_assigned_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/assigned_by_attribute_assignment"
                             entity_measurement="http://www.researchspace.org/pattern/system/entity/measurement"
 
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
                             thing_has_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of_range"
@@ -538,6 +549,36 @@
                         </div>
                     </div>
                 </div>
+    
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the physical object"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the physical object" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
@@ -596,25 +637,6 @@
 
             <rs-tab event-key="event" title="Events">
 
-                <semantic-form-autocomplete-input   for='physical_object_moved_by' 
-                                                    label="Moved by"
-                                                    placeholder="Select move that moved the physical object" 
-                                                    nested-form-templates='[ 
-                                                        {
-                                                            "label": "Move",
-                                                            "nestedForm": "{{{{raw}}}}
-                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Move\" nested=true editable=true mode=\"new\"}}
-                                                                        {{{{/raw}}}}"
-                                                        }
-                                                    ]'>  
-                </semantic-form-autocomplete-input>
-
-                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
-                                                    label="Modified by" 
-                                                    placeholder="Select modification"
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
-                </semantic-form-autocomplete-input>
-
                 <div class="inline-composite-container">
                     <semantic-form-composite-input  for="thing_used_specific_object_range" 
                                                     label="Used for"
@@ -666,11 +688,18 @@
                     </semantic-form-composite-input>
                 </div>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the physical object had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
                                                     label="Brought into existence by" 
@@ -678,10 +707,106 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
+                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
+                                                    label="Modified by" 
+                                                    placeholder="Select modification"
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the physical object out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the physical object" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the physical object had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='physical_object_moved_by' 
+                                                    label="Moved by"
+                                                    placeholder="Select move that moved the physical object" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Move",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Move\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>  
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
@@ -723,6 +848,18 @@
             </rs-tab>
 
             <rs-tab event-key="thing" title="Things">
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the physical object supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the physical object" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_carries_symbolic_object' 
                                                     label="Carries" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalThing.html
@@ -33,6 +33,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
 
@@ -40,17 +42,26 @@
                             physical_thing_has_section="http://www.researchspace.org/pattern/system/physical_thing/has_section"
                             physical_thing_occupies="http://www.researchspace.org/pattern/system/physical_thing/occupies"
 
-                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
-                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
                             persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
+                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
                             entity_influenced_activity="http://www.researchspace.org/pattern/system/entity/influenced_activity"
                             entity_motivated_activity="http://www.researchspace.org/pattern/system/entity/motivated_activity"
                             entity_attributed_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/attributed_by_attribute_assignment"
                             entity_assigned_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/assigned_by_attribute_assignment"
                             entity_measurement="http://www.researchspace.org/pattern/system/entity/measurement"
 
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
                             thing_has_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of_range"
@@ -324,6 +335,36 @@
                     </div>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the physical thing"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the physical thing" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
                                                     placeholder="Select legal rights" 
@@ -369,12 +410,6 @@
 
             <rs-tab event-key="event" title="Events">
 
-                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
-                                                    label="Modified by" 
-                                                    placeholder="Select modification"
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
-                </semantic-form-autocomplete-input>
-
                 <div class="inline-composite-container">
                     <semantic-form-composite-input  for="thing_used_specific_object_range" 
                                                     label="Used for"
@@ -389,48 +424,55 @@
                         <semantic-form-hidden-input for="classtype" default-value='http://www.cidoc-crm.org/cidoc-crm/PC16_used_specific_object'> </semantic-form-hidden-input>
                         
                         <div class="form-inline-inputs">
-                        <div style="flex: 1;">
-                            <semantic-form-autocomplete-input for='used_specific_object_activity_domain' 
-                                                            label="Used for" 
-                                                            render-header="false"
-                                                            placeholder="Select activity in which the use of the physical thing was essential to the performance or outcome" 
-                                                            nested-form-templates='[[> Platform:NestedFormTemplates_activities]]'> 
-                            </semantic-form-autocomplete-input> 
-                        </div>
-                        <div style="flex: 1;">
-                            <semantic-form-tree-picker-input  for="mode_of_use" 
-                                                            label="Mode of use" 
-                                                            render-header="false"
-                                                            placeholder="Select mode of use"
-                                                            close-dropdown-on-selection='true'
-                                                            tree-patterns='{"scheme": "<http://www.researchspace.org/resource/vocab/mode_of_use>", 
-                                                                            "schemePattern": "?item <http://www.cidoc-crm.org/cidoc-crm/P71i_is_listed_in> <http://www.researchspace.org/resource/vocab/mode_of_use>",
-                                                                            "relationPattern": "?item crm:P127_has_broader_term ?parent"}'
-        
-                                                            scheme-page-button-config='{"iri": "http://www.researchspace.org/resource/ThinkingFrames",
-                                                                                        "view": "authority-list",
-                                                                                        "scheme": "http://www.researchspace.org/resource/vocab/mode_of_use",
-                                                                                        "tooltip": "Open list of modes of use"
-                                                                                        }'
-                                                            
-                                                            nested-form-template='{{{{raw}}}}{{> forms:Type nested=true editable=true mode="new"
-                                                                                                    scheme="http://www.researchspace.org/resource/vocab/mode_of_use"
-                                                                                                    entityType="mode of use" }}{{{{/raw}}}}'
-        
-                                                            query-item-label='SELECT ?label WHERE {
-                                                                                ?item skos:prefLabel ?label .
-                                                                            }'>
-                            </semantic-form-tree-picker-input>
-                        </div>
+                            <div style="flex: 1;">
+                                <semantic-form-autocomplete-input for='used_specific_object_activity_domain' 
+                                                                label="Used for" 
+                                                                render-header="false"
+                                                                placeholder="Select activity in which the use of the physical thing was essential to the performance or outcome" 
+                                                                nested-form-templates='[[> Platform:NestedFormTemplates_activities]]'> 
+                                </semantic-form-autocomplete-input> 
+                            </div>
+                            <div style="flex: 1;">
+                                <semantic-form-tree-picker-input  for="mode_of_use" 
+                                                                label="Mode of use" 
+                                                                render-header="false"
+                                                                placeholder="Select mode of use"
+                                                                close-dropdown-on-selection='true'
+                                                                tree-patterns='{"scheme": "<http://www.researchspace.org/resource/vocab/mode_of_use>", 
+                                                                                "schemePattern": "?item <http://www.cidoc-crm.org/cidoc-crm/P71i_is_listed_in> <http://www.researchspace.org/resource/vocab/mode_of_use>",
+                                                                                "relationPattern": "?item crm:P127_has_broader_term ?parent"}'
+            
+                                                                scheme-page-button-config='{"iri": "http://www.researchspace.org/resource/ThinkingFrames",
+                                                                                            "view": "authority-list",
+                                                                                            "scheme": "http://www.researchspace.org/resource/vocab/mode_of_use",
+                                                                                            "tooltip": "Open list of modes of use"
+                                                                                            }'
+                                                                
+                                                                nested-form-template='{{{{raw}}}}{{> forms:Type nested=true editable=true mode="new"
+                                                                                                        scheme="http://www.researchspace.org/resource/vocab/mode_of_use"
+                                                                                                        entityType="mode of use" }}{{{{/raw}}}}'
+            
+                                                                query-item-label='SELECT ?label WHERE {
+                                                                                    ?item skos:prefLabel ?label .
+                                                                                }'>
+                                </semantic-form-tree-picker-input>
+                            </div>
                         </div>
                     </semantic-form-composite-input>
                 </div>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the physical thing had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
                                                     label="Brought into existence by" 
@@ -438,11 +480,94 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
+                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
+                                                    label="Modified by" 
+                                                    placeholder="Select modification"
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the physical thing out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the physical thing" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the physical thing had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
                                                     label="Influenced"
@@ -483,6 +608,18 @@
             </rs-tab>
 
             <rs-tab event-key="thing" title="Things">
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the physical thing supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the physical thing" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_carries_symbolic_object' 
                                                     label="Carries" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSeries.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSeries.html
@@ -39,6 +39,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
                             
@@ -48,18 +50,27 @@
                             physical_thing_has_section="http://www.researchspace.org/pattern/system/physical_thing/has_section"
                             physical_thing_occupies="http://www.researchspace.org/pattern/system/physical_thing/occupies"
 
-                            physical_object_moved_by="http://www.researchspace.org/pattern/system/physical_object/moved_by"
-                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
-                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
                             persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
+                            persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
+                            physical_object_moved_by="http://www.researchspace.org/pattern/system/physical_object/moved_by"
                             entity_influenced_activity="http://www.researchspace.org/pattern/system/entity/influenced_activity"
                             entity_motivated_activity="http://www.researchspace.org/pattern/system/entity/motivated_activity"
                             entity_attributed_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/attributed_by_attribute_assignment"
                             entity_assigned_by_attribute_assignment="http://www.researchspace.org/pattern/system/entity/assigned_by_attribute_assignment"
                             entity_measurement="http://www.researchspace.org/pattern/system/entity/measurement"
 
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
                             thing_has_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of_range"
@@ -542,6 +553,36 @@
                     </div>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the series"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the series" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
                                                     placeholder="Select legal rights" 
@@ -599,25 +640,6 @@
 
             <rs-tab event-key="event" title="Events">
 
-                <semantic-form-autocomplete-input   for='physical_object_moved_by' 
-                                                    label="Moved by"
-                                                    placeholder="Select move that moved the series" 
-                                                    nested-form-templates='[ 
-                                                        {
-                                                            "label": "Move",
-                                                            "nestedForm": "{{{{raw}}}}
-                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Move\" nested=true editable=true mode=\"new\"}}
-                                                                        {{{{/raw}}}}"
-                                                        }
-                                                    ]'>  
-                </semantic-form-autocomplete-input>
-
-                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
-                                                    label="Modified by" 
-                                                    placeholder="Select modification"
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
-                </semantic-form-autocomplete-input>
-
                 <div class="inline-composite-container">
                     <semantic-form-composite-input  for="thing_used_specific_object_range" 
                                                     label="Used for"
@@ -669,11 +691,18 @@
                     </semantic-form-composite-input>
                 </div>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the series had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
                                                     label="Brought into existence by" 
@@ -681,10 +710,107 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
+                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
+                                                    label="Modified by" 
+                                                    placeholder="Select modification"
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the series out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the series" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the series had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='physical_object_moved_by' 
+                                                    label="Moved by"
+                                                    placeholder="Select move that moved the series" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Move",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Move\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>  
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
@@ -726,6 +852,18 @@
             </rs-tab>
 
             <rs-tab event-key="thing" title="Things">
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the series supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the series" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_carries_symbolic_object' 
                                                     label="Carries" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSite.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSite.html
@@ -53,6 +53,8 @@
                             physical_thing_former_owner="http://www.researchspace.org/pattern/system/physical_thing/former_owner"
                             physical_thing_current_keeper="http://www.researchspace.org/pattern/system/physical_thing/current_keeper"
                             physical_thing_former_keeper="http://www.researchspace.org/pattern/system/physical_thing/former_keeper"
+                            physical_thing_changed_ownership_through="http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through"
+                            physical_thing_custody_transferred_through="http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through"
                             legal_object_subject_to_right="http://www.researchspace.org/pattern/system/legal_object/subject_to_right"
                             legal_object_right_held_by_actor="http://www.researchspace.org/pattern/system/legal_object/right_held_by"
 
@@ -60,8 +62,17 @@
                             physical_thing_has_section="http://www.researchspace.org/pattern/system/physical_thing/has_section"
                             physical_thing_occupies="http://www.researchspace.org/pattern/system/physical_thing/occupies"
 
-                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
                             thing_used_specific_object_range="http://www.researchspace.org/pattern/system/thing/used_specific_object_range"
+                            physical_thing_assessed_by="http://www.researchspace.org/pattern/system/physical_thing/assessed_by"
+                            persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
+                            physical_thing_modified_by="http://www.researchspace.org/pattern/system/physical_thing/modified_by"
+                            physical_thing_transformed_by="http://www.researchspace.org/pattern/system/physical_thing/transformed_by"
+                            physical_thing_resulted_from="http://www.researchspace.org/pattern/system/physical_thing/resulted_from"
+                            physical_thing_added_by="http://www.researchspace.org/pattern/system/physical_thing/added_by"
+                            physical_thing_removed_by="http://www.researchspace.org/pattern/system/physical_thing/removed_by"
+                            physical_thing_destroyed_by="http://www.researchspace.org/pattern/system/physical_thing/destroyed_by"
+                            persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
+                            physical_thing_witnessed_period="http://www.researchspace.org/pattern/system/physical_thing/witnessed_period"
                             persistent_item_present_at="http://www.researchspace.org/pattern/system/persistent_item/present_at"
                             persistent_item_brought_into_existence_by="http://www.researchspace.org/pattern/system/persistent_item/brought_into_existence_by"
                             persistent_item_taken_out_of_existence_by="http://www.researchspace.org/pattern/system/persistent_item/taken_out_of_existence_by"
@@ -75,6 +86,8 @@
                             place_origin_of_move="http://www.researchspace.org/pattern/system/place/origin_of_move"
                             place_destination_of_move="http://www.researchspace.org/pattern/system/place/destination_of_move"
 
+                            physical_thing_holds_or_supports="http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports"
+                            physical_thing_held_or_supported_by="http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by"
                             physical_feature_is_found_on="http://www.researchspace.org/pattern/system/physical_feature/is_found_on"
                             physical_thing_carries_symbolic_object="http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object"
                             thing_shows_features_of_thing="http://www.researchspace.org/pattern/system/thing/PC130_shows_features_of"
@@ -697,6 +710,36 @@
                     </div>
                 </div>
 
+                <semantic-form-autocomplete-input   for='physical_thing_changed_ownership_through' 
+                                                    label="Changed ownership through" 
+                                                    placeholder="Select acquisition that changed ownership of the site"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Acquisition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Acquisition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        },
+                                                        {
+                                                        "label": "Purchase",
+                                                        "nestedForm": "{{{{raw}}}}{{> \"http://www.researchspace.org/resource/system/forms/Purchase\" nested=true editable=true mode=\"new\" }}{{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_custody_transferred_through' 
+                                                    label="Custody transferred through" 
+                                                    placeholder="Select transfer of custody of the site" 
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transfer of custody",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/TransferOfCustody\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'>
+                 </semantic-form-autocomplete-input>
+
                 <semantic-form-autocomplete-input   for='legal_object_subject_to_right' 
                                                     label="Legal rights"
                                                     placeholder="Select legal rights" 
@@ -741,12 +784,6 @@
             </rs-tab>
 
             <rs-tab event-key="event" title="Events">
-
-                <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
-                                                    label="Modified by" 
-                                                    placeholder="Select modification"
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
-                </semantic-form-autocomplete-input>
 
                 <div class="inline-composite-container">
                     <semantic-form-composite-input  for="thing_used_specific_object_range" 
@@ -799,11 +836,18 @@
                     </semantic-form-composite-input>
                 </div>
 
-                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
-                                                    label="Present at" 
-                                                    placeholder="Select event in which the site had an active or passive presence" 
-                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
-                </semantic-form-autocomplete-input> 
+                <semantic-form-autocomplete-input   for='physical_thing_assessed_by' 
+                                                    label="Assessed by" 
+                                                    placeholder="Select condition assessment"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                            "label": "Condition assessment",
+                                                            "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/ConditionAssessment\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='persistent_item_brought_into_existence_by' 
                                                     label="Brought into existence by" 
@@ -811,11 +855,95 @@
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_beginningOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
+               <semantic-form-autocomplete-input   for='physical_thing_modified_by' 
+                                                    label="Modified by" 
+                                                    placeholder="Select modification"
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_modifications]]'>
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_transformed_by' 
+                                                    label="Transformed by" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_resulted_from' 
+                                                    label="Resulted from" 
+                                                    placeholder="Select transformation"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Transformation",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Transformation\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_added_by' 
+                                                    label="Added by" 
+                                                    placeholder="Select part addition"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part addition",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartAddition\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_removed_by' 
+                                                    label="Removed by" 
+                                                    placeholder="Select part removal"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Part removal",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/PartRemoval\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_destroyed_by' 
+                                                    label="Destroyed by" 
+                                                    placeholder="Select destruction"
+                                                    nested-form-templates='[ 
+                                                        {
+                                                        "label": "Destruction",
+                                                        "nestedForm": "{{{{raw}}}}
+                                                                            {{> \"http://www.researchspace.org/resource/system/forms/Destruction\" nested=true editable=true mode=\"new\"}}
+                                                                        {{{{/raw}}}}"
+                                                        }
+                                                    ]'> 
+                </semantic-form-autocomplete-input>
+
+
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the site out of existence" 
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_witnessed_period' 
+                                                    label="Witnessed" 
+                                                    placeholder="Select period/event/activity that took place on or within the site" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'> 
+                </semantic-form-autocomplete-input> 
+
+                <semantic-form-autocomplete-input   for='persistent_item_present_at' 
+                                                    label="Present at" 
+                                                    placeholder="Select event in which the site had an active or passive presence" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_events]]'>  
+                </semantic-form-autocomplete-input> 
 
                 <semantic-form-autocomplete-input   for='entity_influenced_activity' 
                                                     label="Influenced"
@@ -888,6 +1016,18 @@
             </rs-tab>
 
             <rs-tab event-key="thing" title="Things">
+
+                <semantic-form-autocomplete-input   for='physical_thing_holds_or_supports' 
+                                                    label="Holds or supports"
+                                                    placeholder="Select what the site supports or contains" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
+
+                <semantic-form-autocomplete-input   for='physical_thing_held_or_supported_by' 
+                                                    label="Held or supported by"
+                                                    placeholder="Select what supports or contains the site" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_physicalThings]]'> 
+                </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_feature_is_found_on' 
                                                     label="Is found on" 

--- a/src/main/resources/org/researchspace/apps/default/ldp/configurations/http%3A%2F%2Fwww.researchspace.org%2Fpatterns%2Fsystem.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/configurations/http%3A%2F%2Fwww.researchspace.org%2Fpatterns%2Fsystem.trig
@@ -362,7 +362,6 @@
     <http://www.researchspace.org/pattern/system/physical_thing/composed_of_physical_thing> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/physical_thing/material> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/physical_thing/has_condition> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
-
     <http://www.researchspace.org/pattern/system/physical_thing/former_owner> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/physical_thing/current_owner> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/physical_thing/former_keeper> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
@@ -372,6 +371,17 @@
     <http://www.researchspace.org/pattern/system/physical_thing/occupies> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/physical_thing/carries_symbolic_object> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/physical_thing/modified_by> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/assessed_by> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/added_by> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/removed_by> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/destroyed_by> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/transformed_by> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/resulted_from> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/witnessed_period> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
 
     <http://www.researchspace.org/pattern/system/physical_human-made_thing/depicts> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/physical_human-made_thing/PC62_depicts> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fadded_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fadded_by.trig
@@ -1,0 +1,79 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/added_by/context> {
+  <http://www.researchspace.org/pattern/system/physical_thing/added_by> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-d5657537a0e24dd08935aecb022d4ade-delvtq;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Added by";
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-d5657537a0e24dd08935aecb022d4ade-6atj3;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-d5657537a0e24dd08935aecb022d4ade-vggzl;
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-d5657537a0e24dd08935aecb022d4ade-rbx5w;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-d5657537a0e24dd08935aecb022d4ade-6ii5w;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E79_Part_Addition>;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T20:01:49.718+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-d5657537a0e24dd08935aecb022d4ade-6ii5w a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P111i_was_added_by $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E79_Part_Addition .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-d5657537a0e24dd08935aecb022d4ade-6atj3 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E79_Part_Addition .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  _:genid-d5657537a0e24dd08935aecb022d4ade-rbx5w a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E79_Part_Addition .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  _:genid-d5657537a0e24dd08935aecb022d4ade-vggzl a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P111i_was_added_by $value . 
+  $value crm:P111_added $subject .
+} WHERE {}""" .
+  
+  _:genid-d5657537a0e24dd08935aecb022d4ade-delvtq a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P111i_was_added_by $value . 
+  $value crm:P111_added $subject .
+} WHERE {
+  $subject crm:P111i_was_added_by $value . 
+  $value crm:P111_added $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E79_Part_Addition .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/added_by> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fassessed_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fassessed_by.trig
@@ -1,0 +1,79 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/assessed_by/context> {
+  <http://www.researchspace.org/pattern/system/physical_thing/assessed_by> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-e75e22651e8d4143a4de3c65927af33c-m5fmgw;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-e75e22651e8d4143a4de3c65927af33c-vxxeo4;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Assessed by";
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-e75e22651e8d4143a4de3c65927af33c-2ct4m3;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-e75e22651e8d4143a4de3c65927af33c-ceyuqm;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-e75e22651e8d4143a4de3c65927af33c-cvkj6k;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E14_Condition_Assessment>;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T19:49:51.813+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-e75e22651e8d4143a4de3c65927af33c-m5fmgw a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E14_Condition_Assessment .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  _:genid-e75e22651e8d4143a4de3c65927af33c-ceyuqm a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P34i_was_assessed_by $value . 
+  $value crm:P34_concerned $subject .
+} WHERE {
+  $subject crm:P34i_was_assessed_by $value . 
+  $value crm:P34_concerned $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E14_Condition_Assessment .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-e75e22651e8d4143a4de3c65927af33c-cvkj6k a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P34i_was_assessed_by $value . 
+  $value crm:P34_concerned $subject .
+} WHERE {}""" .
+  
+  _:genid-e75e22651e8d4143a4de3c65927af33c-2ct4m3 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E14_Condition_Assessment .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  _:genid-e75e22651e8d4143a4de3c65927af33c-vxxeo4 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P34i_was_assessed_by $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E14_Condition_Assessment .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/assessed_by> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fchanged_ownership_through.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fchanged_ownership_through.trig
@@ -1,0 +1,80 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through/context> {
+  _:genid-f9312dd4bcb445e89e2a32a3b651a975-v54z3s a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P24i_changed_ownership_through $value . 
+  $value crm:P24_transferred_title_of $subject .
+} WHERE {}""" .
+  
+  <http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through>
+    a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
+      <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-f9312dd4bcb445e89e2a32a3b651a975-vv1rtm;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E8_Acquisition>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Changed ownership through";
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-f9312dd4bcb445e89e2a32a3b651a975-fqnpef;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-f9312dd4bcb445e89e2a32a3b651a975-x1b5wa;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-f9312dd4bcb445e89e2a32a3b651a975-v54z3s;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-f9312dd4bcb445e89e2a32a3b651a975-8rz5h;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T19:54:11.366+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-f9312dd4bcb445e89e2a32a3b651a975-fqnpef a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E8_Acquisition .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  _:genid-f9312dd4bcb445e89e2a32a3b651a975-x1b5wa a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P24i_changed_ownership_through $value . 
+  $value crm:P24_transferred_title_of $subject .
+} WHERE {
+  $subject crm:P24i_changed_ownership_through $value . 
+  $value crm:P24_transferred_title_of $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E8_Acquisition .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-f9312dd4bcb445e89e2a32a3b651a975-8rz5h a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P24i_changed_ownership_through $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E8_Acquisition .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-f9312dd4bcb445e89e2a32a3b651a975-vv1rtm a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E8_Acquisition .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/changed_ownership_through> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcustody_transferred_through.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fcustody_transferred_through.trig
@@ -1,0 +1,80 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through/context> {
+  <http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through>
+    a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
+      <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Custody transferred through";
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-ad6fb9455d2442f3bc9142905e5da638-k46o3m;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E10_Transfer_of_Custody>;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-ad6fb9455d2442f3bc9142905e5da638-mggps;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ad6fb9455d2442f3bc9142905e5da638-swvl1c;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-ad6fb9455d2442f3bc9142905e5da638-1ubxxm;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-ad6fb9455d2442f3bc9142905e5da638-4mhu8;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T19:56:24.593+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-ad6fb9455d2442f3bc9142905e5da638-swvl1c a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P30i_custody_transferred_through $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E10_Transfer_of_Custody .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-ad6fb9455d2442f3bc9142905e5da638-4mhu8 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P30i_custody_transferred_through $value . 
+  $value crm:P30_transferred_custody_of $subject .
+} WHERE {
+  $subject crm:P30i_custody_transferred_through $value . 
+  $value crm:P30_transferred_custody_of $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E10_Transfer_of_Custody .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-ad6fb9455d2442f3bc9142905e5da638-k46o3m a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E10_Transfer_of_Custody .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  _:genid-ad6fb9455d2442f3bc9142905e5da638-mggps a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E10_Transfer_of_Custody .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  _:genid-ad6fb9455d2442f3bc9142905e5da638-1ubxxm a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P30i_custody_transferred_through $value . 
+  $value crm:P30_transferred_custody_of $subject .
+} WHERE {}""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/custody_transferred_through> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fdestroyed_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fdestroyed_by.trig
@@ -1,0 +1,79 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/destroyed_by/context> {
+  <http://www.researchspace.org/pattern/system/physical_thing/destroyed_by> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Destroyed by";
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-6f4976f2864f45ef833fc98960167621-0n9nxm;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E6_Destruction>;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-6f4976f2864f45ef833fc98960167621-4s9bin;
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-6f4976f2864f45ef833fc98960167621-3x7w4a;
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-6f4976f2864f45ef833fc98960167621-w5naql;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-6f4976f2864f45ef833fc98960167621-qxn45j;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T20:04:25.522+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-6f4976f2864f45ef833fc98960167621-w5naql a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E6_Destruction .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  _:genid-6f4976f2864f45ef833fc98960167621-qxn45j a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P13i_was_destroyed_by $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E6_Destruction .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-6f4976f2864f45ef833fc98960167621-4s9bin a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P13i_was_destroyed_by $value . 
+  $value crm:P13_destroyed $subject .
+} WHERE {}""" .
+  
+  _:genid-6f4976f2864f45ef833fc98960167621-3x7w4a a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E6_Destruction .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  _:genid-6f4976f2864f45ef833fc98960167621-0n9nxm a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P13i_was_destroyed_by $value . 
+  $value crm:P13_destroyed $subject .
+} WHERE {
+  $subject crm:P13i_was_destroyed_by $value . 
+  $value crm:P13_destroyed $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E6_Destruction .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/destroyed_by> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fheld_or_supported_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fheld_or_supported_by.trig
@@ -1,0 +1,80 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by/context> {
+  _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-2q6u08 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E18_Physical_Thing .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  <http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by>
+    a <http://www.researchspace.org/resource/system/fields/Field>, <http://www.w3.org/ns/prov#Entity>,
+      <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-w180dk;
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Held or supported by";
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-78d4xg;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-2q6u08;
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-vwiajx;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-alxlaa;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T20:22:59.890+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-78d4xg a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P198i_is_held_or_supported_by $value . 
+  $value crm:P198_holds_or_supports $subject .
+} WHERE {
+  $subject crm:P198i_is_held_or_supported_by $value . 
+  $value crm:P198_holds_or_supports $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E18_Physical_Thing .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-vwiajx a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E18_Physical_Thing .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-alxlaa a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P198i_is_held_or_supported_by $value . 
+  $value crm:P198_holds_or_supports $subject .
+} WHERE {}""" .
+  
+  _:genid-092d3d1d31d14713ae6da4dc3ce4fdfa-w180dk a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P198i_is_held_or_supported_by $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E18_Physical_Thing .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/held_or_supported_by> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fholds_or_supports.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fholds_or_supports.trig
@@ -1,0 +1,80 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports/context> {
+  _:genid-49face5f10cd4b74b7f9f69c66aeacf4-zdo04v a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P198_holds_or_supports $value . 
+  $value crm:P198i_is_held_or_supported_by $subject .
+} WHERE {
+  $subject crm:P198_holds_or_supports $value . 
+  $value crm:P198i_is_held_or_supported_by $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E18_Physical_Thing .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  <http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "This property relates one instance of Physical Thing which acts as a container or support to another Physical Thing. For example if the Physical Thing function as a container or support including shelves, folders or boxes. These containers or supports provide a stable surface which is intended for other physical objects to be placed upon for storage, display, transport or other similar functions.";
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-49face5f10cd4b74b7f9f69c66aeacf4-wb8h1o;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Holds or supports";
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-49face5f10cd4b74b7f9f69c66aeacf4-ugcgtr;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-49face5f10cd4b74b7f9f69c66aeacf4-0lagpr;
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-49face5f10cd4b74b7f9f69c66aeacf4-vkhsa;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-49face5f10cd4b74b7f9f69c66aeacf4-zdo04v;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T20:20:40.939+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-49face5f10cd4b74b7f9f69c66aeacf4-0lagpr a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P198_holds_or_supports $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E18_Physical_Thing .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-49face5f10cd4b74b7f9f69c66aeacf4-wb8h1o a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P198_holds_or_supports $value . 
+  $value crm:P198i_is_held_or_supported_by $subject .
+} WHERE {}""" .
+  
+  _:genid-49face5f10cd4b74b7f9f69c66aeacf4-vkhsa a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E18_Physical_Thing .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  _:genid-49face5f10cd4b74b7f9f69c66aeacf4-ugcgtr a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E18_Physical_Thing .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/holds_or_supports> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fremoved_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fremoved_by.trig
@@ -1,0 +1,79 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/removed_by/context> {
+  <http://www.researchspace.org/pattern/system/physical_thing/removed_by> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-a0228b21d47846f6ae758bf41035f8a2-pl8fud;
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-a0228b21d47846f6ae758bf41035f8a2-gem23;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Removed by";
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-a0228b21d47846f6ae758bf41035f8a2-uhl6n;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-a0228b21d47846f6ae758bf41035f8a2-q1etbf;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E80_Part_Removal>;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-a0228b21d47846f6ae758bf41035f8a2-qvoapr;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T20:03:08.706+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-a0228b21d47846f6ae758bf41035f8a2-qvoapr a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P113i_was_removed_by $value . 
+  $value crm:P113_removed $subject .
+} WHERE {
+  $subject crm:P113i_was_removed_by $value . 
+  $value crm:P113_removed $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E80_Part_Removal .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-a0228b21d47846f6ae758bf41035f8a2-uhl6n a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E80_Part_Removal .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  _:genid-a0228b21d47846f6ae758bf41035f8a2-gem23 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P113i_was_removed_by $value . 
+  $value crm:P113_removed $subject .
+} WHERE {}""" .
+  
+  _:genid-a0228b21d47846f6ae758bf41035f8a2-pl8fud a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P113i_was_removed_by $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E80_Part_Removal .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-a0228b21d47846f6ae758bf41035f8a2-q1etbf a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E80_Part_Removal .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/removed_by> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fresulted_from.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fresulted_from.trig
@@ -1,0 +1,79 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/resulted_from/context> {
+  <http://www.researchspace.org/pattern/system/physical_thing/resulted_from> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-fca48994ba904886bd972ac9dce14693-mrbzm2;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-fca48994ba904886bd972ac9dce14693-1oqg78;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E81_Transformation>;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-fca48994ba904886bd972ac9dce14693-e8gb1r;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Resulted from";
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-fca48994ba904886bd972ac9dce14693-kaojsp;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-fca48994ba904886bd972ac9dce14693-0ljic8;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T20:07:04.217+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-fca48994ba904886bd972ac9dce14693-mrbzm2 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E81_Transformation .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  _:genid-fca48994ba904886bd972ac9dce14693-1oqg78 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P123i_resulted_from $value . 
+  $value crm:P123_resulted_in $subject .
+} WHERE {}""" .
+  
+  _:genid-fca48994ba904886bd972ac9dce14693-e8gb1r a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P123i_resulted_from $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E81_Transformation .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-fca48994ba904886bd972ac9dce14693-0ljic8 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P123i_resulted_from $value . 
+  $value crm:P123_resulted_in $subject .
+} WHERE {
+  $subject crm:P123i_resulted_from $value . 
+  $value crm:P123_resulted_in $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E81_Transformation .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-fca48994ba904886bd972ac9dce14693-kaojsp a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E81_Transformation .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/resulted_from> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Ftransformed_by.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Ftransformed_by.trig
@@ -1,0 +1,79 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/transformed_by/context> {
+  <http://www.researchspace.org/pattern/system/physical_thing/transformed_by> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E81_Transformation>;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.w3.org/2000/01/rdf-schema#label> "Transformed by";
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-9f636099d3a6404e86e40821368284a8-i3fh2;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-9f636099d3a6404e86e40821368284a8-dsshbe;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-9f636099d3a6404e86e40821368284a8-a0qtj7;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-9f636099d3a6404e86e40821368284a8-hzthk;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-9f636099d3a6404e86e40821368284a8-bi41a;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T20:05:46.632+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-9f636099d3a6404e86e40821368284a8-hzthk a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P124i_was_transformed_by $value . 
+  $value crm:P124_transformed $subject .
+} WHERE {
+  $subject crm:P124i_was_transformed_by $value . 
+  $value crm:P124_transformed $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E81_Transformation .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-9f636099d3a6404e86e40821368284a8-a0qtj7 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P124i_was_transformed_by $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E81_Transformation .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-9f636099d3a6404e86e40821368284a8-i3fh2 a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E81_Transformation .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  _:genid-9f636099d3a6404e86e40821368284a8-bi41a a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E81_Transformation .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  _:genid-9f636099d3a6404e86e40821368284a8-dsshbe a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P124i_was_transformed_by $value . 
+  $value crm:P124_transformed $subject .
+} WHERE {}""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/transformed_by> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fwitnessed_period.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fphysical_thing%2Fwitnessed_period.trig
@@ -1,0 +1,79 @@
+
+<http://www.researchspace.org/pattern/system/physical_thing/witnessed_period/context> {
+  <http://www.researchspace.org/pattern/system/physical_thing/witnessed_period> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E18_Physical_Thing>;
+    <http://www.researchspace.org/resource/system/fields/valueSetPattern> _:genid-ae30ed0b505f40c6b6151cfd33695712-ilpwc;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Witnessed";
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "unbound";
+    <http://www.researchspace.org/resource/system/fields/autosuggestionPattern> _:genid-ae30ed0b505f40c6b6151cfd33695712-x1sw7v;
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#anyURI>;
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-ae30ed0b505f40c6b6151cfd33695712-dlaelu;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-ae30ed0b505f40c6b6151cfd33695712-5o3ybp;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-ae30ed0b505f40c6b6151cfd33695712-o0jkwj;
+    <http://www.researchspace.org/resource/system/fields/range> <http://www.cidoc-crm.org/cidoc-crm/E4_Period>;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/physical_thing>;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-05-23T20:12:21.823+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-ae30ed0b505f40c6b6151cfd33695712-ilpwc a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E4_Period .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+} ORDER BY ASC(LCASE(STR(?label)))""" .
+  
+  _:genid-ae30ed0b505f40c6b6151cfd33695712-x1sw7v a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E4_Period .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+  MINUS { ?value crm:P71i_is_listed_in|skos:inScheme ?systemAuthority . ?systemAuthority crm:P2_has_type Platform:System_Resource . }
+  FILTER REGEX(LCASE(STR(?label)), \"?token\", \"i\")
+} ORDER BY ASC(?label)
+  LIMIT 10""" .
+  
+  _:genid-ae30ed0b505f40c6b6151cfd33695712-dlaelu a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P8i_witnessed $value . 
+  $value crm:P8_took_place_on_or_within $subject .
+} WHERE {}""" .
+  
+  _:genid-ae30ed0b505f40c6b6151cfd33695712-o0jkwj a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+  $subject crm:P8i_witnessed $value . 
+  $value crm:P8_took_place_on_or_within $subject .
+} WHERE {
+  $subject crm:P8i_witnessed $value . 
+  $value crm:P8_took_place_on_or_within $subject .
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E4_Period .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  _:genid-ae30ed0b505f40c6b6151cfd33695712-5o3ybp a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value ?label WHERE {
+  $subject crm:P8i_witnessed $value . 
+      
+  ?value a ?ontologyClass .
+  ?ontologyClass rdfs:subClassOf* crm:E4_Period .
+  ?value crm:P1_is_identified_by ?appellation .
+  ?appellation a crm:E41_Appellation .
+  ?appellation crm:P2_has_type <http://www.researchspace.org/resource/system/vocab/resource_type/primary_appellation> .   
+  ?appellation crm:P190_has_symbolic_content ?label .
+}""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/physical_thing/witnessed_period> .
+}


### PR DESCRIPTION
# Why
The following properties are missing in forms of subclasses of E18_Physical_Thing:
- P24i_changed_ownership_through
- P30i_custody_transferred_through
- P34i_was_assessed_by
- P111i_was_added_by
- P113i_was_removed_by
- P13i_was_destroyed_by
- P123i_resulted_from
- P124i_was_transformed_by
- P198_holds_or_supports
- P198i_is_held_or_supported_by
- P8i_witnessed

# What
KPs have been created for the missing properties and input added to following forms:
- Biological object
- Collection
- Human-made feature
- Human-made object
- Physical feature
- Physical human-made thing
- Physical object
- Physical thing
- Series
- Site

# Screenshot
<img width="1060" alt="Screenshot 2025-06-02 at 16 56 39" src="https://github.com/user-attachments/assets/1b8aafbc-7068-4e5f-a58a-c240ecf3ea0e" />

<img width="1002" alt="Screenshot 2025-06-02 at 16 57 19" src="https://github.com/user-attachments/assets/da6d8428-81db-47af-ba70-428b2fd649f8" />


