### PR TITLE
Security package fix 

### DIFF
--- a/src/main/resources/org/researchspace/security/sso/shiro-sso-keycloak-default.ini
+++ b/src/main/resources/org/researchspace/security/sso/shiro-sso-keycloak-default.ini
@@ -71,18 +71,18 @@ config.clients = $clients
 subjectFactory = io.buji.pac4j.subject.Pac4jSubjectFactory
 securityManager.subjectFactory = $subjectFactory
 
-securityFilter = io.buji.pac4j.filter.SecurityFilter
+securityFilter = io.buji.pac4j.jee.filter.SecurityFilter
 securityFilter.config = $config
 securityFilter.clients = KeycloakOidcClient
 
 # override authorizers to disable CSRF one which is enabled by default, we can't use default CSRF implementation from pac4j because we send many requests in parallel. For pac4j one to work one would need to send requests synchronously  
 securityFilter.authorizers = isAuthenticated
 
-callbackFilter = io.buji.pac4j.filter.CallbackFilter
+callbackFilter = io.buji.pac4j.jee.filter.CallbackFilter
 callbackFilter.defaultClient = KeycloakOidcClient
 callbackFilter.config = $config
 
-logoutFilter = io.buji.pac4j.filter.LogoutFilter
+logoutFilter = io.buji.pac4j.jee.filter.LogoutFilter
 logoutFilter.config = $config
 logoutFilter.localLogout = true
 logoutFilter.centralLogout = $centralLogout

--- a/src/main/resources/org/researchspace/security/sso/shiro-sso-oidc-default.ini
+++ b/src/main/resources/org/researchspace/security/sso/shiro-sso-oidc-default.ini
@@ -75,18 +75,18 @@ config.clients = $clients
 subjectFactory = io.buji.pac4j.subject.Pac4jSubjectFactory
 securityManager.subjectFactory = $subjectFactory
 
-securityFilter = io.buji.pac4j.filter.SecurityFilter
+securityFilter = io.buji.pac4j.jee.filter.SecurityFilter
 securityFilter.config = $config
 securityFilter.clients = OidcClient
 
 # override authorizers to disable CSRF one which is enabled by default, we can't use default CSRF implementation from pac4j because we send many requests in parallel. For pac4j one to work one would need to send requests synchronously  
 securityFilter.authorizers = isAuthenticated
 
-callbackFilter = io.buji.pac4j.filter.CallbackFilter
+callbackFilter = io.buji.pac4j.jee.filter.CallbackFilter
 callbackFilter.defaultClient = OidcClient
 callbackFilter.config = $config
 
-logoutFilter = io.buji.pac4j.filter.LogoutFilter
+logoutFilter = io.buji.pac4j.jee.filter.LogoutFilter
 logoutFilter.config = $config
 logoutFilter.localLogout = true
 logoutFilter.centralLogout = $centralLogout

--- a/src/main/resources/org/researchspace/security/sso/shiro-sso-saml2-default.ini
+++ b/src/main/resources/org/researchspace/security/sso/shiro-sso-saml2-default.ini
@@ -70,18 +70,18 @@ shiroRealm.principalNameAttribute = $principalNameAttribute
 subjectFactory = io.buji.pac4j.subject.Pac4jSubjectFactory
 securityManager.subjectFactory = $subjectFactory
 
-securityFilter = io.buji.pac4j.filter.SecurityFilter
+securityFilter = io.buji.pac4j.jee.filter.SecurityFilter
 securityFilter.config = $config
 securityFilter.clients = SAML2Client
 
 # override authorizers to disable CSRF one which is enabled by default, we can't use default CSRF implementation from pac4j because we send many requests in parallel. For pac4j one to work one would need to send requests synchronously  
 securityFilter.authorizers = isAuthenticated
 
-callbackFilter = io.buji.pac4j.filter.CallbackFilter
+callbackFilter = io.buji.pac4j.jee.filter.CallbackFilter
 callbackFilter.defaultClient = SAML2Client
 callbackFilter.config = $config
 
-logoutFilter = io.buji.pac4j.filter.LogoutFilter
+logoutFilter = io.buji.pac4j.jee.filter.LogoutFilter
 logoutFilter.config = $config
 logoutFilter.localLogout = true
 logoutFilter.centralLogout = $centralLogout


### PR DESCRIPTION
# Why

Earlier updates to the security libraries were not reflected in the default shiro.ini files. 

# What

References to io.buji.pac4j.filter where changed to io.buji.pac4j.jee.filter

# How To Test

In a deployment that uses -Dconfig.environment.sso=saml2 starting researchspace should work without the following error ```org.apache.shiro.config.ConfigurationException: Unable to instantiate class [io.buji.pac4j.filter.SecurityFilter] for object named 'securityFilter'.  Please ensure you've specified the fully qualified class name correctly.```
