### PR TITLE
Dropdown with filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "researchspace-platform-release2",
+  "name": "researchspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "researchspace",
+  "name": "researchspace-platform-release2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FFormAssetSidebar.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FFormAssetSidebar.html
@@ -1112,6 +1112,7 @@
                                                     <semantic-form-autocomplete-input   for='represents_visualItem_domain' 
                                                                                         render-header="false"
                                                                                         placeholder="Select what visually represents the entity"
+                                                                                        show-dropdown-filter="false"
                                                                                         nested-form-templates='[[> Platform:NestedFormTemplates_visualItems]]'>
                                                     </semantic-form-autocomplete-input>
                                                 </div>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FFormAssetTab.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FFormAssetTab.html
@@ -493,6 +493,7 @@
                                                 <semantic-form-autocomplete-input   for='represents_visualItem_domain' 
                                                                                     render-header="false"
                                                                                     placeholder="Select what visually represents the entity"
+                                                                                    show-dropdown-filter="false"
                                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_visualItems]]'>
                                                 </semantic-form-autocomplete-input>
                                               </div>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2F3dModel.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2F3dModel.html
@@ -306,6 +306,7 @@
                 <semantic-form-autocomplete-input   for="entity_id" 
                                                     label="Other identifier"
                                                     placeholder="Select other identifier" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                 </semantic-form-autocomplete-input>
             </rs-tab>
@@ -668,6 +669,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the 3D model" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
       
@@ -678,6 +680,7 @@
                 <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                     label="Created by" 
                                                     placeholder="Select the event that created the 3D model" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
                 </semantic-form-autocomplete-input> 
         
@@ -810,6 +813,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the 3D model out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
         

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAcquisition.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAcquisition.html
@@ -157,6 +157,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -175,6 +176,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -189,12 +191,14 @@
         <semantic-form-autocomplete-input   for='acquisition_transferred_title_from' 
                                             label="Transferred title from" 
                                             placeholder="Select actor who relinquish ownership with the acquisition" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
         <semantic-form-autocomplete-input   for='acquisition_transferred_title_to' 
                                             label="Transferred title to" 
                                             placeholder="Select actor that acquires the ownership after the acquisition" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -216,6 +220,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -266,7 +271,8 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
-                                                      nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
+                                                      show-dropdown-filter="false"
+                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
                   <div style="flex: 1;">
@@ -301,6 +307,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FActivity.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FActivity.html
@@ -143,6 +143,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -161,6 +162,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -190,6 +192,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -240,6 +243,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -275,6 +279,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FActor.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FActor.html
@@ -196,6 +196,7 @@
             <semantic-form-autocomplete-input for='actor_residence' 
                                               label="Residence" 
                                               placeholder="Select current or former residence" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>  
             </semantic-form-autocomplete-input> 
 
@@ -214,6 +215,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 
@@ -506,6 +508,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the actor out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAppellation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAppellation.html
@@ -110,6 +110,7 @@
                   <semantic-form-autocomplete-input for='has_alternative_form_range' 
                                                     render-header="false"
                                                     placeholder="Select alternative form" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                   </semantic-form-autocomplete-input>
                 </div>
@@ -158,6 +159,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -373,6 +375,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the appellation" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -383,6 +386,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the appellation" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -515,6 +519,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the appellation out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAttributeAssignment.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAttributeAssignment.html
@@ -133,6 +133,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -151,6 +152,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -180,6 +182,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -230,6 +233,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -265,6 +269,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAudio.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAudio.html
@@ -205,6 +205,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                     </div>
@@ -568,6 +569,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the audio" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
             </rs-tab>
@@ -577,6 +579,7 @@
                 <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                     label="Created by" 
                                                     placeholder="Select the event that created the audio" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
                 </semantic-form-autocomplete-input> 
         
@@ -709,6 +712,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the audio out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
                 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAuthorityDocument_partial.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FAuthorityDocument_partial.html
@@ -183,6 +183,7 @@
         <semantic-form-autocomplete-input   for="entity_id" 
                                             label="Other identifier"
                                             placeholder="Select other identifier" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
         </semantic-form-autocomplete-input>
 
@@ -1050,6 +1051,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the authority document" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -1060,6 +1062,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the authority document" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -1192,6 +1195,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the authority document out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBeginningOfExistence.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBeginningOfExistence.html
@@ -81,6 +81,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -99,6 +100,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 
@@ -114,6 +116,7 @@
         <semantic-form-autocomplete-input   for='beginning_of_existence_actor' 
                                             label="Brought into existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -135,6 +138,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -170,6 +174,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
       </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBiologicalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBiologicalObject.html
@@ -249,6 +249,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                         {{/if}}
@@ -519,12 +520,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the biological object at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the biological object" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -537,6 +540,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the biological object at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -544,6 +548,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the biological object"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -596,6 +601,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the biological object" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -606,30 +612,35 @@
                 <semantic-form-autocomplete-input   for='physical_object_current_permanent_location' 
                                                     label="Current permanent location" 
                                                     placeholder="Select the place reserved as the current permanent location of the biological object"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_object_current_location' 
                                                     label="Current location" 
                                                     placeholder="Select a place as the current location of the biological object"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the biological object"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the biological object is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the biological object has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -781,6 +792,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the biological object out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBirth.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FBirth.html
@@ -84,6 +84,7 @@
                 <semantic-form-autocomplete-input   for="period_place" 
                                                     label="Place" 
                                                     placeholder="Select place"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
@@ -102,6 +103,7 @@
                 <semantic-form-autocomplete-input   for="entity_id" 
                                                     label="Other identifier"
                                                     placeholder="Select other identifier" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                 </semantic-form-autocomplete-input>
 
@@ -153,6 +155,7 @@
         <semantic-form-autocomplete-input   for='beginning_of_existence_actor' 
                                             label="Brought into existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -174,6 +177,7 @@
                         <semantic-form-autocomplete-input for='participant_range'  
                                                         render-header="false"
                                                         placeholder="Select actor" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                         </semantic-form-autocomplete-input> 
                     </div>
@@ -209,6 +213,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
     </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCollection.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCollection.html
@@ -311,6 +311,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                     {{/if}}
@@ -518,6 +519,7 @@
                 <semantic-form-select-input for='collection_has_curator' 
                                             label="Current or former curator" 
                                             placeholder="Select actor who assumed or have assumed overall curatorial responsibility for the collection" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                 </semantic-form-select-input> 
 
@@ -529,12 +531,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the collection at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the collection" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -547,6 +551,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the collection at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -554,6 +559,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the collection"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -606,6 +612,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the collection" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -616,18 +623,21 @@
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the collection"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the collection is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the collection has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -881,6 +891,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the collection out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
@@ -1162,6 +1173,7 @@
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_visual_item' 
                                                     label="Shows visual item" 
                                                     placeholder="Select visual item shown by the collection" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_visualItems]]'> 
                 </semantic-form-autocomplete-input> 
             </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConceptualObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConceptualObject.html
@@ -132,6 +132,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -178,6 +179,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the conceptual object" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -297,6 +299,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the conceptual object out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConditionAssessment.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConditionAssessment.html
@@ -149,6 +149,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -167,6 +168,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -211,6 +213,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -261,6 +264,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -296,6 +300,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConditionState.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FConditionState.html
@@ -88,6 +88,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCreation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCreation.html
@@ -133,6 +133,7 @@
                 <semantic-form-autocomplete-input for="period_place" 
                                                   label="Place" 
                                                   placeholder="Select place"
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
@@ -151,6 +152,7 @@
                 <semantic-form-autocomplete-input   for="entity_id" 
                                                     label="Other identifier"
                                                     placeholder="Select other identifier" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                 </semantic-form-autocomplete-input>
               </div>
@@ -165,6 +167,7 @@
             <semantic-form-autocomplete-input   for='beginning_of_existence_actor' 
                                                 label="Brought into existence" 
                                                 placeholder="Select actor" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
             </semantic-form-autocomplete-input> 
 
@@ -186,6 +189,7 @@
                     <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -236,6 +240,7 @@
                         <semantic-form-autocomplete-input for='participant_range'  
                                                           render-header="false"
                                                           placeholder="Select actor" 
+                                                          show-dropdown-filter="false"
                                                           nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                         </semantic-form-autocomplete-input> 
                       </div>
@@ -271,6 +276,7 @@
             <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                                 label="Occurred in the presence of" 
                                                 placeholder="Select actor" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
             </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCurationActivity.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCurationActivity.html
@@ -130,6 +130,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -148,6 +149,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -177,6 +179,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -227,6 +230,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -262,6 +266,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCurrency.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FCurrency.html
@@ -157,6 +157,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -493,6 +494,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the currency" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -612,6 +614,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the currency out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDeath.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDeath.html
@@ -82,6 +82,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -100,6 +101,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 
@@ -128,6 +130,7 @@
         <semantic-form-autocomplete-input   for='end_of_existence_actor' 
                                             label="Took out of existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -149,6 +152,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -184,6 +188,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
       </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDesignOrProcedure.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDesignOrProcedure.html
@@ -156,6 +156,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -542,6 +543,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the design or procedure" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -552,6 +554,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the design or procedure" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -690,6 +693,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the design or procedure out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDestruction.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDestruction.html
@@ -82,6 +82,7 @@
               <semantic-form-autocomplete-input for="period_place" 
                                                 label="Place" 
                                                 placeholder="Select place"
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
               </semantic-form-autocomplete-input>
 
@@ -100,6 +101,7 @@
               <semantic-form-autocomplete-input   for="entity_id" 
                                                   label="Other identifier"
                                                   placeholder="Select other identifier" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
               </semantic-form-autocomplete-input>
 
@@ -115,6 +117,7 @@
           <semantic-form-autocomplete-input   for='end_of_existence_actor' 
                                               label="Took out of existence" 
                                               placeholder="Select actor" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
           </semantic-form-autocomplete-input> 
 
@@ -136,6 +139,7 @@
                       <semantic-form-autocomplete-input for='participant_range'  
                                                         render-header="false"
                                                         placeholder="Select actor" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                       </semantic-form-autocomplete-input> 
                     </div>
@@ -171,6 +175,7 @@
           <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                               label="Occurred in the presence of" 
                                               placeholder="Select actor" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
           </semantic-form-autocomplete-input> 
         </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDimension.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDimension.html
@@ -122,6 +122,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                         

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDissolution.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDissolution.html
@@ -82,6 +82,7 @@
           <semantic-form-autocomplete-input for="period_place" 
                                             label="Place" 
                                             placeholder="Select place"
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
           </semantic-form-autocomplete-input>
 
@@ -100,6 +101,7 @@
           <semantic-form-autocomplete-input   for="entity_id" 
                                               label="Other identifier"
                                               placeholder="Select other identifier" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
           </semantic-form-autocomplete-input>
 
@@ -127,6 +129,7 @@
         <semantic-form-autocomplete-input   for='end_of_existence_actor' 
                                             label="Took out of existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -148,6 +151,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -183,6 +187,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
       </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDocument.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDocument.html
@@ -253,6 +253,7 @@
         <semantic-form-autocomplete-input   for="entity_id" 
                                             label="Other identifier"
                                             placeholder="Select other identifier" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
         </semantic-form-autocomplete-input>
 
