### PR TITLE
implement hierarchical templating system

### DIFF
--- a/src/main/java/org/researchspace/templates/TemplateByIriLoader.java
+++ b/src/main/java/org/researchspace/templates/TemplateByIriLoader.java
@@ -1,6 +1,6 @@
 /**
  * ResearchSpace
- * Copyright (C) 2020, © Trustees of the British Museum
+ * Copyright (C) 2025, © Trustees of the British Museum
  * Copyright (C) 2015-2019, metaphacts GmbH
  *
  * This program is free software: you can redistribute it and/or modify
@@ -25,50 +25,122 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.researchspace.config.NamespaceRegistry;
 import org.researchspace.services.storage.api.*;
 
+import java.io.IOException;
 import java.util.Optional;
 
+import com.github.jknack.handlebars.io.TemplateSource;
+import com.github.jknack.handlebars.io.ReloadableTemplateSource;
+
 public class TemplateByIriLoader extends FromStorageLoader {
-    protected final NamespaceRegistry ns;
+    
+    private final NamespaceRegistry ns;
+    private final ValueFactory vf = SimpleValueFactory.getInstance();
+    private final TemplateResolver resolver;
 
     public TemplateByIriLoader(PlatformStorage platformStorage, NamespaceRegistry ns) {
         super(platformStorage);
         this.ns = ns;
+        this.resolver = new TemplateResolver();
+    }
+
+    @Override
+    public TemplateSource sourceAt(String location) throws IOException {
+        // Use unified resolver to find template
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, ns, storage);
+        
+        if (result.isPresent()) {
+            return new ReloadableTemplateSource(
+                new StorageTemplateSource(location, result.get().getRecord()));
+        }
+        
+        // If not found, throw exception with primary path for backward compatibility
+        StoragePath primaryPath = resolveLocation(location);
+        throw new TemplateNotFoundException("Storage object \"" + primaryPath.toString() + "\"");
     }
 
     @Override
     protected StoragePath resolveLocation(String location) {
         IRI templateIri = constructTemplateIri(location);
-        return templatePathFromIri(templateIri);
+        return TemplateIriUtils.templatePathFromIri(templateIri);
     }
 
+    /**
+     * Constructs a template IRI from a location string, handling loader prefix removal.
+     *
+     * @param location The template location
+     * @return The constructed template IRI
+     */
     private IRI constructTemplateIri(String location) {
         String prefix = this.getPrefix();
         if (location.startsWith(prefix)) {
             location = location.substring(prefix.length());
         }
-        location = location.trim();
-
-        String TEMPLATE_PREFIX = "Template:";
-        boolean isTemplate = location.startsWith(TEMPLATE_PREFIX);
-
-        String plainLocation = isTemplate ? location.substring(TEMPLATE_PREFIX.length()) : location;
-
-        ValueFactory vf = SimpleValueFactory.getInstance();
-        IRI iri = plainLocation.startsWith("http") ? SimpleValueFactory.getInstance().createIRI(plainLocation)
-                : ns.resolveToIRI(plainLocation).orElse(vf.createIRI(ns.getDefaultNamespace(), plainLocation));
-
-        IRI templateIri = isTemplate ? vf.createIRI(TEMPLATE_PREFIX + iri.stringValue()) : iri;
-        return templateIri;
+        
+        return TemplateIriUtils.constructTemplateIri(location, ns);
     }
 
+    /**
+     * Converts a template IRI to a storage path.
+     *
+     * @param templateIri The template IRI
+     * @return The storage path for the template
+     */
     public static StoragePath templatePathFromIri(IRI templateIri) {
-        return ObjectKind.TEMPLATE.resolve(StoragePath.encodeIri(templateIri)).addExtension(".html");
+        return TemplateIriUtils.templatePathFromIri(templateIri);
     }
 
