### PR TITLE
Fixed overflow style on form details tab

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FFormAssetSidebar.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FFormAssetSidebar.html
@@ -1,5 +1,5 @@
 
-<div style="margin-top: 20px;">
+<div class="form-details-assets-container">
 
     <div class="customFormHeader" style="padding-top: 0;">Related media/resources</div>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAcquisition.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAcquisition.html
@@ -74,7 +74,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Acquisition name" placeholder="Enter acquisition name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline=true label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FActivity.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FActivity.html
@@ -70,7 +70,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Activity name" placeholder="Enter activity name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FActor.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FActor.html
@@ -70,7 +70,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             {{#if apiResourceName}}
               <div class="focused-input-container">
                 <semantic-form-text-input for="entity_primary_appellation" label="Full name" placeholder="Enter actor full name / known as" default-value="{{apiResourceName}}" force-defaults=true> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAppellation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAppellation.html
@@ -69,7 +69,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="symbolic_object_content" multiline=true label="Appellation content/value" placeholder="Enter the complete, identifying representation of the appellation content"></semantic-form-text-input>
 
             <semantic-form-select-input  for='appellation_type' 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAttributeAssignment.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAttributeAssignment.html
@@ -73,7 +73,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Attribute assignment name" placeholder="Enter attribute assignment name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBeginningOfExistence.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBeginningOfExistence.html
@@ -56,7 +56,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Beginning of existence name" placeholder="Enter beginning of existence name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBiologicalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBiologicalObject.html
@@ -91,7 +91,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                                 <semantic-form-text-input for="entity_primary_appellation" label="Biological object name" placeholder="Enter biological object name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBirth.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBirth.html
@@ -59,7 +59,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
     <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-            <div style="overflow-x: auto;">
+            <div class="form-details-inputs-container">
                 <semantic-form-text-input for="entity_primary_appellation" label="Birth name" placeholder="Enter birth name"></semantic-form-text-input>
 
                 <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCollection.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCollection.html
@@ -98,7 +98,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                                 <semantic-form-text-input for="entity_primary_appellation" label="Collection name" placeholder="Enter collection name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConceptualObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConceptualObject.html
@@ -57,7 +57,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Conceptual object name" placeholder="Enter conceptual object name"></semantic-form-text-input>
             
             <div class="inline-composite-container">

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConditionAssessment.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConditionAssessment.html
@@ -76,7 +76,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Condition assessment name" placeholder="Enter condition assessment name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConditionState.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConditionState.html
@@ -51,7 +51,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <semantic-form-text-input for="entity_primary_appellation" label="Condition state name" placeholder="Enter condition state name"></semantic-form-text-input>
 
                         <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCreation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCreation.html
@@ -73,7 +73,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
           <rs-tab event-key="detail" title="Details">
             <div class="form-details-container">
-              <div style="overflow-x: auto;">
+              <div class="form-details-inputs-container">
                 <semantic-form-text-input for="entity_primary_appellation" label="Creation name" placeholder="Enter creation name"></semantic-form-text-input>
 
                 <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCurationActivity.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCurationActivity.html
@@ -70,7 +70,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Curation activity name" placeholder="Enter curation activity name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCurrency.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCurrency.html
@@ -78,7 +78,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_prefLabel" label="Preferred name" placeholder="Enter preferred name"></semantic-form-text-input>
             
             <semantic-form-text-input for="entity_altLabel" label="Alternative name" placeholder="Enter alternative name"> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDeath.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDeath.html
@@ -57,7 +57,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Death name" placeholder="Enter death name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDesignOrProcedure.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDesignOrProcedure.html
@@ -79,7 +79,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Design or procedure name" placeholder="Enter design or procedure name"></semantic-form-text-input>
 
             <div class="inline-composite-container">

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDestruction.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDestruction.html
@@ -57,7 +57,7 @@
       <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
         <rs-tab event-key="detail" title="Details">
           <div class="form-details-container">
-            <div style="overflow-x: auto;">
+            <div class="form-details-inputs-container">
               <semantic-form-text-input for="entity_primary_appellation" label="Destruction name" placeholder="Enter destruction name"></semantic-form-text-input>
 
               <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDimension.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDimension.html
@@ -54,7 +54,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <semantic-form-text-input for="entity_primary_appellation" label="Dimension name" placeholder="Enter dimension name"></semantic-form-text-input>
                     
                         <semantic-form-select-input for='dimension_type' 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDissolution.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDissolution.html
@@ -57,7 +57,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
           <semantic-form-text-input for="entity_primary_appellation" label="Dissolution name" placeholder="Enter dissolution name"></semantic-form-text-input>
 
           <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEndOfExistence.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEndOfExistence.html
@@ -56,7 +56,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="End of existence name" placeholder="Enter end of existence name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEntity_partial.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEntity_partial.html
@@ -51,7 +51,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <div>
                             {{#if node}} 
                                 {{> @partial-block }}                                           

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEvent.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEvent.html
@@ -54,7 +54,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Event name" placeholder="Enter event name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FExhibition.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FExhibition.html
@@ -74,7 +74,7 @@
         
         <rs-tab event-key="detail" title="Details">
           <div class="form-details-container">
-            <div style="overflow-x: auto;">
+            <div class="form-details-inputs-container">
               <semantic-form-text-input for="entity_primary_appellation" label="Exhibition name" placeholder="Enter exhibition name"></semantic-form-text-input>
               
               <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FFormation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FFormation.html
@@ -74,7 +74,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Formation name" placeholder="Enter formation name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FGroup.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FGroup.html
@@ -78,7 +78,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
         <rs-tab event-key="detail" title="Details">
           <div class="form-details-container">
-            <div style="overflow-x: auto;">
+            <div class="form-details-inputs-container">
               {{#if apiResourceName}}
                 <div class="focused-input-container">
                   <semantic-form-text-input for="entity_primary_appellation" label="Full name" placeholder="Enter group full name / known as" default-value="{{apiResourceName}}" force-defaults=true> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeFeature.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeFeature.html
@@ -94,7 +94,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                                 <semantic-form-text-input for="entity_primary_appellation" label="Human-made feature name" placeholder="Enter human-made feature name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeObject.html
@@ -100,7 +100,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                                 <semantic-form-text-input for="entity_primary_appellation" label="Human-made object name" placeholder="Enter human-made object name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeThing.html
@@ -53,7 +53,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <semantic-form-text-input for="entity_primary_appellation" label="Human-made thing name" placeholder="Enter human-made thing name"> </semantic-form-text-input>
                         <semantic-form-text-input for="entity_description" label="Human-made thing description" placeholder="Enter description/comment" multiline='true'> </semantic-form-text-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FIdentifier.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FIdentifier.html
@@ -72,7 +72,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <div class="form-inline-inputs" style="align-items: flex-end;">
                             <div style="flex: 1;">
                                 <semantic-form-text-input for="symbolic_object_content" label="Identifier value" placeholder="Enter identifier value"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FIdentifierAssignment.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FIdentifierAssignment.html
@@ -77,7 +77,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Identifier assignment name" placeholder="Enter identifier assignment name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FInformationObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FInformationObject.html
@@ -73,7 +73,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Information object name" placeholder="Enter information object name"></semantic-form-text-input>
 
             <div class="inline-composite-container">

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FInscription.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FInscription.html
@@ -78,7 +78,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="symbolic_object_content" multiline=true label="Inscription content/value" placeholder="Enter the complete, identifying representation of its content"></semantic-form-text-input>
             
             <semantic-form-autocomplete-input for='linguistic_object_has_language' 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FJoining.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FJoining.html
@@ -71,7 +71,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Joining name" placeholder="Enter joining name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FKnowledgeMap.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FKnowledgeMap.html
@@ -57,7 +57,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
           <rs-tab event-key="detail" title="Details">
             <div class="form-details-container">
-              <div style="overflow-x: auto;">
+              <div class="form-details-inputs-container">
                 <semantic-form-text-input for="entity_description" multiline=true label="Description" placeholder="Enter description/comment"></semantic-form-text-input>
     
                 <semantic-form-autocomplete-input   for="entity_preferred_id" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLanguage.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLanguage.html
@@ -77,7 +77,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_prefLabel" label="Preferred name" placeholder="Enter preferred name"></semantic-form-text-input>
             
             <semantic-form-text-input for="entity_altLabel" label="Alternative name" placeholder="Enter alternative name"> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLeaving.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLeaving.html
@@ -71,7 +71,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Leaving name" placeholder="Enter leaving name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLegalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLegalObject.html
@@ -56,7 +56,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <semantic-form-text-input for="entity_primary_appellation" label="Legal object name" placeholder="Enter legal object name"> </semantic-form-text-input>
                         <semantic-form-text-input for="entity_description" label="Legal object description" placeholder="Enter description/comment" multiline='true'> </semantic-form-text-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLinguisticObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLinguisticObject.html
@@ -75,7 +75,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="symbolic_object_content" multiline=true label="Content/value" placeholder="Enter the complete, identifying representation of its content"></semantic-form-text-input>
             
             <semantic-form-autocomplete-input for='linguistic_object_has_language' 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMark.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMark.html
@@ -76,7 +76,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Mark name" placeholder="Enter mark name"></semantic-form-text-input>
 
             <div class="inline-composite-container">

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMaterial.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMaterial.html
@@ -77,7 +77,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_prefLabel" label="Preferred name" placeholder="Enter preferred name"></semantic-form-text-input>
             
             <semantic-form-text-input for="entity_altLabel" label="Alternative name" placeholder="Enter alternative name"> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMeasurement.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMeasurement.html
@@ -76,7 +76,7 @@
       <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
         <rs-tab event-key="detail" title="Details">
           <div class="form-details-container">
-            <div style="overflow-x: auto;">
+            <div class="form-details-inputs-container">
               <semantic-form-text-input for="entity_primary_appellation" label="Measurement name" placeholder="Enter measurement name"></semantic-form-text-input>
 
               <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMeasurementUnit.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMeasurementUnit.html
@@ -76,7 +76,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_prefLabel" label="Preferred name" placeholder="Enter preferred name"></semantic-form-text-input>
             
             <semantic-form-text-input for="entity_altLabel" label="Alternative name" placeholder="Enter alternative name"> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FModification.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FModification.html
@@ -71,7 +71,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Modification name" placeholder="Enter modification name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMonetaryAmount.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMonetaryAmount.html
@@ -55,7 +55,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <semantic-form-text-input for="entity_primary_appellation" label="Monetary amount name" placeholder="Enter monetary amount name"></semantic-form-text-input>
                 
                         

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMove.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMove.html
@@ -72,7 +72,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Move name" placeholder="Enter move name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FOrganisation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FOrganisation.html
@@ -109,7 +109,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                             <semantic-form-text-input for="entity_primary_appellation" label="Organisation name" placeholder="Enter organisation name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPartAddition.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPartAddition.html
@@ -73,7 +73,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Part addition name" placeholder="Enter part addition name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPartRemoval.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPartRemoval.html
@@ -74,7 +74,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Part removal name" placeholder="Enter part removal name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPeriod.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPeriod.html
@@ -50,7 +50,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Period name" placeholder="Enter period name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPersistentItem.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPersistentItem.html
@@ -47,7 +47,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <semantic-form-text-input for="entity_primary_appellation" label="Persistent item name" placeholder="Enter persistent item name"> </semantic-form-text-input>
                         <semantic-form-text-input for="entity_description" label="Persistent item description" placeholder="Enter description/comment" multiline='true'> </semantic-form-text-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPerson.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPerson.html
@@ -82,7 +82,7 @@
       <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
           <rs-tab event-key="detail" title="Details">
             <div class="form-details-container">
-              <div style="overflow-x: auto;">
+              <div class="form-details-inputs-container">
                 {{#if apiResourceName}}
                     <div class="focused-input-container">
                         <semantic-form-text-input for="entity_primary_appellation" label="Full name" placeholder="Enter person full name / known as" default-value="{{apiResourceName}}" force-defaults=true> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalFeature.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalFeature.html
@@ -85,7 +85,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                                 <semantic-form-text-input for="entity_primary_appellation" label="Physical feature name" placeholder="Enter physical feature name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalHumanMadeThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalHumanMadeThing.html
@@ -93,7 +93,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                                 <semantic-form-text-input for="entity_primary_appellation" label="Physical human-made thing name" placeholder="Enter physical human-made thing name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalObject.html
@@ -91,7 +91,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                                 <semantic-form-text-input for="entity_primary_appellation" label="Physical object name" placeholder="Enter physical object name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalThing.html
@@ -82,7 +82,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <semantic-form-text-input for="entity_primary_appellation" label="Physical thing name" placeholder="Enter physical thing name"> </semantic-form-text-input>
                         <semantic-form-text-input for="entity_description" label="Description" placeholder="Enter description/comment" multiline='true'> </semantic-form-text-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPlace.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPlace.html
@@ -74,7 +74,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             {{#if apiResourceName}}
               <div class="focused-input-container">
                 <semantic-form-text-input for="entity_primary_appellation" label="Place name" placeholder="Enter place name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProductType.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProductType.html
@@ -77,7 +77,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_prefLabel" label="Preferred name" placeholder="Enter preferred name"></semantic-form-text-input>
             
             <semantic-form-text-input for="entity_altLabel" label="Alternative name" placeholder="Enter alternative name"> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProduction.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProduction.html
@@ -75,7 +75,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Production name" placeholder="Enter production name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProject_partial.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProject_partial.html
@@ -74,7 +74,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Project name" placeholder="Enter project name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPropositionalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPropositionalObject.html
@@ -63,7 +63,7 @@
             <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
                 <rs-tab event-key="detail" title="Details">
                     <div class="form-details-container">
-                        <div style="overflow-x: auto;">
+                        <div class="form-details-inputs-container">
                             <semantic-form-text-input for="entity_primary_appellation" label="Propositional object name" placeholder="Enter propositional object name"></semantic-form-text-input>
 
                             <div class="inline-composite-container">

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPublication.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPublication.html
@@ -76,7 +76,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
 
             <semantic-form-text-input for="entity_primary_appellation" label="Publication name" placeholder="Enter publication name"></semantic-form-text-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPurchase.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPurchase.html
@@ -75,7 +75,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Purchase name" placeholder="Enter purchase name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline=true label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FResearchQuestion.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FResearchQuestion.html
@@ -64,7 +64,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
               <semantic-form-text-input for="entity_primary_appellation" label="Research question name" placeholder="Enter research question name"></semantic-form-text-input>
 
               <div class="inline-composite-container">

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FRight.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FRight.html
@@ -66,7 +66,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
 
                         <semantic-form-text-input for="entity_primary_appellation" label="Right name" placeholder="Enter right name"></semantic-form-text-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticNarrative.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticNarrative.html
@@ -56,7 +56,7 @@
           <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
               <div class="form-details-container">
-                <div style="overflow-x: auto;">
+                <div class="form-details-inputs-container">
                   <semantic-form-text-input for="entity_description" multiline=true label="Description" placeholder="Enter description/comment"></semantic-form-text-input>
     
                   <semantic-form-autocomplete-input   for="entity_preferred_id" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticTimeline.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticTimeline.html
@@ -56,7 +56,7 @@
             <rs-tab event-key="detail" title="Details">
                 [[> timelineSection ]]
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <semantic-form-text-input for="entity_description" multiline=true label="Description" placeholder="Enter description/comment"></semantic-form-text-input>
     
                         <semantic-form-autocomplete-input   for="entity_preferred_id" 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSeries.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSeries.html
@@ -94,7 +94,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                                 <semantic-form-text-input for="entity_primary_appellation" label="Series name" placeholder="Enter series name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSet.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSet.html
@@ -60,7 +60,7 @@
       <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
         <rs-tab event-key="detail" title="Details">
           <div class="form-details-container">
-            <div style="overflow-x: auto;">
+            <div class="form-details-inputs-container">
               [[!-- SETS ARE CONTAINERS EDITING THEIR LABEL REQUIRES IT IS DONE BY THE USER WHO CREATED THEM --]]
               [[!-- <semantic-form-text-input readonly for="set_title" label="Set name" placeholder="Enter set name"> 
                 </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSite.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSite.html
@@ -119,7 +119,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         {{#if apiResourceName}}
                             <div class="focused-input-container">
                                 <semantic-form-text-input for="entity_primary_appellation" label="Site name" placeholder="Enter site name" default-value="{{apiResourceName}}" force-defaults=true></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSymbolicObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSymbolicObject.html
@@ -67,7 +67,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Symbolic object name" placeholder="Enter symbolic object name"></semantic-form-text-input>
 
             <div class="inline-composite-container">

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FThing.html
@@ -53,7 +53,7 @@
         <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
             <rs-tab event-key="detail" title="Details">
                 <div class="form-details-container">
-                    <div style="overflow-x: auto;">
+                    <div class="form-details-inputs-container">
                         <semantic-form-text-input for="entity_primary_appellation" label="Thing name" placeholder="Enter thing name"> </semantic-form-text-input>
                         <semantic-form-text-input for="entity_description" label="Thing description" placeholder="Enter description/comment" multiline='true'> </semantic-form-text-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTimespan.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTimespan.html
@@ -55,7 +55,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for='timespan_text_value' label="Timespan (text value)" placeholder="Enter timespan (text value)"></semantic-form-text-input>
 
             <div class="form-inline-inputs">

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTitle.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTitle.html
@@ -77,7 +77,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="symbolic_object_content" multiline=true label="Title content/value" placeholder="Enter the complete, identifying representation of the title content"></semantic-form-text-input>
             
             <semantic-form-autocomplete-input for='linguistic_object_has_language' 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTransferOfCustody.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTransferOfCustody.html
@@ -72,7 +72,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Transfer of custody name" placeholder="Enter transfer of custody name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTransformation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTransformation.html
@@ -60,7 +60,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Transformation name" placeholder="Enter transformation name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FType.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FType.html
@@ -75,7 +75,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_prefLabel" label="Preferred name" placeholder="Enter preferred name"></semantic-form-text-input>
             
             <semantic-form-text-input for="entity_altLabel" label="Alternative name" placeholder="Enter alternative name"> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTypeAssignment.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTypeAssignment.html
@@ -76,7 +76,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Type assignment name" placeholder="Enter type assignment name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTypeCreation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTypeCreation.html
@@ -75,7 +75,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs"> 
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Type creation name" placeholder="Enter type creation name"></semantic-form-text-input>
 
             <semantic-form-text-input for="entity_description" multiline="true" label="Description" placeholder="Enter description/comment"></semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FUser_partial.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FUser_partial.html
@@ -64,7 +64,7 @@
       <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
         <rs-tab event-key="detail" title="Details">
           <div class="form-details-container">
-            <div style="overflow-x: auto;">
+            <div class="form-details-inputs-container">
               <div class="form-inline-inputs"> 
                 <div style="flex: 1;">
                   <semantic-form-text-input for="entity_primary_appellation" label="Full name" placeholder="Enter full name"> </semantic-form-text-input>
@@ -589,7 +589,7 @@
       <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
         <rs-tab event-key="detail" title="Details">
           <div class="form-details-container">
-            <div>
+            <div class="form-details-inputs-container">
               <div class="form-inline-inputs"> 
                 <div style="flex: 1;">
                   <semantic-form-text-input for="entity_primary_appellation" label="First and Last name" placeholder="Enter full and last name"> </semantic-form-text-input>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FVisualItem.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FVisualItem.html
@@ -76,7 +76,7 @@
     <rs-tabs id="{{viewId}}-form-tabs" class-name="form-tabs">
       <rs-tab event-key="detail" title="Details">
         <div class="form-details-container">
-          <div style="overflow-x: auto;">
+          <div class="form-details-inputs-container">
             <semantic-form-text-input for="entity_primary_appellation" label="Visual item name" placeholder="Enter visual item name"></semantic-form-text-input>
 
             <div class="inline-composite-container">

--- a/src/main/web/components/forms/forms.scss
+++ b/src/main/web/components/forms/forms.scss
@@ -1392,11 +1392,13 @@ fieldset[disabled] .form-control {
 }
 
 .formResourceAsset-tabs {
-  height: 100%;
+
   margin-top: 1px; 
   margin-bottom: 0;
   display: flex;
   flex-direction: column;
+  gap: 5px;
+  flex: 1;
 
   .page__section-container.tab-content {
 
@@ -1404,6 +1406,7 @@ fieldset[disabled] .form-control {
     flex: 1;
     margin: 5px 0 0;
     padding: 12px 15px;
+    margin: 0;
   }
 
   .tab-pane-content {
@@ -1935,7 +1938,10 @@ fieldset[disabled] .form-control {
   display: grid; 
   grid-template-columns: 2fr minmax(385px, 1fr);
   gap: 20px;
+
+  height: inherit;
   width: 100%;
+
 }
 
 .tab-content:has(.form-details-container) {
@@ -1949,4 +1955,17 @@ fieldset[disabled] .form-control {
     grid-template-columns: 100%;
     gap: 0;
   }
+}
+
+.form-details-assets-container {
+
+  padding-top: 20px;
+
+  display: flex;
+  flex-direction: column;
+}
+
+.form-details-inputs-container {
+
+ // overflow-x: auto;
 }


### PR DESCRIPTION
# Why

In forms the content inside the details tab has overflow issues when the frame is resizing.
Style has been modified to extend to 100% the height of the main container and removing the inline overflow-x:auto