@@ -667,6 +668,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the document" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -677,6 +679,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the document" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -809,6 +812,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the document out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEndOfExistence.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEndOfExistence.html
@@ -81,6 +81,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -98,7 +99,8 @@
 
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
-                                                placeholder="Select other identifier" 
+                                                placeholder="Select other identifier"
+                                                show-dropdown-filter="false" 
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 
@@ -114,6 +116,7 @@
         <semantic-form-autocomplete-input   for='end_of_existence_actor' 
                                             label="Took out of existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -135,6 +138,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -170,6 +174,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
       </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEntity_partial.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEntity_partial.html
@@ -75,6 +75,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                         

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEvent.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FEvent.html
@@ -79,6 +79,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -97,6 +98,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 
@@ -127,6 +129,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -162,6 +165,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
       </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FExhibition.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FExhibition.html
@@ -170,6 +170,7 @@
               <semantic-form-autocomplete-input for="period_place" 
                                                 label="Place" 
                                                 placeholder="Select place"
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
               </semantic-form-autocomplete-input>
   
@@ -188,6 +189,7 @@
               <semantic-form-autocomplete-input   for="entity_id" 
                                                   label="Other identifier"
                                                   placeholder="Select other identifier" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
               </semantic-form-autocomplete-input>
             </div>
@@ -217,6 +219,7 @@
                   <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                     render-header="false"
                                                     placeholder="Select actor" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                   </semantic-form-autocomplete-input> 
                 </div>
@@ -267,6 +270,7 @@
                       <semantic-form-autocomplete-input for='participant_range'  
                                                         render-header="false"
                                                         placeholder="Select actor" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                       </semantic-form-autocomplete-input> 
                     </div>
@@ -302,6 +306,7 @@
           <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                               label="Occurred in the presence of" 
                                               placeholder="Select actor" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
           </semantic-form-autocomplete-input> 
   

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FFormation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FFormation.html
@@ -134,6 +134,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -152,6 +153,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -192,6 +194,7 @@
         <semantic-form-autocomplete-input   for='beginning_of_existence_actor' 
                                             label="Brought into existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -213,6 +216,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -263,6 +267,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -298,6 +303,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FGroup.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FGroup.html
@@ -204,6 +204,7 @@
               <semantic-form-autocomplete-input for='actor_residence' 
                                                 label="Residence" 
                                                 placeholder="Select current or former residence" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>  
               </semantic-form-autocomplete-input> 
 
@@ -222,6 +223,7 @@
               <semantic-form-autocomplete-input   for="entity_id" 
                                                   label="Other identifier"
                                                   placeholder="Select other identifier" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
               </semantic-form-autocomplete-input>
 
@@ -350,6 +352,7 @@
                       <semantic-form-autocomplete-input for='has_member_actor_range' 
                                                         render-header="false"
                                                         placeholder="Select the actor that is or has been a member of the group" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                       </semantic-form-autocomplete-input>
                     </div>
@@ -650,6 +653,7 @@
           <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                               label="Taken out of existence by" 
                                               placeholder="Select event that took the group out of existence" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
           </semantic-form-autocomplete-input>
   

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeFeature.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeFeature.html
@@ -307,6 +307,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                         {{/if}}
@@ -517,12 +518,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the human-made feature at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the human-made feature" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -535,6 +538,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the human-made feature at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -542,6 +546,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the human-made feature"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -594,6 +599,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the human-made feature" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -604,18 +610,21 @@
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the human-made feature"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the human-made feature is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the human-made feature has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -856,6 +865,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the human-made feature out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
@@ -1143,6 +1153,7 @@
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_visual_item' 
                                                     label="Shows visual item" 
                                                     placeholder="Select visual item shown by the human-made feature" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_visualItems]]'> 
                 </semantic-form-autocomplete-input> 
             </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeObject.html
@@ -313,6 +313,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                         {{/if}}
@@ -591,12 +592,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the human-made object at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the human-made object" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -609,6 +612,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the human-made object at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -616,6 +620,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the human-made object"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -668,6 +673,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the human-made object" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -678,30 +684,35 @@
                 <semantic-form-autocomplete-input   for='physical_object_current_permanent_location' 
                                                     label="Current permanent location" 
                                                     placeholder="Select the place reserved as the current permanent location of the human-made object"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_object_current_location' 
                                                     label="Current location" 
                                                     placeholder="Select a place as the current location of the human-made object"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the human-made object"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the human-made object is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the human-made object has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -942,6 +953,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the human-made object out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
@@ -1244,6 +1256,7 @@
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_visual_item' 
                                                     label="Shows visual item" 
                                                     placeholder="Select visual item shown by the human-made object" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_visualItems]]'> 
                 </semantic-form-autocomplete-input> 
             </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FHumanMadeThing.html
@@ -72,6 +72,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                         
@@ -175,6 +176,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the human-made thing out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FIdentifier.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FIdentifier.html
@@ -121,9 +121,10 @@
                     
                             <div class="form-inline-inputs">
                                 <div style="flex: 1;">
-                                <semantic-form-autocomplete-input for='has_alternative_form_range' 
+                                <semantic-form-autocomplete-input   for='has_alternative_form_range' 
                                                                     render-header="false"
                                                                     placeholder="Select alternative form" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                                 </semantic-form-autocomplete-input>
                                 </div>
@@ -173,6 +174,7 @@
                     <semantic-form-autocomplete-input   for="entity_id" 
                                                         label="Other identifier"
                                                         placeholder="Select other identifier" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                     </semantic-form-autocomplete-input>
                     --]]
@@ -390,6 +392,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the identifier" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -426,6 +429,7 @@
                 <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                     label="Created by" 
                                                     placeholder="Select the event that created the identifier" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
                 </semantic-form-autocomplete-input> 
 
@@ -558,6 +562,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the identifier out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FIdentifierAssignment.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FIdentifierAssignment.html
@@ -137,6 +137,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -155,6 +156,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -211,6 +213,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -261,6 +264,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -296,6 +300,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FImage.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FImage.html
@@ -183,6 +183,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                     </div>
@@ -784,6 +785,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the image" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
             </rs-tab>
@@ -793,6 +795,7 @@
                 <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                     label="Created by" 
                                                     placeholder="Select the event that created the image" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
                 </semantic-form-autocomplete-input> 
         
@@ -925,6 +928,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the image out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
         

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FImageAnnotation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FImageAnnotation.html
@@ -171,6 +171,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -228,6 +229,7 @@
           <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                               label="Right held by" 
                                               placeholder="Select actor who holds legal right on the image annotation" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
           </semantic-form-autocomplete-input> 
 
@@ -238,6 +240,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the image annotation" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -370,6 +373,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the image annotation out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FInformationObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FInformationObject.html
@@ -150,6 +150,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -518,6 +519,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the information object" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -528,6 +530,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the information object" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -660,6 +663,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the information object out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FInscription.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FInscription.html
@@ -95,12 +95,14 @@
             <semantic-form-autocomplete-input   for='linguistic_object_has_translation' 
                                                 label="Translation" 
                                                 placeholder="Select translation" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_linguisticObjects]]'> 
             </semantic-form-autocomplete-input> 
 
             <semantic-form-autocomplete-input   for='linguistic_object_is_translation_of' 
                                                 label="Is translation of" 
                                                 placeholder="Select linguistic object that has this as translation" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_linguisticObjects]]'> 
             </semantic-form-autocomplete-input> 
 
@@ -247,6 +249,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 
@@ -618,6 +621,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the inscription" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -628,6 +632,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the inscription" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -760,6 +765,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the inscription out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FJoining.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FJoining.html
@@ -131,6 +131,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -149,6 +150,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -163,6 +165,7 @@
         <semantic-form-autocomplete-input   for='joining_joined' 
                                             label="Joined by" 
                                             placeholder="Select actor that becomes member of the group" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -238,6 +241,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -288,6 +292,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -323,6 +328,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FKnowledgeMap.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FKnowledgeMap.html
@@ -75,6 +75,7 @@
                 <semantic-form-autocomplete-input   for="entity_id" 
                                                     label="Other identifier"
                                                     placeholder="Select other identifier" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -101,6 +102,7 @@
             <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                 label="Right held by" 
                                                 placeholder="Select actor who holds legal right on the knowledge map" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
             </semantic-form-autocomplete-input> 
   
@@ -111,6 +113,7 @@
             <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                 label="Created by" 
                                                 placeholder="Select the event that created the knowledge map" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
             </semantic-form-autocomplete-input> 
   
@@ -243,6 +246,7 @@
             <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                 label="Taken out of existence by" 
                                                 placeholder="Select event that took the knowledge map out of existence" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
             </semantic-form-autocomplete-input>
   

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLanguage.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLanguage.html
@@ -138,6 +138,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -151,6 +152,7 @@
         <semantic-form-autocomplete-input   for='language_language_of' 
                                             label="Is language of" 
                                             placeholder="Select linguistic object that is expressed, at least partially, in this language" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_linguisticObjects]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -483,6 +485,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the language" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -602,6 +605,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the language out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLeaving.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLeaving.html
@@ -131,6 +131,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -149,6 +150,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -163,6 +165,7 @@
         <semantic-form-autocomplete-input   for='leaving_separated' 
                                             label="Separated" 
                                             placeholder="Select actor that leaves a group" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input>
 
@@ -197,6 +200,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -247,6 +251,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -282,6 +287,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLegalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLegalObject.html
@@ -75,6 +75,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                         
@@ -128,6 +129,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the legal object" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
         
@@ -201,6 +203,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the legal object out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLinguisticObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FLinguisticObject.html
@@ -92,12 +92,14 @@
             <semantic-form-autocomplete-input   for='linguistic_object_has_translation' 
                                                 label="Translation" 
                                                 placeholder="Select translation" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_linguisticObjects]]'> 
             </semantic-form-autocomplete-input> 
 
             <semantic-form-autocomplete-input   for='linguistic_object_is_translation_of' 
                                                 label="Is translation of" 
                                                 placeholder="Select linguistic object that has this as translation" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_linguisticObjects]]'> 
             </semantic-form-autocomplete-input> 
             
@@ -171,6 +173,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 
@@ -541,6 +544,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the linguistic object" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -551,6 +555,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the linguistic object" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -683,6 +688,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the linguistic object out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMark.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMark.html
@@ -226,6 +226,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -594,6 +595,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the mark" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -604,6 +606,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the mark" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -736,6 +739,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the mark out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMaterial.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMaterial.html
@@ -138,6 +138,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -474,6 +475,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the material" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -593,6 +595,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the material out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMeasurement.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMeasurement.html
@@ -148,6 +148,7 @@
               <semantic-form-autocomplete-input for="period_place" 
                                                 label="Place" 
                                                 placeholder="Select place"
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
               </semantic-form-autocomplete-input>
 
@@ -166,6 +167,7 @@
               <semantic-form-autocomplete-input   for="entity_id" 
                                                   label="Other identifier"
                                                   placeholder="Select other identifier" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
               </semantic-form-autocomplete-input>
             </div>
@@ -220,6 +222,7 @@
                   <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                     render-header="false"
                                                     placeholder="Select actor" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                   </semantic-form-autocomplete-input> 
                 </div>
@@ -270,6 +273,7 @@
                       <semantic-form-autocomplete-input for='participant_range'  
                                                         render-header="false"
                                                         placeholder="Select actor" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                       </semantic-form-autocomplete-input> 
                     </div>