+    /**
+     * Extracts a template IRI from a storage path, handling both root-level and subfolder templates.
+     * This method safely handles the "Cannot unescape IRI from a non-root path" limitation
+     * by extracting just the filename component for IRI decoding when dealing with subfolder paths.
+     *
+     * @param objectPath The storage path to extract the IRI from
+     * @return Optional containing the template IRI if successfully decoded, empty otherwise
+     */
     public static Optional<IRI> templateIriFromPath(StoragePath objectPath) {
-        if (!objectPath.hasExtension(".html")) {
+        if (objectPath == null || !objectPath.hasExtension(".html")) {
             return Optional.empty();
         }
-        return ObjectKind.TEMPLATE.relativize(objectPath.stripExtension(".html")).map(StoragePath::decodeIri);
+        
+        // Get the relative path from the template root
+        Optional<StoragePath> relativePath = ObjectKind.TEMPLATE.relativize(objectPath.stripExtension(".html"));
+        if (!relativePath.isPresent()) {
+            return Optional.empty();
+        }
+        
+        StoragePath relPath = relativePath.get();
+        
+        // If the path contains separators (i.e., it's in a subfolder),
+        // extract just the filename part for IRI decoding
+        if (relPath.toString().contains(StoragePath.SEPARATOR)) {
+            String filename = relPath.getLastComponent();
+            return decodeFilenameAsIri(filename);
+        } else {
+            // Root level path - decode directly
+            return decodeFilenameAsIri(relPath.toString());
+        }
+    }
+    
+    /**
+     * Attempts to decode a filename as an IRI.
+     *
+     * @param filename The filename to decode
+     * @return Optional containing the IRI if successfully decoded, empty otherwise
+     */
+    private static Optional<IRI> decodeFilenameAsIri(String filename) {
+        try {
+            // Check if this looks like a prefixed name (contains colon but no URL encoding)
+            // Prefixed names like "test:Person" should not be decoded as IRIs
+            if (filename.contains(":") && !filename.contains("%")) {
+                return Optional.empty();
+            }
+            
+            StoragePath filenamePath = StoragePath.parse(filename);
+            return Optional.of(filenamePath.decodeIri());
+        } catch (Exception e) {
+            // If decoding fails, this might be a prefixed template name
+            // Return empty since we can't decode non-IRI filenames to IRIs
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/org/researchspace/templates/TemplateIriUtils.java
+++ b/src/main/java/org/researchspace/templates/TemplateIriUtils.java
@@ -1,0 +1,148 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2025, © President and Fellows of Harvard College
+ * Copyright (C) 2015-2019, metaphacts GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.researchspace.templates;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.researchspace.config.NamespaceRegistry;
+import org.researchspace.services.storage.api.ObjectKind;
+import org.researchspace.services.storage.api.StoragePath;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+/**
+ * Utility class for template IRI operations including construction, encoding, and path conversion.
+ * This class consolidates common functionality used across the template resolution system.
+ */
+public final class TemplateIriUtils {
+    
+    /** Template prefix constant used throughout the system */
+    public static final String TEMPLATE_PREFIX = "Template:";
+    
+    private static final ValueFactory VALUE_FACTORY = SimpleValueFactory.getInstance();
+    
+    // Private constructor to prevent instantiation
+    private TemplateIriUtils() {
+        throw new UnsupportedOperationException("Utility class cannot be instantiated");
+    }
+    
+    /**
+     * Constructs a template IRI from a location string.
+     * Handles Template: prefix logic and namespace resolution.
+     * 
+     * @param location The template location string
+     * @param namespaceRegistry The namespace registry for prefix resolution
+     * @return The constructed template IRI
+     */
+    public static IRI constructTemplateIri(String location, NamespaceRegistry namespaceRegistry) {
+        if (location == null) {
+            throw new IllegalArgumentException("Location cannot be null");
+        }
+        if (namespaceRegistry == null) {
+            throw new IllegalArgumentException("NamespaceRegistry cannot be null");
+        }
+        
+        location = location.trim();
+        
+        boolean isTemplate = location.startsWith(TEMPLATE_PREFIX);
+        String plainLocation = isTemplate ? location.substring(TEMPLATE_PREFIX.length()) : location;
+        
+        IRI iri = plainLocation.startsWith("http") ? 
+            VALUE_FACTORY.createIRI(plainLocation) :
+            namespaceRegistry.resolveToIRI(plainLocation)
+                .orElse(VALUE_FACTORY.createIRI(namespaceRegistry.getDefaultNamespace(), plainLocation));
+        
+        return isTemplate ? VALUE_FACTORY.createIRI(TEMPLATE_PREFIX + iri.stringValue()) : iri;
+    }
+    
+    /**
+     * Converts a template IRI to a storage path.
+     * 
+     * @param templateIri The template IRI to convert
+     * @return The storage path for the template
+     */
+    public static StoragePath templatePathFromIri(IRI templateIri) {
+        if (templateIri == null) {
+            throw new IllegalArgumentException("Template IRI cannot be null");
+        }
+        
+        return ObjectKind.TEMPLATE.resolve(StoragePath.encodeIri(templateIri)).addExtension(".html");
+    }
+    
+    /**
+     * URL-encodes an IRI string for use as a filename.
+     * 
+     * @param iri The IRI string to encode
+     * @return The URL-encoded IRI string, or null if encoding fails
+     */
+    public static String urlEncodeIri(String iri) {
+        if (iri == null) {
+            return null;
+        }
+        
+        try {
+            return URLEncoder.encode(iri, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // UTF-8 should always be supported
+            return null;
+        }
+    }
+    
+    /**
+     * Checks if a location has the Template: prefix.
+     * 
+     * @param location The location to check
+     * @return true if the location has the Template: prefix
+     */
+    public static boolean hasTemplatePrefix(String location) {
+        return location != null && location.trim().startsWith(TEMPLATE_PREFIX);
+    }
+    
+    /**
+     * Removes the Template: prefix from a location if present.
+     * 
+     * @param location The location to process
+     * @return The location without the Template: prefix
+     */
+    public static String withoutTemplatePrefix(String location) {
+        if (location == null) {
+            return null;
+        }
+        
+        String trimmed = location.trim();
+        return hasTemplatePrefix(trimmed) ? trimmed.substring(TEMPLATE_PREFIX.length()) : trimmed;
+    }
+    
+    /**
+     * Adds the Template: prefix to a location if not already present.
+     * 
+     * @param location The location to process
+     * @return The location with the Template: prefix
+     */
+    public static String withTemplatePrefix(String location) {
+        if (location == null) {
+            return TEMPLATE_PREFIX;
+        }
+        
+        return hasTemplatePrefix(location) ? location : TEMPLATE_PREFIX + location;
+    }
+}

--- a/src/main/java/org/researchspace/templates/TemplateResolver.java
+++ b/src/main/java/org/researchspace/templates/TemplateResolver.java
@@ -1,0 +1,293 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2025, © President and Fellows of Harvard College
+ * Copyright (C) 2015-2019, metaphacts GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.researchspace.templates;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.researchspace.config.NamespaceRegistry;
+import org.researchspace.services.storage.api.*;
+
+import java.util.*;
+
+/**
+ * Template resolver that handles all input formats (prefixed, full IRI, Template: prefixed)
+ * and searches for both filename formats (IRI-encoded and prefixed) across all subfolders simultaneously.
+ *
+ * This resolver provides a comprehensive template resolution strategy that:
+ * - Generates all possible template variations from any input format
+ * - Tries direct path lookup first for optimal performance
+ * - Falls back to hierarchical search across all template locations
+ * - Supports both clean prefixed filenames and URL-encoded IRI filenames
+ */
+public class TemplateResolver {
+    
+    private final ValueFactory vf = SimpleValueFactory.getInstance();
+    
+    /**
+     * Resolves a template location using unified hierarchical search.
+     * 
+     * @param location The template location to resolve
+     * @param namespaceRegistry The namespace registry for prefix/IRI conversion
+     * @param storage The platform storage for template lookup
+     * @return Optional containing the storage result if found, empty otherwise
+     */
+    public Optional<PlatformStorage.FindResult> resolve(String location,
+                                                       NamespaceRegistry namespaceRegistry,
+                                                       PlatformStorage storage) {
+        if (location == null || location.trim().isEmpty()) {
+            return Optional.empty();
+        }
+        if (namespaceRegistry == null || storage == null) {
+            return Optional.empty();
+        }
+        
+        // Generate all possible template variations
+        Set<String> variations = generateAllVariations(location, namespaceRegistry);
+        
+        // Try direct path lookup first (most efficient)
+        for (String variation : variations) {
+            Optional<PlatformStorage.FindResult> result = tryDirectPath(variation, namespaceRegistry, storage);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        
+        // If direct paths fail, search all templates for filename matches
+        return searchAllTemplates(variations, storage);
+    }
+    
+    /**
+     * Generates all possible variations of a template location.
+     *
+     * @param location The original template location
+     * @param namespaceRegistry The namespace registry for prefix/IRI conversion
+     * @return Set of all possible location variations
+     */
+    private Set<String> generateAllVariations(String location, NamespaceRegistry namespaceRegistry) {
+        Set<String> variations = new LinkedHashSet<>();
+        
+        // Normalize input
+        String trimmed = location.trim();
+        boolean hasTemplatePrefix = TemplateIriUtils.hasTemplatePrefix(trimmed);
+        String withoutTemplate = TemplateIriUtils.withoutTemplatePrefix(trimmed);
+        
+        // Add original location
+        variations.add(trimmed);
+        
+        if (withoutTemplate.contains(":") && !withoutTemplate.startsWith("http")) {
+            // Prefixed format (e.g., "test:Person")
+            addPrefixedVariations(withoutTemplate, hasTemplatePrefix, namespaceRegistry, variations);
+        } else if (withoutTemplate.startsWith("http")) {
+            // Full IRI format (e.g., "http://example.org/Person")
+            addIriVariations(withoutTemplate, hasTemplatePrefix, namespaceRegistry, variations);
+        } else {
+            // Simple name format (e.g., "Person")
+            addSimpleNameVariations(withoutTemplate, hasTemplatePrefix, namespaceRegistry, variations);
+        }
+        
+        return variations;
+    }
+    
+    private void addPrefixedVariations(String prefixed, boolean hasTemplatePrefix,
+                                     NamespaceRegistry namespaceRegistry, Set<String> variations) {
+        // Add prefixed form variations
+        variations.add(prefixed);
+        if (hasTemplatePrefix) {
+            variations.add(TemplateIriUtils.withTemplatePrefix(prefixed));
+        } else {
+            variations.add(prefixed);
+            variations.add(TemplateIriUtils.withTemplatePrefix(prefixed));
+        }
+        
+        // Try to expand to full IRI
+        Optional<IRI> fullIri = namespaceRegistry.resolveToIRI(prefixed);
+        if (fullIri.isPresent()) {
+            String iriString = fullIri.get().stringValue();
+            variations.add(iriString);
+            variations.add(TemplateIriUtils.withTemplatePrefix(iriString));
+        }
+    }
+    
+    private void addIriVariations(String iri, boolean hasTemplatePrefix,
+                                NamespaceRegistry namespaceRegistry, Set<String> variations) {
+        // Add IRI form variations
+        variations.add(iri);
+        if (hasTemplatePrefix) {
+            variations.add(TemplateIriUtils.withTemplatePrefix(iri));
+        } else {
+            variations.add(iri);
+            variations.add(TemplateIriUtils.withTemplatePrefix(iri));
+        }
+        
+        // Try to compress to prefixed form
+        try {
+            IRI iriObj = vf.createIRI(iri);
+            String namespace = iriObj.getNamespace();
+            String localName = iriObj.getLocalName();
+            
+            if (localName != null && !localName.isEmpty()) {
+                Optional<String> prefix = namespaceRegistry.getPrefix(namespace);
+                if (prefix.isPresent()) {
+                    String prefixed = prefix.get() + ":" + localName;
+                    variations.add(prefixed);
+                    variations.add(TemplateIriUtils.withTemplatePrefix(prefixed));
+                }
+            }
+        } catch (Exception e) {
+            // Ignore invalid IRIs
+        }
+    }
+    
+    private void addSimpleNameVariations(String name, boolean hasTemplatePrefix,
+                                       NamespaceRegistry namespaceRegistry, Set<String> variations) {
+        // Add simple name variations
+        variations.add(name);
+        if (hasTemplatePrefix) {
+            variations.add(TemplateIriUtils.withTemplatePrefix(name));
+        } else {
+            variations.add(name);
+            variations.add(TemplateIriUtils.withTemplatePrefix(name));
+        }
+        
+        // Try with default namespace
+        String defaultNamespace = namespaceRegistry.getDefaultNamespace();
+        if (defaultNamespace != null) {
+            String fullIri = defaultNamespace + name;
+            variations.add(fullIri);
+            variations.add(TemplateIriUtils.withTemplatePrefix(fullIri));
+        }
+    }
+    
+    /**
+     * Tries to find a template using direct path lookup.
+     *
+     * @param variation The template variation to try
+     * @param namespaceRegistry The namespace registry
+     * @param storage The platform storage
+     * @return Optional containing the result if found
+     */
+    private Optional<PlatformStorage.FindResult> tryDirectPath(String variation,
+                                                              NamespaceRegistry namespaceRegistry,
+                                                              PlatformStorage storage) {
+        try {
+            IRI templateIri = TemplateIriUtils.constructTemplateIri(variation, namespaceRegistry);
+            StoragePath path = TemplateIriUtils.templatePathFromIri(templateIri);
+            return storage.findObject(path);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+    
+    /**
+     * Searches all templates for filename matches when direct paths fail.
+     * This method performs a comprehensive search across all template locations.
+     *
+     * @param variations The set of template variations to search for
+     * @param storage The platform storage
+     * @return Optional containing the result if found
+     */
+    private Optional<PlatformStorage.FindResult> searchAllTemplates(Set<String> variations,
+                                                                   PlatformStorage storage) {
+        try {
+            Map<StoragePath, PlatformStorage.FindResult> allTemplates = storage.findAll(ObjectKind.TEMPLATE);
+            
+            // Create filename patterns to match
+            Set<String> filenamePatterns = generateFilenamePatterns(variations);
+            
+            // Search through all templates
+            for (Map.Entry<StoragePath, PlatformStorage.FindResult> entry : allTemplates.entrySet()) {
+                StoragePath templatePath = entry.getKey();
+                
+                if (templatePath.hasExtension(".html")) {
+                    // Check IRI-encoded filename
+                    if (matchesIriEncodedPath(templatePath, variations)) {
+                        return Optional.of(entry.getValue());
+                    }
+                    
+                    // Check clean filename
+                    if (matchesCleanFilename(templatePath, filenamePatterns)) {
+                        return Optional.of(entry.getValue());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // Ignore search errors
+        }
+        
+        return Optional.empty();
+    }
+    
+    /**
+     * Generates all possible filename patterns from the given variations.
+     *
+     * @param variations The template variations
+     * @return Set of filename patterns to match
+     */
+    private Set<String> generateFilenamePatterns(Set<String> variations) {
+        Set<String> filenamePatterns = new HashSet<>();
+        
+        for (String variation : variations) {
+            // Add clean prefixed filename (e.g., "test:Person.html")
+            filenamePatterns.add(variation + ".html");
+            
+            // If it's an IRI, also add URL-encoded version
+            if (variation.startsWith("http")) {
+                String encodedVariation = TemplateIriUtils.urlEncodeIri(variation);
+                if (encodedVariation != null) {
+                    filenamePatterns.add(encodedVariation + ".html");
+                }
+            }
+            
+            // Also try without Template: prefix for filename matching
+            if (TemplateIriUtils.hasTemplatePrefix(variation)) {
+                String withoutTemplate = TemplateIriUtils.withoutTemplatePrefix(variation);
+                filenamePatterns.add(withoutTemplate + ".html");
+                
+                // If the part after Template: is an IRI, encode it too
+                if (withoutTemplate.startsWith("http")) {
+                    String encodedWithoutTemplate = TemplateIriUtils.urlEncodeIri(withoutTemplate);
+                    if (encodedWithoutTemplate != null) {
+                        filenamePatterns.add(encodedWithoutTemplate + ".html");
+                    }
+                }
+            }
+        }
+        
+        return filenamePatterns;
+    }
+    
+    private boolean matchesIriEncodedPath(StoragePath templatePath, Set<String> variations) {
+        try {
+            IRI decodedIri = templatePath.stripExtension(".html").decodeIri();
+            String decodedString = decodedIri.stringValue();
+            return variations.contains(decodedString);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    private boolean matchesCleanFilename(StoragePath templatePath, Set<String> filenamePatterns) {
+        String pathString = templatePath.toString();
+        String filename = pathString.substring(pathString.lastIndexOf('/') + 1);
+        return filenamePatterns.contains(filename);
+    }
+    
+}

--- a/src/test/java/org/researchspace/templates/TemplateByIriLoaderTest.java
+++ b/src/test/java/org/researchspace/templates/TemplateByIriLoaderTest.java
@@ -1,0 +1,211 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2020, © Trustees of the British Museum
+ * Copyright (C) 2015-2019, metaphacts GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.researchspace.templates;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.Test;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.researchspace.config.NamespaceRegistry;
+import org.researchspace.services.storage.api.*;
+
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for TemplateByIriLoader.
+ */
+public class TemplateByIriLoaderTest {
+    
+    @Mock
+    private PlatformStorage storage;
+    
+    @Mock
+    private NamespaceRegistry namespaceRegistry;
+    
+    @Mock
+    private PlatformStorage.FindResult findResult;
+    
+    private TemplateByIriLoader loader;
+    private ValueFactory vf;
+    
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        vf = SimpleValueFactory.getInstance();
+        loader = new TemplateByIriLoader(storage, namespaceRegistry);
+        
+        // Setup common mock behaviors
+        when(namespaceRegistry.getDefaultNamespace()).thenReturn("http://example.org/");
+        when(namespaceRegistry.resolveToIRI("test:Person"))
+            .thenReturn(Optional.of(vf.createIRI("http://test.org/resource/Person")));
+    }
+    
+    @Test
+    public void testTemplatePathFromIri() {
+        IRI templateIri = vf.createIRI("http://example.org/resource/Test");
+        StoragePath result = TemplateByIriLoader.templatePathFromIri(templateIri);
+        
+        assertNotNull(result);
+        assertTrue(result.toString().endsWith(".html"));
+        assertTrue(result.toString().contains("http%3A%2F%2Fexample.org%2Fresource%2FTest"));
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_RootLevel_IriEncoded() {
+        StoragePath path = StoragePath.parse("data/templates/http%3A%2F%2Fexample.org%2Fresource%2FTest.html");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        assertTrue(result.isPresent());
+        assertEquals("http://example.org/resource/Test", result.get().stringValue());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_RootLevel_PrefixedName() {
+        StoragePath path = StoragePath.parse("data/templates/test:Person.html");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        // Prefixed names cannot be decoded to IRIs, should return empty
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_Subfolder_IriEncoded() {
+        StoragePath path = StoragePath.parse("data/templates/subfolder/http%3A%2F%2Fexample.org%2Fresource%2FTest.html");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        assertTrue(result.isPresent());
+        assertEquals("http://example.org/resource/Test", result.get().stringValue());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_Subfolder_PrefixedName() {
+        StoragePath path = StoragePath.parse("data/templates/subfolder/forms/test:Person.html");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        // Prefixed names cannot be decoded to IRIs, should return empty
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_DeepNested_IriEncoded() {
+        StoragePath path = StoragePath.parse("data/templates/deep/nested/folder/http%3A%2F%2Fexample.org%2Fresource%2FDeep.html");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        assertTrue(result.isPresent());
+        assertEquals("http://example.org/resource/Deep", result.get().stringValue());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_NonHtmlFile() {
+        StoragePath path = StoragePath.parse("data/templates/test:Person.txt");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_NullPath() {
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(null);
+        
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_InvalidPath() {
+        StoragePath path = StoragePath.parse("not-templates/test:Person.html");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        // Should return empty if not under templates directory
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_TemplatePrefix() {
+        StoragePath path = StoragePath.parse("data/templates/Template%3Ahttp%3A%2F%2Fexample.org%2Fresource%2FTest.html");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        assertTrue(result.isPresent());
+        assertEquals("Template:http://example.org/resource/Test", result.get().stringValue());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_ComplexIri() {
+        String complexIri = "http://example.org/resource/Test?param=value&other=123";
+        String encodedIri = "http%3A%2F%2Fexample.org%2Fresource%2FTest%3Fparam%3Dvalue%26other%3D123";
+        StoragePath path = StoragePath.parse("data/templates/" + encodedIri + ".html");
+        
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        assertTrue(result.isPresent());
+        assertEquals(complexIri, result.get().stringValue());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_InvalidIriEncoding() {
+        // Test with invalid URL encoding that can't be decoded
+        StoragePath path = StoragePath.parse("data/templates/invalid%encoding.html");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        
+        // Should handle gracefully and return empty
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testTemplateIriFromPath_EdgeCases() {
+        // Test empty filename
+        StoragePath path = StoragePath.parse("data/templates/.html");
+        Optional<IRI> result = TemplateByIriLoader.templateIriFromPath(path);
+        assertFalse(result.isPresent());
+        
+        // Test filename with only extension
+        path = StoragePath.parse("data/templates/subfolder/.html");
+        result = TemplateByIriLoader.templateIriFromPath(path);
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testResolveLocation() {
+        // This tests the protected method indirectly through the loader's behavior
+        // The actual template resolution is handled by TemplateResolver
+        // so we just verify the path construction works
+        
+        StoragePath result = loader.resolveLocation("test:Person");
+        assertNotNull(result);
+        assertTrue(result.toString().endsWith(".html"));
+    }
+    
+    @Test
+    public void testTemplatePathFromIri_StaticMethod() {
+        // Test the static utility method
+        IRI templateIri = vf.createIRI("Template:http://example.org/resource/Test");
+        StoragePath result = TemplateByIriLoader.templatePathFromIri(templateIri);
+        
+        assertNotNull(result);
+        assertTrue(result.toString().endsWith(".html"));
+        assertTrue(result.toString().contains("Template%3Ahttp%3A%2F%2Fexample.org%2Fresource%2FTest"));
+    }
+}

--- a/src/test/java/org/researchspace/templates/TemplateIriUtilsTest.java
+++ b/src/test/java/org/researchspace/templates/TemplateIriUtilsTest.java
@@ -1,0 +1,180 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2020, © Trustees of the British Museum
+ * Copyright (C) 2015-2019, metaphacts GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.researchspace.templates;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.Test;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.researchspace.config.NamespaceRegistry;
+import org.researchspace.services.storage.api.StoragePath;
+
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for TemplateIriUtils utility class.
+ */
+public class TemplateIriUtilsTest {
+    
+    @Mock
+    private NamespaceRegistry namespaceRegistry;
+    
+    private ValueFactory vf;
+    
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        vf = SimpleValueFactory.getInstance();
+        
+        // Setup common mock behaviors
+        when(namespaceRegistry.getDefaultNamespace()).thenReturn("http://example.org/");
+        when(namespaceRegistry.resolveToIRI("test:Person"))
+            .thenReturn(Optional.of(vf.createIRI("http://test.org/resource/Person")));
+        when(namespaceRegistry.getPrefix("http://test.org/resource/"))
+            .thenReturn(Optional.of("test"));
+        
+        // Mock resolveToIRI to return empty for unknown prefixes (like "SimpleName")
+        when(namespaceRegistry.resolveToIRI(anyString())).thenReturn(Optional.empty());
+        // Override specific known prefixes
+        when(namespaceRegistry.resolveToIRI("test:Person"))
+            .thenReturn(Optional.of(vf.createIRI("http://test.org/resource/Person")));
+    }
+    
+    @Test
+    public void testConstructTemplateIri_WithFullIri() {
+        String location = "http://example.org/resource/Test";
+        IRI result = TemplateIriUtils.constructTemplateIri(location, namespaceRegistry);
+        
+        assertEquals("http://example.org/resource/Test", result.stringValue());
+    }
+    
+    @Test
+    public void testConstructTemplateIri_WithPrefixedForm() {
+        String location = "test:Person";
+        IRI result = TemplateIriUtils.constructTemplateIri(location, namespaceRegistry);
+        
+        assertEquals("http://test.org/resource/Person", result.stringValue());
+    }
+    
+    @Test
+    public void testConstructTemplateIri_WithTemplatePrefix() {
+        String location = "Template:http://example.org/resource/Test";
+        IRI result = TemplateIriUtils.constructTemplateIri(location, namespaceRegistry);
+        
+        assertEquals("Template:http://example.org/resource/Test", result.stringValue());
+    }
+    
+    @Test
+    public void testConstructTemplateIri_WithTemplatePrefixedForm() {
+        String location = "Template:test:Person";
+        IRI result = TemplateIriUtils.constructTemplateIri(location, namespaceRegistry);
+        
+        assertEquals("Template:http://test.org/resource/Person", result.stringValue());
+    }
+    
+    @Test
+    public void testConstructTemplateIri_WithSimpleName() {
+        String location = "SimpleName";
+        IRI result = TemplateIriUtils.constructTemplateIri(location, namespaceRegistry);
+        
+        assertEquals("http://example.org/SimpleName", result.stringValue());
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructTemplateIri_WithNullLocation() {
+        TemplateIriUtils.constructTemplateIri(null, namespaceRegistry);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructTemplateIri_WithNullNamespaceRegistry() {
+        TemplateIriUtils.constructTemplateIri("test:Person", null);
+    }
+    
+    @Test
+    public void testTemplatePathFromIri() {
+        IRI templateIri = vf.createIRI("http://example.org/resource/Test");
+        StoragePath result = TemplateIriUtils.templatePathFromIri(templateIri);
+        
+        assertTrue(result.toString().endsWith(".html"));
+        assertTrue(result.toString().contains("http%3A%2F%2Fexample.org%2Fresource%2FTest"));
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testTemplatePathFromIri_WithNullIri() {
+        TemplateIriUtils.templatePathFromIri(null);
+    }
+    
+    @Test
+    public void testUrlEncodeIri() {
+        String iri = "http://example.org/resource/Test";
+        String result = TemplateIriUtils.urlEncodeIri(iri);
+        
+        assertEquals("http%3A%2F%2Fexample.org%2Fresource%2FTest", result);
+    }
+    
+    @Test
+    public void testUrlEncodeIri_WithNull() {
+        String result = TemplateIriUtils.urlEncodeIri(null);
+        assertNull(result);
+    }
+    
+    @Test
+    public void testHasTemplatePrefix() {
+        assertTrue(TemplateIriUtils.hasTemplatePrefix("Template:test:Person"));
+        assertTrue(TemplateIriUtils.hasTemplatePrefix("Template:http://example.org/Test"));
+        assertTrue(TemplateIriUtils.hasTemplatePrefix("  Template:test:Person  "));
+        
+        assertFalse(TemplateIriUtils.hasTemplatePrefix("test:Person"));
+        assertFalse(TemplateIriUtils.hasTemplatePrefix("http://example.org/Test"));
+        assertFalse(TemplateIriUtils.hasTemplatePrefix(""));
+        assertFalse(TemplateIriUtils.hasTemplatePrefix(null));
+    }
+    
+    @Test
+    public void testWithoutTemplatePrefix() {
+        assertEquals("test:Person", TemplateIriUtils.withoutTemplatePrefix("Template:test:Person"));
+        assertEquals("http://example.org/Test", TemplateIriUtils.withoutTemplatePrefix("Template:http://example.org/Test"));
+        assertEquals("test:Person", TemplateIriUtils.withoutTemplatePrefix("test:Person"));
+        assertEquals("test:Person", TemplateIriUtils.withoutTemplatePrefix("  Template:test:Person  "));
+        
+        assertNull(TemplateIriUtils.withoutTemplatePrefix(null));
+    }
+    
+    @Test
+    public void testWithTemplatePrefix() {
+        assertEquals("Template:test:Person", TemplateIriUtils.withTemplatePrefix("test:Person"));
+        assertEquals("Template:http://example.org/Test", TemplateIriUtils.withTemplatePrefix("http://example.org/Test"));
+        assertEquals("Template:test:Person", TemplateIriUtils.withTemplatePrefix("Template:test:Person"));
+        
+        assertEquals("Template:", TemplateIriUtils.withTemplatePrefix(null));
+    }
+    
+    @Test
+    public void testConstants() {
+        assertEquals("Template:", TemplateIriUtils.TEMPLATE_PREFIX);
+    }
+}

--- a/src/test/java/org/researchspace/templates/TemplateResolverTest.java
+++ b/src/test/java/org/researchspace/templates/TemplateResolverTest.java
@@ -1,0 +1,295 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2020, © Trustees of the British Museum
+ * Copyright (C) 2015-2019, metaphacts GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.researchspace.templates;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.Test;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.researchspace.config.NamespaceRegistry;
+import org.researchspace.services.storage.api.*;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Comprehensive unit tests for TemplateResolver.
+ */
+public class TemplateResolverTest {
+    
+    @Mock
+    private NamespaceRegistry namespaceRegistry;
+    
+    @Mock
+    private PlatformStorage storage;
+    
+    @Mock
+    private PlatformStorage.FindResult findResult;
+    
+    private TemplateResolver resolver;
+    private ValueFactory vf;
+    
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        resolver = new TemplateResolver();
+        vf = SimpleValueFactory.getInstance();
+        
+        // Setup common mock behaviors
+        when(namespaceRegistry.getDefaultNamespace()).thenReturn("http://example.org/");
+        when(namespaceRegistry.resolveToIRI("test:Person"))
+            .thenReturn(Optional.of(vf.createIRI("http://test.org/resource/Person")));
+        when(namespaceRegistry.getPrefix("http://test.org/resource/"))
+            .thenReturn(Optional.of("test"));
+        
+        // Mock resolveToIRI to return empty for unknown prefixes
+        when(namespaceRegistry.resolveToIRI(anyString())).thenReturn(Optional.empty());
+        // Override specific known prefixes
+        when(namespaceRegistry.resolveToIRI("test:Person"))
+            .thenReturn(Optional.of(vf.createIRI("http://test.org/resource/Person")));
+        when(namespaceRegistry.resolveToIRI("test:Actor"))
+            .thenReturn(Optional.of(vf.createIRI("http://test.org/resource/Actor")));
+    }
+    
+    @Test
+    public void testResolve_WithNullInputs() {
+        // Test null location
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(null, namespaceRegistry, storage);
+        assertFalse(result.isPresent());
+        
+        // Test empty location
+        result = resolver.resolve("", namespaceRegistry, storage);
+        assertFalse(result.isPresent());
+        
+        // Test null namespace registry
+        result = resolver.resolve("test:Person", null, storage);
+        assertFalse(result.isPresent());
+        
+        // Test null storage
+        result = resolver.resolve("test:Person", namespaceRegistry, null);
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testResolve_DirectPathSuccess() throws Exception {
+        String location = "test:Person";
+        
+        // Mock direct path lookup success
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.of(findResult));
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertTrue(result.isPresent());
+        assertEquals(findResult, result.get());
+        verify(storage, atLeastOnce()).findObject(any(StoragePath.class));
+    }
+    
+    @Test
+    public void testResolve_FallbackToHierarchicalSearch() throws Exception {
+        String location = "test:Person";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock hierarchical search success
+        Map<StoragePath, PlatformStorage.FindResult> allTemplates = new HashMap<>();
+        StoragePath templatePath = StoragePath.parse("subfolder/test:Person.html");
+        allTemplates.put(templatePath, findResult);
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenReturn(allTemplates);
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertTrue(result.isPresent());
+        assertEquals(findResult, result.get());
+        verify(storage).findAll(ObjectKind.TEMPLATE);
+    }
+    
+    @Test
+    public void testResolve_IriEncodedTemplate() throws Exception {
+        String location = "http://example.org/resource/Test";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock hierarchical search with IRI-encoded template
+        Map<StoragePath, PlatformStorage.FindResult> allTemplates = new HashMap<>();
+        StoragePath templatePath = StoragePath.parse("http%3A%2F%2Fexample.org%2Fresource%2FTest.html");
+        allTemplates.put(templatePath, findResult);
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenReturn(allTemplates);
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertTrue(result.isPresent());
+        assertEquals(findResult, result.get());
+    }
+    
+    @Test
+    public void testResolve_TemplatePrefix() throws Exception {
+        String location = "Template:test:Person";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock hierarchical search success
+        Map<StoragePath, PlatformStorage.FindResult> allTemplates = new HashMap<>();
+        StoragePath templatePath = StoragePath.parse("test:Person.html");
+        allTemplates.put(templatePath, findResult);
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenReturn(allTemplates);
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertTrue(result.isPresent());
+        assertEquals(findResult, result.get());
+    }
+    
+    @Test
+    public void testResolve_SubfolderTemplate() throws Exception {
+        String location = "test:Actor";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock hierarchical search with template in subfolder
+        Map<StoragePath, PlatformStorage.FindResult> allTemplates = new HashMap<>();
+        StoragePath templatePath = StoragePath.parse("subfolder/forms/test:Actor.html");
+        allTemplates.put(templatePath, findResult);
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenReturn(allTemplates);
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertTrue(result.isPresent());
+        assertEquals(findResult, result.get());
+    }
+    
+    @Test
+    public void testResolve_NotFound() throws Exception {
+        String location = "test:NonExistent";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock empty hierarchical search
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenReturn(new HashMap<>());
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testResolve_StorageException() throws Exception {
+        String location = "test:Person";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock storage exception during hierarchical search
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenThrow(new StorageException("Test exception"));
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertFalse(result.isPresent());
+    }
+    
+    @Test
+    public void testResolve_MixedTemplateFormats() throws Exception {
+        String location = "test:Person";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock hierarchical search with mixed template formats
+        Map<StoragePath, PlatformStorage.FindResult> allTemplates = new HashMap<>();
+        allTemplates.put(StoragePath.parse("http%3A%2F%2Fexample.org%2Fresource%2FTest1.html"), mock(PlatformStorage.FindResult.class));
+        allTemplates.put(StoragePath.parse("test:Test2.html"), mock(PlatformStorage.FindResult.class));
+        allTemplates.put(StoragePath.parse("subfolder/http%3A%2F%2Fexample.org%2Fresource%2FTest4.html"), mock(PlatformStorage.FindResult.class));
+        allTemplates.put(StoragePath.parse("subfolder/forms/test:Person.html"), findResult); // This should match
+        
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenReturn(allTemplates);
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertTrue(result.isPresent());
+        assertEquals(findResult, result.get());
+    }
+    
+    @Test
+    public void testResolve_IriToPrefix_Conversion() throws Exception {
+        String location = "http://test.org/resource/Person";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock hierarchical search with prefixed template
+        Map<StoragePath, PlatformStorage.FindResult> allTemplates = new HashMap<>();
+        StoragePath templatePath = StoragePath.parse("test:Person.html");
+        allTemplates.put(templatePath, findResult);
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenReturn(allTemplates);
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertTrue(result.isPresent());
+        assertEquals(findResult, result.get());
+    }
+    
+    @Test
+    public void testResolve_PrefixToIri_Conversion() throws Exception {
+        String location = "test:Person";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock hierarchical search with IRI-encoded template
+        Map<StoragePath, PlatformStorage.FindResult> allTemplates = new HashMap<>();
+        StoragePath templatePath = StoragePath.parse("http%3A%2F%2Ftest.org%2Fresource%2FPerson.html");
+        allTemplates.put(templatePath, findResult);
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenReturn(allTemplates);
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertTrue(result.isPresent());
+        assertEquals(findResult, result.get());
+    }
+    
+    @Test
+    public void testResolve_SimpleNameWithDefaultNamespace() throws Exception {
+        String location = "SimpleName";
+        
+        // Mock direct path lookup failure
+        when(storage.findObject(any(StoragePath.class))).thenReturn(Optional.empty());
+        
+        // Mock hierarchical search with template using default namespace
+        Map<StoragePath, PlatformStorage.FindResult> allTemplates = new HashMap<>();
+        StoragePath templatePath = StoragePath.parse("http%3A%2F%2Fexample.org%2FSimpleName.html");
+        allTemplates.put(templatePath, findResult);
+        when(storage.findAll(ObjectKind.TEMPLATE)).thenReturn(allTemplates);
+        
+        Optional<PlatformStorage.FindResult> result = resolver.resolve(location, namespaceRegistry, storage);
+        
+        assertTrue(result.isPresent());
+        assertEquals(findResult, result.get());
+    }
+}


### PR DESCRIPTION
# Why

The existing template resolution system was limited to storing templates with URL-encoded filenames in specific directory structures, making template organization inflexible and filenames unreadable. 
Also, this is the new implementation of #252, which is now compatible with RS version 4.x

# What

This PR implements a template resolution system in which:

- TemplateResolver class handles all filename typologies: full IRIs (`http%3A%2F%2Ftest.org%2Fresource%2FPerson.html`), prefixed forms `test:Person`, and `Template:{prefix}:{name}`

- Template files can be stored in any folder structure independent of the IRI hierarchy
- The new system employs a fallback mechanism to conduct comprehensive searches across all template directories when the direct lookup fails, ensuring retro compatibility and preserving legacy template resolution functionality.

# Video / Gif / Screenshot

N/A - Backend template resolution system changes with no UI impact. 

# Meta

The main components are: 

`src/main/java/org/researchspace/templates/TemplateResolver.java` - Core unified resolution logic and hierarchical search implementation

`src/main/java/org/researchspace/templates/TemplateByIriLoader.java` - Subfolder IRI decoding fixes and prefixed name handling

`src/main/java/org/researchspace/templates/TemplateIriUtils.java` - Consolidated utility functions with enhanced pattern generation

I decided to Implement a two-phase resolution: direct lookup first, then a comprehensive hierarchical search.

# How To Test

Create the following structure for verifying how the resolution works for templates. Also, Verify existing templates continue to work without changes.

```
data/templates/
├── test:Person.html                    # Root level prefixed
├── http%3A%2F%2Fexample.org%2FTest.html # Root level encoded
├── forms/
│   ├── test:Actor.html                 # Subfolder prefixed
│   └── complex/
│       └── test:Movie.html             # Deep nested
└── encoded/
    └── http%3A%2F%2Ftest.org%2Fresource%2FPerson2.html # Subfolder encoded
```