@@ -305,6 +309,7 @@
           <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                               label="Occurred in the presence of" 
                                               placeholder="Select actor" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
           </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMeasurementUnit.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMeasurementUnit.html
@@ -155,6 +155,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -488,6 +489,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the measurement unit" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -607,6 +609,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the measurement unit out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FModification.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FModification.html
@@ -131,6 +131,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -149,6 +150,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -178,6 +180,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -228,6 +231,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -263,6 +267,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMonetaryAmount.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMonetaryAmount.html
@@ -122,6 +122,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                         

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMove.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMove.html
@@ -132,18 +132,21 @@
             <semantic-form-autocomplete-input for="move_from_place" 
                                               label="Move from place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
             <semantic-form-autocomplete-input for="move_to_place" 
                                               label="Move to place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
             
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -162,6 +165,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -191,6 +195,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -241,6 +246,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -276,6 +282,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FOrganisation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FOrganisation.html
@@ -213,6 +213,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                     </div>
@@ -242,31 +243,36 @@
                 <semantic-form-autocomplete-input   for="place_overlaps_with_place" 
                                                     label="Overlap with place" 
                                                     placeholder="Enter place name"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
     
                 <semantic-form-autocomplete-input   for="place_borders_with_place" 
                                                     label="Borders with place" 
                                                     placeholder="Enter place name"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for="place_approximates_place" 
                                                     label="Approximates place" 
                                                     placeholder="Enter place name"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for="place_approximated_by_place" 
                                                     label="Is approximates by place" 
                                                     placeholder="Enter place name"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input for='actor_residence' 
-                                                label="Residence" 
-                                                placeholder="Select current or former residence" 
-                                                nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>  
+                <semantic-form-autocomplete-input   for='actor_residence' 
+                                                    label="Residence" 
+                                                    placeholder="Select current or former residence" 
+                                                    show-dropdown-filter="false"
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>  
                 </semantic-form-autocomplete-input> 
 
             </rs-tab>
@@ -346,12 +352,14 @@
                             <semantic-form-autocomplete-input   for="place_falls_within_place" 
                                                                 label="Falls within place" 
                                                                 placeholder="Select location that fully contains the organisation"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                             </semantic-form-autocomplete-input>
 
                             <semantic-form-autocomplete-input   for="place_contains_place" 
                                                                 label="Contains place" 
                                                                 placeholder="Select location that falls wholly within the organisation"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -544,10 +552,11 @@
         
                             <div class="form-inline-inputs">
                             <div style="flex: 1;">
-                                <semantic-form-autocomplete-input for='has_member_actor_range' 
-                                                                render-header="false"
-                                                                placeholder="Select the actor that is or has been a member of the organisation" 
-                                                                nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
+                                <semantic-form-autocomplete-input   for='has_member_actor_range' 
+                                                                    render-header="false"
+                                                                    placeholder="Select the actor that is or has been a member of the organisation" 
+                                                                    show-dropdown-filter="false"
+                                                                    nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <div style="flex: 1;">
@@ -583,6 +592,7 @@
                     <semantic-form-autocomplete-input   for='place_residence_of_actor' 
                                                         label="Residence of" 
                                                         placeholder="Select actor that reside in the organisation" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
             </rs-tab>
@@ -853,13 +863,14 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the organisation out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
-                <semantic-form-autocomplete-input for='place_witnessed_period' 
-                                                label="Witnessed event"
-                                                placeholder="Select the period/event that happened at the organisation" 
-                                                nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'>  
+                <semantic-form-autocomplete-input   for='place_witnessed_period' 
+                                                    label="Witnessed event"
+                                                    placeholder="Select the period/event that happened at the organisation" 
+                                                    nested-form-templates='[[> Platform:NestedFormTemplates_periods]]'>  
                 </semantic-form-autocomplete-input>
         
                 <semantic-form-autocomplete-input for='place_origin_of_move' 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPartAddition.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPartAddition.html
@@ -133,6 +133,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -151,6 +152,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -180,6 +182,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -230,6 +233,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -265,6 +269,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPartRemoval.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPartRemoval.html
@@ -134,6 +134,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -152,6 +153,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -181,6 +183,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -231,6 +234,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -266,6 +270,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPeriod.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPeriod.html
@@ -75,6 +75,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -93,6 +94,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPersistentItem.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPersistentItem.html
@@ -66,6 +66,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                         
@@ -91,6 +92,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the persistent item out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPerson.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPerson.html
@@ -254,6 +254,7 @@
                 <semantic-form-autocomplete-input for='actor_residence' 
                                                 label="Residence" 
                                                 placeholder="Select current or former residence" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>  
                 </semantic-form-autocomplete-input> 
 
@@ -272,6 +273,7 @@
                 <semantic-form-autocomplete-input   for="entity_id" 
                                                     label="Other identifier"
                                                     placeholder="Select other identifier" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                 </semantic-form-autocomplete-input>
 
@@ -746,6 +748,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the person out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
         

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalFeature.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalFeature.html
@@ -243,6 +243,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                         {{/if}}
@@ -448,12 +449,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the physical feature at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the physical feature" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -466,6 +469,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the physical feature at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -473,6 +477,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the physical feature"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -525,6 +530,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the physical feature" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -535,18 +541,21 @@
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the physical feature"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the physical feature is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the physical feature has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -698,6 +707,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the physical feature out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalHumanMadeThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalHumanMadeThing.html
@@ -306,6 +306,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                         {{/if}}
@@ -517,12 +518,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the physical human-made thing at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the physical human-made thing" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -535,6 +538,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the physical human-made thing at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -542,6 +546,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the physical human-made thing"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -594,6 +599,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the physical human-made thing" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -604,18 +610,21 @@
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the physical human-made thing"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the physical human-made thing is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the physical human-made thing has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -856,6 +865,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the physical human-made thing out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
@@ -1137,6 +1147,7 @@
                 <semantic-form-autocomplete-input   for='physical_human-made_thing_visual_item' 
                                                     label="Shows visual item" 
                                                     placeholder="Select visual item shown by the physical human-made thing" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_visualItems]]'> 
                 </semantic-form-autocomplete-input> 
             </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalObject.html
@@ -249,6 +249,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                         {{/if}}
@@ -519,12 +520,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the physical object at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the physical object" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -537,6 +540,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the physical object at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -544,6 +548,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the physical object"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -596,6 +601,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the physical object" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -606,30 +612,35 @@
                 <semantic-form-autocomplete-input   for='physical_object_current_permanent_location' 
                                                     label="Current permanent location" 
                                                     placeholder="Select the place reserved as the current permanent location of the physical object"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_object_current_location' 
                                                     label="Current location" 
                                                     placeholder="Select a place as the current location of the physical object"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the physical object"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the physical object is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the physical object has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -781,6 +792,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the physical object out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPhysicalThing.html
@@ -101,6 +101,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                         
@@ -304,12 +305,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the physical thing at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the physical thing" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -322,6 +325,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the physical thing at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -329,6 +333,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the physical thing"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -381,6 +386,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the physical thing" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -391,18 +397,21 @@
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the physical thing"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the physical thing is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the physical thing has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -554,6 +563,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the physical thing out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPlace.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPlace.html
@@ -134,24 +134,28 @@
             <semantic-form-autocomplete-input for="place_overlaps_with_place" 
                                               label="Overlap with place" 
                                               placeholder="Enter place name"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
             <semantic-form-autocomplete-input for="place_borders_with_place" 
                                               label="Borders with place" 
                                               placeholder="Enter place name"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
             <semantic-form-autocomplete-input for="place_approximates_place" 
                                               label="Approximates place" 
                                               placeholder="Enter place name"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
             <semantic-form-autocomplete-input for="place_approximated_by_place" 
                                               label="Is approximates by place" 
                                               placeholder="Enter place name"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -170,6 +174,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -252,12 +257,14 @@
               <semantic-form-autocomplete-input   for="place_falls_within_place" 
                                                   label="Falls within place" 
                                                   placeholder="Select location that fully contains the place"
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
               </semantic-form-autocomplete-input>
 
               <semantic-form-autocomplete-input   for="place_contains_place" 
                                                   label="Contains place" 
                                                   placeholder="Select location that falls wholly within the place"
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
               </semantic-form-autocomplete-input>
             </div>
@@ -339,6 +346,7 @@
         <semantic-form-autocomplete-input for='place_residence_of_actor' 
                                           label="Residence of" 
                                           placeholder="Select actor that reside in the place" 
+                                          show-dropdown-filter="false"
                                           nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProductType.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProductType.html
@@ -138,6 +138,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -484,6 +485,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the product type" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -603,6 +605,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the product type out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProduction.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProduction.html
@@ -135,6 +135,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -153,6 +154,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -182,6 +184,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -232,6 +235,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -267,12 +271,14 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
         <semantic-form-autocomplete-input   for='beginning_of_existence_actor' 
                                             label="Brought into existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
       </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProject_partial.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FProject_partial.html
@@ -171,6 +171,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -189,6 +190,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -220,6 +222,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -270,6 +273,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -305,6 +309,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPropositionalObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPropositionalObject.html
@@ -138,6 +138,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                             
@@ -439,6 +440,7 @@
                     <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                         label="Created by" 
                                                         placeholder="Select the creation event of the propositional object" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
                     </semantic-form-autocomplete-input> 
 
@@ -457,6 +459,7 @@
                     <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                         label="Taken out of existence by" 
                                                         placeholder="Select event that took the propositional object out of existence" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                     </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPublication.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPublication.html
@@ -178,6 +178,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -570,6 +571,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the publication" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -580,6 +582,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the publication" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -712,6 +715,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the publication out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPurchase.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FPurchase.html
@@ -135,6 +135,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -153,6 +154,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -183,12 +185,14 @@
         <semantic-form-autocomplete-input   for='acquisition_transferred_title_from' 
                                             label="Transferred title from" 
                                             placeholder="Select actor who relinquish ownership with the purchase" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
         <semantic-form-autocomplete-input   for='acquisition_transferred_title_to' 
                                             label="Transferred title to" 
                                             placeholder="Select actor that acquires the ownership after the purchase" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -210,6 +214,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -260,6 +265,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -295,6 +301,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FResearchQuestion.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FResearchQuestion.html
@@ -164,6 +164,7 @@
               <semantic-form-autocomplete-input   for="entity_id" 
                                                   label="Other identifier"
                                                   placeholder="Select other identifier" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
               </semantic-form-autocomplete-input>
               
@@ -472,6 +473,7 @@
           <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                               label="Created by" 
                                               placeholder="Select the creation event of the research question" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
           </semantic-form-autocomplete-input> 
 
@@ -490,6 +492,7 @@
           <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                               label="Taken out of existence by" 
                                               placeholder="Select event that took the research question out of existence" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
           </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FRight.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FRight.html
@@ -142,6 +142,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                         
@@ -341,6 +342,7 @@
                 <semantic-form-autocomplete-input   for='right_is_possessed_by' 
                                                     label="Possessed by" 
                                                     placeholder="Select actor that hold the right" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
             </rs-tab>
@@ -451,6 +453,7 @@
                 <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                     label="Created by" 
                                                     placeholder="Select the creation event of the right" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
                 </semantic-form-autocomplete-input> 
 
@@ -469,6 +472,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the right out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticChart.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticChart.html
@@ -74,6 +74,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                             [[> rsp:FormAssetSidebar]]
@@ -149,6 +150,7 @@
                     <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                         label="Right held by" 
                                                         placeholder="Select actor who holds legal right on the chart" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                 </rs-tab>
@@ -157,6 +159,7 @@
                     <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                         label="Created by" 
                                                         placeholder="Select the event that created the chart" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
                     </semantic-form-autocomplete-input> 
         
@@ -289,6 +292,7 @@
                     <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                         label="Taken out of existence by" 
                                                         placeholder="Select event that took the chart out of existence" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                     </semantic-form-autocomplete-input>
         

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticNarrative.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticNarrative.html
@@ -74,6 +74,7 @@
                   <semantic-form-autocomplete-input   for="entity_id" 
                                                       label="Other identifier"
                                                       placeholder="Select other identifier" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                   </semantic-form-autocomplete-input>
                 </div>
@@ -99,6 +100,7 @@
               <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                   label="Right held by" 
                                                   placeholder="Select actor who holds legal right on the semantic narrative" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
               </semantic-form-autocomplete-input> 
     
@@ -109,6 +111,7 @@
               <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                   label="Created by" 
                                                   placeholder="Select the event that created the semantic narrative" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
               </semantic-form-autocomplete-input> 
     
@@ -240,7 +243,8 @@
     
               <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                   label="Taken out of existence by" 
-                                                  placeholder="Select event that took the semantic narrative out of existence" 
+                                                  placeholder="Select event that took the semantic narrative out of existence"
+                                                  show-dropdown-filter="false" 
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
               </semantic-form-autocomplete-input>
     

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticTimeline.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSemanticTimeline.html
@@ -74,6 +74,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>             
                     </div>
@@ -99,6 +100,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the timeline" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
         
@@ -109,6 +111,7 @@
                 <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                     label="Created by" 
                                                     placeholder="Select the event that created the timeline" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
                 </semantic-form-autocomplete-input> 
         
@@ -241,6 +244,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the timeline out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
         

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSeries.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSeries.html
@@ -252,6 +252,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                         {{/if}}
@@ -522,12 +523,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the series at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the series" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -540,6 +543,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the series at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -547,6 +551,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the series"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -599,6 +604,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the series" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -609,30 +615,35 @@
                 <semantic-form-autocomplete-input   for='physical_object_current_permanent_location' 
                                                     label="Current permanent location" 
                                                     placeholder="Select the place reserved as the current permanent location of the series"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_object_current_location' 
                                                     label="Current location" 
                                                     placeholder="Select a place as the current location of the series"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the series"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the series is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the series has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -784,6 +795,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the series out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSet.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSet.html
@@ -83,6 +83,7 @@
               <semantic-form-autocomplete-input   for="entity_id" 
                                                   label="Other identifier"
                                                   placeholder="Select other identifier" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
               </semantic-form-autocomplete-input>
               
@@ -109,6 +110,7 @@
           <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                               label="Right held by" 
                                               placeholder="Select actor who holds legal right on the set" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
           </semantic-form-autocomplete-input> 
 
@@ -119,6 +121,7 @@
           <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                               label="Created by" 
                                               placeholder="Select the event that created the set" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
           </semantic-form-autocomplete-input> 
 
@@ -251,6 +254,7 @@
           <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                               label="Taken out of existence by" 
                                               placeholder="Select event that took the set out of existence" 
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
           </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSite.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSite.html
@@ -277,6 +277,7 @@
                             <semantic-form-autocomplete-input   for="entity_id" 
                                                                 label="Other identifier"
                                                                 placeholder="Select other identifier" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                             </semantic-form-autocomplete-input>
                         {{/if}}
@@ -308,24 +309,28 @@
                 <semantic-form-autocomplete-input   for="place_overlaps_with_place" 
                                                     label="Overlap with place" 
                                                     placeholder="Enter place name"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
     
                 <semantic-form-autocomplete-input   for="place_borders_with_place" 
                                                     label="Borders with place" 
                                                     placeholder="Enter place name"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for="place_approximates_place" 
                                                     label="Approximates place" 
                                                     placeholder="Enter place name"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for="place_approximated_by_place" 
                                                     label="Is approximates by place" 
                                                     placeholder="Enter place name"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
@@ -406,12 +411,14 @@
                             <semantic-form-autocomplete-input   for="place_falls_within_place" 
                                                                 label="Falls within place" 
                                                                 placeholder="Select location that fully contains the site"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                             </semantic-form-autocomplete-input>
 
                             <semantic-form-autocomplete-input   for="place_contains_place" 
                                                                 label="Contains place" 
                                                                 placeholder="Select location that falls wholly within the site"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -684,12 +691,14 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_owner'
                                                                     label="Current owner"
                                                                     placeholder="Select current legal owner of the site at the time of validity of the record" 
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>
                             <semantic-form-autocomplete-input   for='physical_thing_former_owner' 
                                                                 label="Former owner" 
                                                                 placeholder="Select actor that is or had been the legal owner of the site" 
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -702,6 +711,7 @@
                                 <semantic-form-autocomplete-input   for='physical_thing_current_keeper' 
                                                                     label="Current keeper" 
                                                                     placeholder="Select actor that has custody of the site at the time of validity of the record"
+                                                                    show-dropdown-filter="false"
                                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                                 </semantic-form-autocomplete-input>
                             </div>    
@@ -709,6 +719,7 @@
                             <semantic-form-autocomplete-input   for='physical_thing_former_keeper' 
                                                                 label="Former keeper" 
                                                                 placeholder="Select actor that has or has had custody of the site"
+                                                                show-dropdown-filter="false"
                                                                 nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                         </div>
@@ -761,6 +772,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the site" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -771,18 +783,21 @@
                 <semantic-form-autocomplete-input   for='physical_thing_former_location' 
                                                     label="Former or current location" 
                                                     placeholder="Select a place as the former or current location of the site"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_has_section' 
                                                     label="Has section" 
                                                     placeholder="Select a place as the area upon which the site is found"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
 
                 <semantic-form-autocomplete-input   for='physical_thing_occupies' 
                                                     label="Occupies space" 
                                                     placeholder="Select a place as the volume that contains all the points which the site has covered at some time during its existence"
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
                 </semantic-form-autocomplete-input>
                 
@@ -935,6 +950,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the site out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 
@@ -1290,6 +1306,7 @@
                     <semantic-form-autocomplete-input   for='place_residence_of_actor' 
                                                         label="Residence of" 
                                                         placeholder="Select actor that reside in the site" 
+                                                        show-dropdown-filter="false"
                                                         nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
             </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSymbolicObject.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FSymbolicObject.html
@@ -144,6 +144,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -360,6 +361,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the symbolic object" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -370,6 +372,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the symbolic object" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -502,6 +505,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the symbolic object out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FThing.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FThing.html
@@ -72,6 +72,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                         
@@ -175,6 +176,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the thing out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTimespan.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTimespan.html
@@ -147,6 +147,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTitle.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTitle.html
@@ -149,12 +149,14 @@
             <semantic-form-autocomplete-input   for='linguistic_object_has_translation' 
                                                 label="Translation" 
                                                 placeholder="Select translation" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_linguisticObjects]]'> 
             </semantic-form-autocomplete-input> 
 
             <semantic-form-autocomplete-input   for='linguistic_object_is_translation_of' 
                                                 label="Is translation of" 
                                                 placeholder="Select linguistic object that has this as translation" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_linguisticObjects]]'> 
             </semantic-form-autocomplete-input> 
 
@@ -176,6 +178,7 @@
                   <semantic-form-autocomplete-input for='has_alternative_form_range' 
                                                     render-header="false"
                                                     placeholder="Select alternative form" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                   </semantic-form-autocomplete-input>
                 </div>
@@ -222,6 +225,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 
@@ -592,6 +596,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the title" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -602,6 +607,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the title" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -734,6 +740,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the title out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTransferOfCustody.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTransferOfCustody.html
@@ -132,6 +132,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -150,6 +151,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -164,12 +166,14 @@
         <semantic-form-autocomplete-input   for='transfer_of_custody_surrendered_by' 
                                             label="Custody surrendered by" 
                                             placeholder="Select actor who surrendered the custody" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
         <semantic-form-autocomplete-input   for='transfer_of_custody_received_by' 
                                             label="Custody received by" 
                                             placeholder="Select actor who received the custody" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -191,6 +195,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -241,6 +246,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -276,6 +282,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTransformation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTransformation.html
@@ -85,6 +85,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -103,6 +104,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
 
@@ -118,12 +120,14 @@
         <semantic-form-autocomplete-input   for='beginning_of_existence_actor' 
                                             label="Brought into existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
         <semantic-form-autocomplete-input   for='end_of_existence_actor' 
                                             label="Took out of existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -145,6 +149,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -180,6 +185,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
       </rs-tab>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FType.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FType.html
@@ -136,6 +136,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -470,6 +471,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the type" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -589,6 +591,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the type out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTypeAssignment.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTypeAssignment.html
@@ -136,6 +136,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -154,6 +155,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -198,6 +200,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -248,6 +251,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -283,6 +287,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTypeCreation.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FTypeCreation.html
@@ -135,6 +135,7 @@
             <semantic-form-autocomplete-input for="period_place" 
                                               label="Place" 
                                               placeholder="Select place"
+                                              show-dropdown-filter="false"
                                               nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>
             </semantic-form-autocomplete-input>
 
@@ -153,6 +154,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
           </div>
@@ -167,6 +169,7 @@
         <semantic-form-autocomplete-input   for='beginning_of_existence_actor' 
                                             label="Brought into existence" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -188,6 +191,7 @@
                 <semantic-form-autocomplete-input for='carried_out_by_range'  
                                                   render-header="false"
                                                   placeholder="Select actor" 
+                                                  show-dropdown-filter="false"
                                                   nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
               </div>
@@ -238,6 +242,7 @@
                     <semantic-form-autocomplete-input for='participant_range'  
                                                       render-header="false"
                                                       placeholder="Select actor" 
+                                                      show-dropdown-filter="false"
                                                       nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                     </semantic-form-autocomplete-input> 
                   </div>
@@ -273,6 +278,7 @@
         <semantic-form-autocomplete-input   for='event_occurred_in_the_presence_of_actor' 
                                             label="Occurred in the presence of" 
                                             placeholder="Select actor" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FUser_partial.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FUser_partial.html
@@ -233,6 +233,7 @@
                             <semantic-form-autocomplete-input for='has_member_actor_range' 
                                                               render-header="false"
                                                               placeholder="Select the user/actor/person/group that is or has been a member" 
+                                                              show-dropdown-filter="false"
                                                               nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'>
                             </semantic-form-autocomplete-input>
                           </div>
@@ -339,6 +340,7 @@
               <semantic-form-autocomplete-input for='actor_residence' 
                                                 label="Residence" 
                                                 placeholder="Select current or former residence" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_places]]'>  
               </semantic-form-autocomplete-input> 
           

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FVideo.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FVideo.html
@@ -205,6 +205,7 @@
                         <semantic-form-autocomplete-input   for="entity_id" 
                                                             label="Other identifier"
                                                             placeholder="Select other identifier" 
+                                                            show-dropdown-filter="false"
                                                             nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
                         </semantic-form-autocomplete-input>
                     </div>
@@ -570,6 +571,7 @@
                 <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                                     label="Right held by" 
                                                     placeholder="Select actor who holds legal right on the video" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
                 </semantic-form-autocomplete-input> 
 
@@ -580,6 +582,7 @@
                 <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                                     label="Created by" 
                                                     placeholder="Select the event that created the video" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
                 </semantic-form-autocomplete-input> 
         
@@ -712,6 +715,7 @@
                 <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                                     label="Taken out of existence by" 
                                                     placeholder="Select event that took the video out of existence" 
+                                                    show-dropdown-filter="false"
                                                     nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
                 </semantic-form-autocomplete-input>
                 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FVisualItem.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FVisualItem.html
@@ -226,6 +226,7 @@
             <semantic-form-autocomplete-input   for="entity_id" 
                                                 label="Other identifier"
                                                 placeholder="Select other identifier" 
+                                                show-dropdown-filter="false"
                                                 nested-form-templates='[[> Platform:NestedFormTemplates_appellations]]'>
             </semantic-form-autocomplete-input>
             
@@ -594,6 +595,7 @@
         <semantic-form-autocomplete-input   for='legal_object_right_held_by_actor' 
                                             label="Right held by" 
                                             placeholder="Select actor who holds legal right on the visual item" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_actors]]'> 
         </semantic-form-autocomplete-input> 
 
@@ -604,6 +606,7 @@
         <semantic-form-autocomplete-input   for='conceptual_object_created_by' 
                                             label="Created by" 
                                             placeholder="Select the event that created the visual item" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_creations]]'>  
         </semantic-form-autocomplete-input> 
 
@@ -736,6 +739,7 @@
         <semantic-form-autocomplete-input   for='persistent_item_taken_out_of_existence_by' 
                                             label="Taken out of existence by" 
                                             placeholder="Select event that took the visual item out of existence" 
+                                            show-dropdown-filter="false"
                                             nested-form-templates='[[> Platform:NestedFormTemplates_endOfExistences]]'>  
         </semantic-form-autocomplete-input>
 

--- a/src/main/web/components/forms/inputs/AutocompleteInput.tsx
+++ b/src/main/web/components/forms/inputs/AutocompleteInput.tsx
@@ -61,6 +61,11 @@ export interface AutocompleteInputProps extends AtomicValueInputProps {
    * If set to true, the resource can not be edited and the Edit button will not be shown and will not possible to open the resource in a new tab
    */
   readonlyResource?: boolean;
+  /**
+   * If set to false, the filter input in the dropdown will be hidden
+   * @default true
+   */
+  showDropdownFilter?: boolean;
 }
 
 interface SelectValue {
@@ -287,6 +292,7 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
             getLabel={item => String(item.label)}
             placeholder="Filter..."
             noResultsText="No results"
+            showFilter={this.props.showDropdownFilter}
           />
         )}
         { showEditButton && 

--- a/src/main/web/components/forms/inputs/AutocompleteInput.tsx
+++ b/src/main/web/components/forms/inputs/AutocompleteInput.tsx
@@ -153,7 +153,6 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
   }
 
   private onDropdownSelectHandler(label: string) {
-    console.log('Selected label: ', label);
     const nestedFormTemplateSelected = this.state.nestedFormTemplates.filter((e) => e.label === label)[0].nestedForm
     const modalId = this.state.nestedFormTemplates.filter((e) => e.label === label)[0].modalId
     const parentIri = this.state.nestedFormTemplates.filter((e) => e.label === label)[0].parentIri

--- a/src/main/web/components/forms/inputs/AutocompleteInput.tsx
+++ b/src/main/web/components/forms/inputs/AutocompleteInput.tsx
@@ -1,6 +1,6 @@
 /**
  * ResearchSpace
- * Copyright (C) 2022-2024, © Kartography Community Interest Company
+ * Copyright (C) 2022-2025, © Kartography Community Interest Company
  * Copyright (C) 2020, © Trustees of the British Museum
  * Copyright (C) 2015-2019, metaphacts GmbH
  *
@@ -37,11 +37,9 @@ import Icon from 'platform/components/ui/icon/Icon';
 import ResourceLinkContainer from 'platform/api/navigation/components/ResourceLinkContainer';
 import { SparqlClient, SparqlUtil } from 'platform/api/sparql';
 
-import { DropdownButton, Dropdown, MenuItem } from 'react-bootstrap';
 import { DropdownWithFilter } from './dropdown/DropdownWithFilter';
 import { RdfLiteral } from 'platform/ontodia/src/ontodia';
 import { ConfigHolder } from 'platform/api/services/config-holder';
-import { item } from 'platform/components/arguments/AssertionComponent.scss';
 
 
 type nestedFormEl = {

--- a/src/main/web/components/forms/inputs/AutocompleteInput.tsx
+++ b/src/main/web/components/forms/inputs/AutocompleteInput.tsx
@@ -38,7 +38,7 @@ import ResourceLinkContainer from 'platform/api/navigation/components/ResourceLi
 import { SparqlClient, SparqlUtil } from 'platform/api/sparql';
 
 import { DropdownButton, Dropdown, MenuItem } from 'react-bootstrap';
-import { DropdownWithFilter } from './DropdownWithFilter';
+import { DropdownWithFilter } from './dropdown/DropdownWithFilter';
 import { RdfLiteral } from 'platform/ontodia/src/ontodia';
 import { ConfigHolder } from 'platform/api/services/config-holder';
 import { item } from 'platform/components/arguments/AssertionComponent.scss';
@@ -281,7 +281,7 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
         { showCreateNewDropdown && (
           <DropdownWithFilter
             id="add-form"
-            title="New A"
+            title="New"
             items={this.state.nestedFormTemplates}
             filterValue={this.state.filterValue || ''}
             onFilterChange={v => this.setState({ filterValue: v })}

--- a/src/main/web/components/forms/inputs/AutocompleteInput.tsx
+++ b/src/main/web/components/forms/inputs/AutocompleteInput.tsx
@@ -41,6 +41,7 @@ import { DropdownButton, Dropdown, MenuItem } from 'react-bootstrap';
 import { DropdownWithFilter } from './DropdownWithFilter';
 import { RdfLiteral } from 'platform/ontodia/src/ontodia';
 import { ConfigHolder } from 'platform/api/services/config-holder';
+import { item } from 'platform/components/arguments/AssertionComponent.scss';
 
 
 type nestedFormEl = {
@@ -281,11 +282,11 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
           <DropdownWithFilter
             id="add-form"
             title="New A"
-            items={this.state.nestedFormTemplates || []}
+            items={this.state.nestedFormTemplates}
             filterValue={this.state.filterValue || ''}
             onFilterChange={v => this.setState({ filterValue: v })}
-            getLabel={item => item.label || ''}
-            onSelect={item => this.onDropdownSelectHandler(item.label)}
+            onSelect={item => this.onDropdownSelectHandler(String(item.label))}
+            getLabel={item => String(item.label)}
             placeholder="Filter..."
             noResultsText="No results"
           />

--- a/src/main/web/components/forms/inputs/AutocompleteInput.tsx
+++ b/src/main/web/components/forms/inputs/AutocompleteInput.tsx
@@ -36,7 +36,9 @@ import { ValidationMessages } from './Decorations';
 import Icon from 'platform/components/ui/icon/Icon';
 import ResourceLinkContainer from 'platform/api/navigation/components/ResourceLinkContainer';
 import { SparqlClient, SparqlUtil } from 'platform/api/sparql';
-import { DropdownButton, MenuItem } from 'react-bootstrap';
+
+import { DropdownButton, Dropdown, MenuItem } from 'react-bootstrap';
+import { DropdownWithFilter } from './DropdownWithFilter';
 import { RdfLiteral } from 'platform/ontodia/src/ontodia';
 import { ConfigHolder } from 'platform/api/services/config-holder';
 
@@ -77,6 +79,7 @@ interface State {
   modalId?: string;
   parentIri?: string;
   passValuesFor?: string[];
+  filterValue?: string;
 }
 
 const CLASS_NAME = 'autocomplete-text-field';
@@ -92,7 +95,8 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
     super(props, context);
     this.state = { 
       nestedFormOpen: false ,
-      nestedFormTemplates: []
+      nestedFormTemplates: [],
+      filterValue: ''
     };
     this.tupleTemplate = this.tupleTemplate || this.compileTemplate();
   }
@@ -149,6 +153,7 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
   }
 
   private onDropdownSelectHandler(label: string) {
+    console.log('Selected label: ', label);
     const nestedFormTemplateSelected = this.state.nestedFormTemplates.filter((e) => e.label === label)[0].nestedForm
     const modalId = this.state.nestedFormTemplates.filter((e) => e.label === label)[0].modalId
     const parentIri = this.state.nestedFormTemplates.filter((e) => e.label === label)[0].parentIri
@@ -274,12 +279,17 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
           </Button>
         )}
         { showCreateNewDropdown && (
-          <DropdownButton title="New" pullRight id="add-form" onSelect={(label) => this.onDropdownSelectHandler(label)}>
-            {this.state.nestedFormTemplates.map((e) => {
-                return (<MenuItem key={e.label} eventKey={e.label} draggable={false}>{e.label}</MenuItem>)
-              }
-            )}
-          </DropdownButton>
+          <DropdownWithFilter
+            id="add-form"
+            title="New A"
+            items={this.state.nestedFormTemplates || []}
+            filterValue={this.state.filterValue || ''}
+            onFilterChange={v => this.setState({ filterValue: v })}
+            getLabel={item => item.label || ''}
+            onSelect={item => this.onDropdownSelectHandler(item.label)}
+            placeholder="Filter..."
+            noResultsText="No results"
+          />
         )}
         { showEditButton && 
           <Button className={`${CLASS_NAME}__create-button btn-textAndIcon`} title='Edit' onClick={() => {this.onEditHandler(value.value as Rdf.Iri)}}>
@@ -345,3 +355,4 @@ export class AutocompleteInput extends AtomicValueInput<AutocompleteInputProps, 
 SingleValueInput.assertStatic(AutocompleteInput);
 
 export default AutocompleteInput;
+

--- a/src/main/web/components/forms/inputs/DropdownWithFilter.tsx
+++ b/src/main/web/components/forms/inputs/DropdownWithFilter.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+
+interface CustomDropdownProps<T> {
+  id: string;
+  title: React.ReactNode;
+  items: T[];
+  filterValue: string;
+  onFilterChange: (value: string) => void;
+  getLabel: (item: T) => string;
+  onSelect: (item: T) => void;
+  placeholder?: string;
+  noResultsText?: string;
+}
+
+export class DropdownWithFilter<T> extends React.PureComponent<CustomDropdownProps<T>, { open: boolean; filter: string }> {
+  wrapperRef: React.RefObject<HTMLDivElement>;
+  inputRef: React.RefObject<HTMLInputElement>;
+  constructor(props: CustomDropdownProps<T>) {
+    super(props);
+    this.state = { open: false, filter: '' };
+    this.wrapperRef = React.createRef();
+    this.inputRef = React.createRef();
+  }
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleClickOutside);
+  }
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleClickOutside);
+  }
+
+  handleClickOutside = (event: MouseEvent) => {
+    if (this.wrapperRef.current && !this.wrapperRef.current.contains(event.target as Node)) {
+      this.setState({ open: false });
+    }
+  };
+
+  handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    this.setState(
+      prev => ({ open: !prev.open }),
+      () => {
+        if (this.state.open && this.inputRef.current) {
+          this.inputRef.current.focus();
+        }
+      }
+    );
+  };
+
+  handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ filter: e.target.value });
+    this.props.onFilterChange(e.target.value);
+  };
+
+  handleSelect = (item: T) => {
+    this.setState({ open: false, filter: '' });
+    this.props.onSelect(item);
+    this.props.onFilterChange('');
+  };
+
+  render() {
+    const { title, items, getLabel, placeholder, noResultsText } = this.props;
+    const { open, filter } = this.state;
+    const filtered = items.filter(item => !filter || getLabel(item).toLowerCase().includes(filter.toLowerCase()));
+    return (
+      <div ref={this.wrapperRef} style={{ display: 'inline-block', position: 'relative', marginLeft: 8 }}>
+        <button
+          type="button"
+          className="btn btn-default dropdown-toggle"
+          onClick={this.handleToggle}
+          aria-haspopup="true"
+          aria-expanded={open}
+          style={{ userSelect: 'none' }}
+        >
+          {title} <span className="caret" />
+        </button>
+        {open && (
+          <div className="dropdown-menu" style={{ display: 'block', minWidth: 200, padding: 8, position: 'absolute', zIndex: 1051 }}>
+            <input
+              ref={this.inputRef}
+              type="text"
+              placeholder={placeholder || 'Filter...'}
+              style={{ width: '100%', marginBottom: 8 }}
+              value={filter}
+              onChange={this.handleFilterChange}
+              autoComplete="off"
+            />
+            <ul className="list-unstyled" style={{ maxHeight: 200, overflowY: 'auto', margin: 0, padding: 0 }}>
+              {filtered.length > 0 ? (
+                filtered.map(item => (
+                  <li key={getLabel(item)}>
+                    <a
+                      href="#"
+                      style={{ display: 'block', padding: '6px 12px', cursor: 'pointer', whiteSpace: 'normal' }}
+                      onClick={e => { e.preventDefault(); this.handleSelect(item); }}
+                    >
+                      {getLabel(item)}
+                    </a>
+                  </li>
+                ))
+              ) : (
+                <li><span style={{ color: '#888', padding: '6px 12px', display: 'block' }}>{noResultsText || 'No results'}</span></li>
+              )}
+            </ul>
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/main/web/components/forms/inputs/DropdownWithFilter.tsx
+++ b/src/main/web/components/forms/inputs/DropdownWithFilter.tsx
@@ -25,6 +25,20 @@ export function DropdownWithFilter<T>({
 }: DropdownWithFilterProps<T>) {
   const [open, setOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const dropdownRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [open]);
 
   const filtered = !filterValue
     ? items
@@ -47,7 +61,12 @@ export function DropdownWithFilter<T>({
   };
 
   return (
-    <div style={{ display: 'inline-block', position: 'relative', marginLeft: 8 }} id={id}>
+    <div
+      ref={dropdownRef}
+      className={`dropdown${open ? ' open' : ''}`}
+      style={{ display: 'inline-block', position: 'relative', marginLeft: 8 }}
+      id={id}
+    >
       <button
         type="button"
         className="btn btn-default dropdown-toggle"
@@ -59,34 +78,36 @@ export function DropdownWithFilter<T>({
         {title} <span className="caret" />
       </button>
       {open && (
-        <div className="dropdown-menu" style={{ display: 'block', padding: 8, position: 'absolute', zIndex: 1051 }}>
-          <input
-            ref={inputRef}
-            type="text"
-            placeholder={placeholder || 'Filter...'}
-            style={{ width: '100%', marginBottom: 8 }}
-            value={filterValue}
-            onChange={e => onFilterChange(e.target.value)}
-            autoComplete="off"
-          />
-          <ul className="list-unstyled" style={{ maxHeight: 200, overflowY: 'auto', margin: 0, padding: 0 }}>
-            {filtered.length > 0 ? (
-              filtered.map(item => (
-                <li key={getLabel(item)}>
-                  <a
-                    href="#"
-                    style={{ display: 'block', padding: '6px 12px', cursor: 'pointer', whiteSpace: 'normal' }}
-                    onClick={e => { e.preventDefault(); handleSelect(item); }}
-                  >
-                    {getLabel(item)}
-                  </a>
-                </li>
-              ))
-            ) : (
-              <li><span style={{ color: '#888', padding: '6px 12px', display: 'block' }}>{noResultsText || 'No results'}</span></li>
-            )}
-          </ul>
-        </div>
+        <ul className="dropdown-menu pull-right" style={{ minWidth: 180, maxHeight: 240, overflowY: 'auto', padding: 0 }}>
+          <li style={{ padding: '8px 12px', position: 'sticky', top: 0, background: '#fff', zIndex: 1 }}>
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder={placeholder || 'Filter...'}
+              className="form-control"
+              style={{ width: '100%', marginBottom: 4 }}
+              value={filterValue}
+              onChange={e => onFilterChange(e.target.value)}
+              autoComplete="off"
+            />
+          </li>
+          {filtered.length > 0 ? (
+            filtered.map(item => (
+              <li role="menuitem" key={getLabel(item)}>
+                <a
+                  href="#"
+                  tabIndex={-1}
+                  style={{ display: 'block', padding: '6px 20px', cursor: 'pointer', whiteSpace: 'normal' }}
+                  onClick={e => { e.preventDefault(); handleSelect(item); }}
+                >
+                  {getLabel(item)}
+                </a>
+              </li>
+            ))
+          ) : (
+            <li><span style={{ color: '#888', padding: '6px 20px', display: 'block' }}>{noResultsText || 'No results'}</span></li>
+          )}
+        </ul>
       )}
     </div>
   );

--- a/src/main/web/components/forms/inputs/DropdownWithFilter.tsx
+++ b/src/main/web/components/forms/inputs/DropdownWithFilter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-interface CustomDropdownProps<T> {
+interface Props<T> {
   id: string;
   title: React.ReactNode;
   items: T[];
@@ -12,99 +12,91 @@ interface CustomDropdownProps<T> {
   noResultsText?: string;
 }
 
-export class DropdownWithFilter<T> extends React.PureComponent<CustomDropdownProps<T>, { open: boolean; filter: string }> {
-  wrapperRef: React.RefObject<HTMLDivElement>;
-  inputRef: React.RefObject<HTMLInputElement>;
-  constructor(props: CustomDropdownProps<T>) {
-    super(props);
-    this.state = { open: false, filter: '' };
-    this.wrapperRef = React.createRef();
-    this.inputRef = React.createRef();
-  }
 
-  componentDidMount() {
-    document.addEventListener('mousedown', this.handleClickOutside);
-  }
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClickOutside);
-  }
+export function DropdownWithFilter<T>(props: Props<T>) {
+  const { title, items, getLabel, placeholder, noResultsText, onFilterChange, onSelect } = props;
+  const [open, setOpen] = React.useState(false);
+  const [filter, setFilter] = React.useState('');
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
-  handleClickOutside = (event: MouseEvent) => {
-    if (this.wrapperRef.current && !this.wrapperRef.current.contains(event.target as Node)) {
-      this.setState({ open: false });
-    }
-  };
-
-  handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    this.setState(
-      prev => ({ open: !prev.open }),
-      () => {
-        if (this.state.open && this.inputRef.current) {
-          this.inputRef.current.focus();
-        }
+  React.useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
+        setOpen(false);
       }
-    );
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setOpen(prev => {
+      const next = !prev;
+      if (next && inputRef.current) {
+        setTimeout(() => inputRef.current && inputRef.current.focus(), 0);
+      }
+      return next;
+    });
   };
 
-  handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ filter: e.target.value });
-    this.props.onFilterChange(e.target.value);
+  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilter(e.target.value);
+    onFilterChange(e.target.value);
   };
 
-  handleSelect = (item: T) => {
-    this.setState({ open: false, filter: '' });
-    this.props.onSelect(item);
-    this.props.onFilterChange('');
+  const handleSelect = (item: T) => {
+    setOpen(false);
+    setFilter('');
+    onSelect(item);
+    onFilterChange('');
   };
 
-  render() {
-    const { title, items, getLabel, placeholder, noResultsText } = this.props;
-    const { open, filter } = this.state;
-    const filtered = items.filter(item => !filter || getLabel(item).toLowerCase().includes(filter.toLowerCase()));
-    return (
-      <div ref={this.wrapperRef} style={{ display: 'inline-block', position: 'relative', marginLeft: 8 }}>
-        <button
-          type="button"
-          className="btn btn-default dropdown-toggle"
-          onClick={this.handleToggle}
-          aria-haspopup="true"
-          aria-expanded={open}
-          style={{ userSelect: 'none' }}
-        >
-          {title} <span className="caret" />
-        </button>
-        {open && (
-          <div className="dropdown-menu" style={{ display: 'block', minWidth: 200, padding: 8, position: 'absolute', zIndex: 1051 }}>
-            <input
-              ref={this.inputRef}
-              type="text"
-              placeholder={placeholder || 'Filter...'}
-              style={{ width: '100%', marginBottom: 8 }}
-              value={filter}
-              onChange={this.handleFilterChange}
-              autoComplete="off"
-            />
-            <ul className="list-unstyled" style={{ maxHeight: 200, overflowY: 'auto', margin: 0, padding: 0 }}>
-              {filtered.length > 0 ? (
-                filtered.map(item => (
-                  <li key={getLabel(item)}>
-                    <a
-                      href="#"
-                      style={{ display: 'block', padding: '6px 12px', cursor: 'pointer', whiteSpace: 'normal' }}
-                      onClick={e => { e.preventDefault(); this.handleSelect(item); }}
-                    >
-                      {getLabel(item)}
-                    </a>
-                  </li>
-                ))
-              ) : (
-                <li><span style={{ color: '#888', padding: '6px 12px', display: 'block' }}>{noResultsText || 'No results'}</span></li>
-              )}
-            </ul>
-          </div>
-        )}
-      </div>
-    );
-  }
+  const filtered = items.filter(item => !filter || getLabel(item).toLowerCase().includes(filter.toLowerCase()));
+
+  return (
+    <div ref={wrapperRef} style={{ display: 'inline-block', position: 'relative', marginLeft: 8 }}>
+      <button
+        type="button"
+        className="btn btn-default dropdown-toggle"
+        onClick={handleToggle}
+        aria-haspopup="true"
+        aria-expanded={open}
+        style={{ userSelect: 'none' }}
+      >
+        {title} <span className="caret" />
+      </button>
+      {open && (
+        <div className="dropdown-menu" style={{ display: 'block', minWidth: 200, padding: 8, position: 'absolute', zIndex: 1051 }}>
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder={placeholder || 'Filter...'}
+            style={{ width: '100%', marginBottom: 8 }}
+            value={filter}
+            onChange={handleFilterChange}
+            autoComplete="off"
+          />
+          <ul className="list-unstyled" style={{ maxHeight: 200, overflowY: 'auto', margin: 0, padding: 0 }}>
+            {filtered.length > 0 ? (
+              filtered.map(item => (
+                <li key={getLabel(item)}>
+                  <a
+                    href="#"
+                    style={{ display: 'block', padding: '6px 12px', cursor: 'pointer', whiteSpace: 'normal' }}
+                    onClick={e => { e.preventDefault(); handleSelect(item); }}
+                  >
+                    {getLabel(item)}
+                  </a>
+                </li>
+              ))
+            ) : (
+              <li><span style={{ color: '#888', padding: '6px 12px', display: 'block' }}>{noResultsText || 'No results'}</span></li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/main/web/components/forms/inputs/DropdownWithFilter.tsx
+++ b/src/main/web/components/forms/inputs/DropdownWithFilter.tsx
@@ -1,37 +1,36 @@
 import * as React from 'react';
 
-interface Props<T> {
+interface DropdownWithFilterProps<T> {
   id: string;
   title: React.ReactNode;
   items: T[];
   filterValue: string;
   onFilterChange: (value: string) => void;
-  getLabel: (item: T) => string;
   onSelect: (item: T) => void;
+  getLabel: (item: T) => string;
   placeholder?: string;
   noResultsText?: string;
 }
 
-
-export function DropdownWithFilter<T>(props: Props<T>) {
-  const { title, items, getLabel, placeholder, noResultsText, onFilterChange, onSelect } = props;
+export function DropdownWithFilter<T>({
+  id,
+  title,
+  items,
+  filterValue,
+  onFilterChange,
+  onSelect,
+  getLabel,
+  placeholder,
+  noResultsText
+}: DropdownWithFilterProps<T>) {
   const [open, setOpen] = React.useState(false);
-  const [filter, setFilter] = React.useState('');
-  const wrapperRef = React.useRef<HTMLDivElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
 
-  React.useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  const filtered = !filterValue
+    ? items
+    : items.filter(item => getLabel(item).toLowerCase().includes(filterValue.toLowerCase()));
 
-  const handleToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
+  const handleToggle = () => {
     setOpen(prev => {
       const next = !prev;
       if (next && inputRef.current) {
@@ -41,22 +40,14 @@ export function DropdownWithFilter<T>(props: Props<T>) {
     });
   };
 
-  const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFilter(e.target.value);
-    onFilterChange(e.target.value);
-  };
-
   const handleSelect = (item: T) => {
     setOpen(false);
-    setFilter('');
     onSelect(item);
     onFilterChange('');
   };
 
-  const filtered = items.filter(item => !filter || getLabel(item).toLowerCase().includes(filter.toLowerCase()));
-
   return (
-    <div ref={wrapperRef} style={{ display: 'inline-block', position: 'relative', marginLeft: 8 }}>
+    <div style={{ display: 'inline-block', position: 'relative', marginLeft: 8 }} id={id}>
       <button
         type="button"
         className="btn btn-default dropdown-toggle"
@@ -68,14 +59,14 @@ export function DropdownWithFilter<T>(props: Props<T>) {
         {title} <span className="caret" />
       </button>
       {open && (
-        <div className="dropdown-menu" style={{ display: 'block', minWidth: 200, padding: 8, position: 'absolute', zIndex: 1051 }}>
+        <div className="dropdown-menu" style={{ display: 'block', padding: 8, position: 'absolute', zIndex: 1051 }}>
           <input
             ref={inputRef}
             type="text"
             placeholder={placeholder || 'Filter...'}
             style={{ width: '100%', marginBottom: 8 }}
-            value={filter}
-            onChange={handleFilterChange}
+            value={filterValue}
+            onChange={e => onFilterChange(e.target.value)}
             autoComplete="off"
           />
           <ul className="list-unstyled" style={{ maxHeight: 200, overflowY: 'auto', margin: 0, padding: 0 }}>

--- a/src/main/web/components/forms/inputs/SelectInput.tsx
+++ b/src/main/web/components/forms/inputs/SelectInput.tsx
@@ -1,6 +1,6 @@
 /**
  * ResearchSpace
- * Copyright (C) 2022-2024, © Kartography Community Interest Company
+ * Copyright (C) 2022-2025, © Kartography Community Interest Company
  * Copyright (C) 2020, © Trustees of the British Museum
  * Copyright (C) 2015-2019, metaphacts GmbH
  *
@@ -25,13 +25,13 @@ import * as Immutable from 'immutable';
 import * as React from 'react';
 import { Button } from 'react-bootstrap';
 import * as _ from 'lodash';
-import { DropdownButton, MenuItem } from 'react-bootstrap';
 
 import { Cancellation } from 'platform/api/async/Cancellation';
 import { Rdf } from 'platform/api/rdf';
 
 import { TemplateItem } from 'platform/components/ui/template';
 
+import { DropdownWithFilter } from './dropdown/DropdownWithFilter';
 import { FieldDefinition, getPreferredLabel } from '../FieldDefinition';
 import { FieldValue, AtomicValue, EmptyValue, SparqlBindingValue, ErrorKind, DataState } from '../FieldValues';
 import { SingleValueInput, AtomicValueInput, AtomicValueInputProps } from './SingleValueInput';
@@ -102,6 +102,13 @@ export interface SelectInputProps extends AtomicValueInputProps {
    * If set to true, the resource can not be edited and the Edit button will not be shown and will not possible to open the resource in a new tab
    */
   readonlyResource?: boolean;
+
+  /**
+   * If set to false, the filter input in the dropdown will be hidden
+   * @default true
+   */
+  showDropdownFilter?: boolean;
+
 }
 
 interface State {
@@ -115,6 +122,7 @@ interface State {
   modalId?: string,
   parentIri?: string,
   passValuesFor?: string[]
+  filterValue?: string;
 }
 
 const SELECT_TEXT_CLASS = 'select-text-field';
@@ -131,7 +139,8 @@ export class SelectInput extends AtomicValueInput<SelectInputProps, State> {
     this.state = {
       valueSet: Immutable.List<SparqlBindingValue>(),
       nestedFormOpen: false,
-      nestedFormTemplates: []
+      nestedFormTemplates: [],
+      filterValue: ''
     };
   }
 
@@ -371,12 +380,18 @@ export class SelectInput extends AtomicValueInput<SelectInputProps, State> {
           </Button>
         )}
         { showCreateNewDropdown && (
-          <DropdownButton title="New" pullRight id="add-form" onSelect={(label) => this.onDropdownSelectHandler(label)}>
-            {this.state.nestedFormTemplates.map((e) => {
-                return (<MenuItem key={e.label} eventKey={e.label} draggable={false}>{e.label}</MenuItem>)
-              }
-            )}
-          </DropdownButton>
+          <DropdownWithFilter
+            id="add-form"
+            title="New"
+            items={this.state.nestedFormTemplates}
+            filterValue={this.state.filterValue || ''}
+            onFilterChange={v => this.setState({ filterValue: v })}
+            onSelect={item => this.onDropdownSelectHandler(String(item.label))}
+            getLabel={item => String(item.label)}
+            placeholder="Filter..."
+            noResultsText="No results"
+            showFilter={this.props.showDropdownFilter}
+          />
         )}
         { showEditButton && 
           <Button className={`${SELECT_TEXT_CLASS}__create-button btn-textAndIcon`} title='Edit' onClick={() => {this.onEditHandler(selectedValue)}}>

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.css
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * ResearchSpace
  * Copyright (C) 2022-2024, © Kartography Community Interest Company
@@ -18,17 +19,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 .dropdown-with-filter {
-  display: inline-block;
-  position: relative;
   margin-left: 8px;
 }
 
-.dropdown-with-filter .dropdown-toggle {
-  user-select: none;
-}
-
-.dropdown-with-filter .dropdown-menu {
-  min-width: 180px;
+.dropdown-with-filter > .dropdown-menu,
+.dropdown-with-filter.open > .dropdown-menu,
+.dropdown-with-filter .dropdown-menu.pull-right {
+  min-width: 220px;
+  max-width: 320px;
+  width: auto;
   max-height: 240px;
   overflow-y: auto;
   padding: 0;
@@ -43,19 +42,15 @@
 }
 
 .dropdown-with-filter .dropdown-filter-input input {
-  width: 100%;
   margin-bottom: 4px;
 }
 
 .dropdown-with-filter .dropdown-item {
-  display: block;
-  padding: 6px 20px;
-  cursor: pointer;
   white-space: normal;
 }
 
 .dropdown-with-filter .dropdown-no-results {
-  color: #888;
   padding: 6px 20px;
   display: block;
 }
+

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss
@@ -1,0 +1,61 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2022-2024, © Kartography Community Interest Company
+ * Copyright (C) 2020, © Trustees of the British Museum
+ * Copyright (C) 2015-2019, metaphacts GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+.dropdown-with-filter {
+  display: inline-block;
+  position: relative;
+  margin-left: 8px;
+}
+
+.dropdown-with-filter .dropdown-toggle {
+  user-select: none;
+}
+
+.dropdown-with-filter .dropdown-menu {
+  min-width: 180px;
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.dropdown-with-filter .dropdown-filter-input {
+  padding: 8px 12px;
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 1;
+}
+
+.dropdown-with-filter .dropdown-filter-input input {
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.dropdown-with-filter .dropdown-item {
+  display: block;
+  padding: 6px 20px;
+  cursor: pointer;
+  white-space: normal;
+}
+
+.dropdown-with-filter .dropdown-no-results {
+  color: #888;
+  padding: 6px 20px;
+  display: block;
+}

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /**
  * ResearchSpace
  * Copyright (C) 2025, © Kartography Community Interest Company
@@ -16,29 +15,32 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@import '~basic-styles.scss';
+
 .dropdownWithFilter {
-  margin-left: 8px;
+  margin-left: -1px;
 }
 
 .dropdownMenu {
   min-width: 220px;
   max-width: 320px;
   width: auto;
-  max-height: 240px;
   overflow-y: auto;
-  padding: 0;
 }
 
 .dropdownFilterInput {
-  padding: 8px 12px;
   position: sticky;
   top: 0;
-  background: #fff;
   z-index: 1;
-}
 
-.dropdownFilterInputInput {
-  margin-bottom: 4px;
+  :global(.form-control),
+  :global(.form-control):focus {
+      
+    border-radius: 0;
+    border-top: none;
+    border-right: none;
+    border-left: none;
+  }
 }
 
 .dropdownItem {
@@ -46,7 +48,10 @@
 }
 
 .dropdownNoResults {
-  padding: 6px 20px;
   display: block;
+  color: $color-secondary;
+  font-size: $dropdown-font-size;
+  padding: 10px 15px;
+  white-space: nowrap;
 }
 

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss
@@ -1,15 +1,13 @@
 @charset "UTF-8";
 /**
  * ResearchSpace
- * Copyright (C) 2022-2024, © Kartography Community Interest Company
- * Copyright (C) 2020, © Trustees of the British Museum
- * Copyright (C) 2015-2019, metaphacts GmbH
+ * Copyright (C) 2025, © Kartography Community Interest Company
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
-
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -18,13 +16,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-.dropdown-with-filter {
+.dropdownWithFilter {
   margin-left: 8px;
 }
 
-.dropdown-with-filter > .dropdown-menu,
-.dropdown-with-filter.open > .dropdown-menu,
-.dropdown-with-filter .dropdown-menu.pull-right {
+.dropdownMenu {
   min-width: 220px;
   max-width: 320px;
   width: auto;
@@ -33,7 +29,7 @@
   padding: 0;
 }
 
-.dropdown-with-filter .dropdown-filter-input {
+.dropdownFilterInput {
   padding: 8px 12px;
   position: sticky;
   top: 0;
@@ -41,15 +37,15 @@
   z-index: 1;
 }
 
-.dropdown-with-filter .dropdown-filter-input input {
+.dropdownFilterInputInput {
   margin-bottom: 4px;
 }
 
-.dropdown-with-filter .dropdown-item {
+.dropdownItem {
   white-space: normal;
 }
 
-.dropdown-with-filter .dropdown-no-results {
+.dropdownNoResults {
   padding: 6px 20px;
   display: block;
 }

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss
@@ -26,6 +26,10 @@
   max-width: 320px;
   width: auto;
   overflow-y: auto;
+
+  &:has(.dropdownFilterInput) {
+    padding-top: 0;
+  }
 }
 
 .dropdownFilterInput {
@@ -40,6 +44,7 @@
     border-top: none;
     border-right: none;
     border-left: none;
+    height: 42px;
   }
 }
 

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss.d.ts
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss.d.ts
@@ -20,7 +20,6 @@ declare namespace DropdownWithFilterScssNamespace {
     dropdownWithFilter: string;
     dropdownMenu: string;
     dropdownFilterInput: string;
-    dropdownFilterInputInput: string;
     dropdownItem: string;
     dropdownNoResults: string;
   }

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss.d.ts
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.scss.d.ts
@@ -1,0 +1,31 @@
+/**
+ * ResearchSpace
+ * Copyright (C) 2025, © Kartography Community Interest Company
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+declare namespace DropdownWithFilterScssNamespace {
+  export interface IDropdownWithFilterScss {
+    dropdownWithFilter: string;
+    dropdownMenu: string;
+    dropdownFilterInput: string;
+    dropdownFilterInputInput: string;
+    dropdownItem: string;
+    dropdownNoResults: string;
+  }
+}
+
+declare const DropdownWithFilterScssModule: DropdownWithFilterScssNamespace.IDropdownWithFilterScss;
+
+export = DropdownWithFilterScssModule;

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
@@ -1,8 +1,6 @@
 /**
  * ResearchSpace
- * Copyright (C) 2022-2024, © Kartography Community Interest Company
- * Copyright (C) 2020, © Trustees of the British Museum
- * Copyright (C) 2015-2019, metaphacts GmbH
+ * Copyright (C) 2025, © Kartography Community Interest Company
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,9 +15,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import * as React from 'react';
-import './DropdownWithFilter.css';
+import * as styles from './DropdownWithFilter.scss';
 
 /**
  * Props for DropdownWithFilter.
@@ -138,7 +135,7 @@ export function DropdownWithFilter<T>({
   return (
     <div
       ref={dropdownRef}
-      className={`dropdown dropdown-with-filter${open ? ' open' : ''}`}
+      className={`dropdown ${styles.dropdownWithFilter}${open ? ' open' : ''}`}
       id={id}
     >
       <button
@@ -151,13 +148,13 @@ export function DropdownWithFilter<T>({
         {title} <span className="caret" />
       </button>
       {open && (
-        <ul className="dropdown-menu pull-right">
-          <li className="dropdown-filter-input">
+        <ul className={`dropdown-menu pull-right ${styles.dropdownMenu}`}>
+          <li className={styles.dropdownFilterInput}>
             <input
               ref={inputRef}
               type="text"
               placeholder={placeholder || 'Filter...'}
-              className="form-control"
+              className={styles.dropdownFilterInputInput + ' form-control'}
               value={filterValue}
               onChange={e => onFilterChange(e.target.value)}
               autoComplete="off"
@@ -169,7 +166,7 @@ export function DropdownWithFilter<T>({
                 <a
                   href="#"
                   tabIndex={-1}
-                  className="dropdown-item"
+                  className={styles.dropdownItem}
                   onClick={e => { e.preventDefault(); handleSelect(item); }}
                 >
                   {getLabel(item)}
@@ -177,7 +174,7 @@ export function DropdownWithFilter<T>({
               </li>
             ))
           ) : (
-            <li><span className="dropdown-no-results">{noResultsText || 'No results'}</span></li>
+            <li><span className={styles.dropdownNoResults}>{noResultsText || 'No results'}</span></li>
           )}
         </ul>
       )}

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
@@ -19,7 +19,7 @@
  */
 
 import * as React from 'react';
-import './DropdownWithFilter.scss';
+import './DropdownWithFilter.css';
 
 /**
  * Props for DropdownWithFilter.

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
@@ -1,17 +1,92 @@
-import * as React from 'react';
+/**
+ * ResearchSpace
+ * Copyright (C) 2022-2024, © Kartography Community Interest Company
+ * Copyright (C) 2020, © Trustees of the British Museum
+ * Copyright (C) 2015-2019, metaphacts GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
+import * as React from 'react';
+import './DropdownWithFilter.scss';
+
+/**
+ * Props for DropdownWithFilter.
+ *
+ * @template T - The type of each item in the dropdown list. T can be any object or primitive; you provide a getLabel function to extract a string label from each item.
+ */
 interface DropdownWithFilterProps<T> {
+  /**
+   * Unique id for the dropdown root element.
+   */
   id: string;
+  /**
+   * The button label or content for the dropdown toggle.
+   */
   title: React.ReactNode;
+  /**
+   * The array of items to display in the dropdown.
+   */
   items: T[];
+  /**
+   * The current value of the filter input.
+   */
   filterValue: string;
+  /**
+   * Callback when the filter input changes.
+   */
   onFilterChange: (value: string) => void;
+  /**
+   * Callback when an item is selected.
+   */
   onSelect: (item: T) => void;
+  /**
+   * Function to extract the display label from an item.
+   */
   getLabel: (item: T) => string;
+  /**
+   * Optional placeholder for the filter input.
+   */
   placeholder?: string;
+  /**
+   * Optional text to display when no items match the filter.
+   */
   noResultsText?: string;
 }
 
+
+/**
+ * DropdownWithFilter
+ * ------------------
+ * A reusable, generic dropdown component with a filter input, styled for React-Bootstrap v3.
+ *
+ * Renders a dropdown menu with a filterable list of items.
+ *
+ *
+ * @example
+ * <DropdownWithFilter
+ *   id="my-dropdown"
+ *   title="Select Item"
+ *   items={[{ label: 'A' }, { label: 'B' }]}
+ *   filterValue={filterValue}
+ *   onFilterChange={setFilterValue}
+ *   onSelect={item => alert(item.label)}
+ *   getLabel={item => item.label}
+ *   placeholder="Filter..."
+ *   noResultsText="No items found"
+ * />
+ */
 export function DropdownWithFilter<T>({
   id,
   title,
@@ -63,8 +138,7 @@ export function DropdownWithFilter<T>({
   return (
     <div
       ref={dropdownRef}
-      className={`dropdown${open ? ' open' : ''}`}
-      style={{ display: 'inline-block', position: 'relative', marginLeft: 8 }}
+      className={`dropdown dropdown-with-filter${open ? ' open' : ''}`}
       id={id}
     >
       <button
@@ -73,19 +147,17 @@ export function DropdownWithFilter<T>({
         onClick={handleToggle}
         aria-haspopup="true"
         aria-expanded={open}
-        style={{ userSelect: 'none' }}
       >
         {title} <span className="caret" />
       </button>
       {open && (
-        <ul className="dropdown-menu pull-right" style={{ minWidth: 180, maxHeight: 240, overflowY: 'auto', padding: 0 }}>
-          <li style={{ padding: '8px 12px', position: 'sticky', top: 0, background: '#fff', zIndex: 1 }}>
+        <ul className="dropdown-menu pull-right">
+          <li className="dropdown-filter-input">
             <input
               ref={inputRef}
               type="text"
               placeholder={placeholder || 'Filter...'}
               className="form-control"
-              style={{ width: '100%', marginBottom: 4 }}
               value={filterValue}
               onChange={e => onFilterChange(e.target.value)}
               autoComplete="off"
@@ -97,7 +169,7 @@ export function DropdownWithFilter<T>({
                 <a
                   href="#"
                   tabIndex={-1}
-                  style={{ display: 'block', padding: '6px 20px', cursor: 'pointer', whiteSpace: 'normal' }}
+                  className="dropdown-item"
                   onClick={e => { e.preventDefault(); handleSelect(item); }}
                 >
                   {getLabel(item)}
@@ -105,7 +177,7 @@ export function DropdownWithFilter<T>({
               </li>
             ))
           ) : (
-            <li><span style={{ color: '#888', padding: '6px 20px', display: 'block' }}>{noResultsText || 'No results'}</span></li>
+            <li><span className="dropdown-no-results">{noResultsText || 'No results'}</span></li>
           )}
         </ul>
       )}

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
@@ -159,7 +159,7 @@ export function DropdownWithFilter<T>({
               ref={inputRef}
               type="text"
               placeholder={placeholder || 'Filter...'}
-              className={styles.dropdownFilterInputInput + ' form-control'}
+              className={'form-control'}
               value={filterValue}
               onChange={e => onFilterChange(e.target.value)}
               autoComplete="off"

--- a/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
+++ b/src/main/web/components/forms/inputs/dropdown/DropdownWithFilter.tsx
@@ -60,6 +60,10 @@ interface DropdownWithFilterProps<T> {
    * Optional text to display when no items match the filter.
    */
   noResultsText?: string;
+  /**
+   * Optional to hide or show the filter input entirely.
+   */
+  showFilter?: boolean;
 }
 
 
@@ -93,7 +97,8 @@ export function DropdownWithFilter<T>({
   onSelect,
   getLabel,
   placeholder,
-  noResultsText
+  noResultsText,
+  showFilter = true,
 }: DropdownWithFilterProps<T>) {
   const [open, setOpen] = React.useState(false);
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -149,7 +154,7 @@ export function DropdownWithFilter<T>({
       </button>
       {open && (
         <ul className={`dropdown-menu pull-right ${styles.dropdownMenu}`}>
-          <li className={styles.dropdownFilterInput}>
+          {showFilter && <li className={styles.dropdownFilterInput}>
             <input
               ref={inputRef}
               type="text"
@@ -159,7 +164,7 @@ export function DropdownWithFilter<T>({
               onChange={e => onFilterChange(e.target.value)}
               autoComplete="off"
             />
-          </li>
+          </li>}
           {filtered.length > 0 ? (
             filtered.map(item => (
               <li role="menuitem" key={getLabel(item)}>


### PR DESCRIPTION
# Why

This addresses the need for a dropdown that supports filtering, does not close on input focus, and is easy to integrate into forms or toolbars.

# What

Added a `DropdownWithFilter` component with the following features
- Filterable dropdown menu with a sticky filter input at the top.
- Ability to hide/show input filter
- Closes when clicking outside.
- Uses Bootstrap v3 classes for styling, with minimal custom CSS.

The component is available in form `AutocompleteInput` and `SelectInput` for the dropdown displaying the list of resource available to insert.

Example of how to use it

```
<DropdownWithFilter
  id="my-dropdown"
  title="Select Item"
  items={[{ label: 'A' }, { label: 'B' }]}
  filterValue={filterValue}
  onFilterChange={setFilterValue}
  onSelect={item => alert(item.label)}
  getLabel={item => item.label}
  placeholder="Filter..."
  noResultsText="No items found"
/>
```

# Video / Gif / Screenshot


https://github.com/user-attachments/assets/9e47d5cc-13d5-4549-a3b4-c0f9c8ce267c

# How To Test

- Open a form that has `AutocompleteInput` component
- Click `New` button to open dropdown
- You should be able to see the filter input
- Start typing in the input should filter dropdown items