### PR TITLE
Dimension value KP fix

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDimension.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FDimension.html
@@ -19,6 +19,8 @@
                             entity_primary_appellation="http://www.researchspace.org/pattern/system/entity/primary_appellation"
                             dimension_type="http://www.researchspace.org/pattern/system/dimension/type"
                             dimension_value="http://www.researchspace.org/pattern/system/dimension/value"
+                            dimension_value_integer="http://www.researchspace.org/pattern/system/dimension/value_integer"
+                            dimension_value_decimal="http://www.researchspace.org/pattern/system/dimension/value_decimal"
                             dimension_lower_value="http://www.researchspace.org/pattern/system/dimension/lower_value"
                             dimension_upper_value="http://www.researchspace.org/pattern/system/dimension/upper_value"
                             dimension_unit="http://www.researchspace.org/pattern/system/dimension/unit"
@@ -70,11 +72,20 @@
                                                         }
                                                     ]'> 
                         </semantic-form-select-input>
-                
+
                         <div class="form-inline-inputs">
                             <div style="flex: 1;">
-                                <semantic-form-text-input for="dimension_value" label="Dimension value" placeholder="Enter measured value"></semantic-form-text-input>
+                                <semantic-form-text-input for="dimension_value" label="Dimension value (text)" placeholder="Enter measured value"></semantic-form-text-input>
                             </div>
+                            <div style="flex: 1;">
+                                <semantic-form-text-input for="dimension_value_integer" label="Dimension value (number)" placeholder="Enter measured value"></semantic-form-text-input>
+                            </div>
+                            <div style="flex: 1;">
+                                <semantic-form-text-input for="dimension_value_decimal" label="Dimension value (decimal number)" placeholder="Enter measured value"></semantic-form-text-input>
+                            </div>
+                        </div>
+
+                        <div class="form-inline-inputs">
                             <div style="flex: 1;">
                                 <semantic-form-text-input for="dimension_lower_value" label="Dimension lower value" placeholder="Enter lower measured value"></semantic-form-text-input>
                             </div>

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMonetaryAmount.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2Fsystem%2Fforms%2FMonetaryAmount.html
@@ -19,6 +19,8 @@
                             entity_primary_appellation="http://www.researchspace.org/pattern/system/entity/primary_appellation"
                             monetary_amount_currency="http://www.researchspace.org/pattern/system/monetary_amount/currency"
                             dimension_value="http://www.researchspace.org/pattern/system/dimension/value"
+                            dimension_value_integer="http://www.researchspace.org/pattern/system/dimension/value_integer"
+                            dimension_value_decimal="http://www.researchspace.org/pattern/system/dimension/value_decimal"
                             dimension_lower_value="http://www.researchspace.org/pattern/system/dimension/lower_value"
                             dimension_upper_value="http://www.researchspace.org/pattern/system/dimension/upper_value"
                             dimension_unit="http://www.researchspace.org/pattern/system/dimension/unit"
@@ -73,13 +75,22 @@
 
                         <div class="form-inline-inputs">
                             <div style="flex: 1;">
-                                <semantic-form-text-input for="dimension_value" label="Monetary amount value" placeholder="Enter value"></semantic-form-text-input>
+                                <semantic-form-text-input for="dimension_value" label="Monetary amount value (text)" placeholder="Enter measured value"></semantic-form-text-input>
                             </div>
                             <div style="flex: 1;">
-                                <semantic-form-text-input for="dimension_lower_value" label="Monetary amount lower value" placeholder="Enter lower value"></semantic-form-text-input>
+                                <semantic-form-text-input for="dimension_value_integer" label="Monetary amount value (number)" placeholder="Enter measured value"></semantic-form-text-input>
                             </div>
                             <div style="flex: 1;">
-                                <semantic-form-text-input for="dimension_upper_value" label="Monetary amount upper value" placeholder="Enter upper value"></semantic-form-text-input>
+                                <semantic-form-text-input for="dimension_value_decimal" label="Monetary amount value (decimal number)" placeholder="Enter measured value"></semantic-form-text-input>
+                            </div>
+                        </div>
+
+                        <div class="form-inline-inputs">
+                            <div style="flex: 1;">
+                                <semantic-form-text-input for="dimension_lower_value" label="Monetary amount lower value" placeholder="Enter lower measured value"></semantic-form-text-input>
+                            </div>
+                            <div style="flex: 1;">
+                                <semantic-form-text-input for="dimension_upper_value" label="Monetary amount upper value" placeholder="Enter upper measured value"></semantic-form-text-input>
                             </div>
                         </div>
 

--- a/src/main/resources/org/researchspace/apps/default/ldp/configurations/http%3A%2F%2Fwww.researchspace.org%2Fpatterns%2Fsystem.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/configurations/http%3A%2F%2Fwww.researchspace.org%2Fpatterns%2Fsystem.trig
@@ -445,6 +445,8 @@
 
     <http://www.researchspace.org/pattern/system/dimension/type> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/dimension/value> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/dimension/value_integer> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
+    <http://www.researchspace.org/pattern/system/dimension/value_decimal> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/dimension/lower_value> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/dimension/upper_value> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .
     <http://www.researchspace.org/pattern/system/dimension/unit> <http://www.researchspace.org/resource/system/fields/type> <http://www.researchspace.org/resource/system/type/system> .

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Flower_value.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Flower_value.trig
@@ -22,6 +22,7 @@
   _:genid-c73a815da1e5400c9565eba9d3ccdd17-upma9 a <http://spinrdf.org/sp#Query>;
     <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value WHERE {
   $subject crm:P90a_has_lower_value_limit $value . 
+  FILTER(datatype(?value) = xsd:string)
 }""" .
   
   _:genid-c73a815da1e5400c9565eba9d3ccdd17-yl5ji3 a <http://spinrdf.org/sp#Query>;
@@ -29,6 +30,7 @@
     $subject crm:P90a_has_lower_value_limit $value .
 }  WHERE {
     $subject crm:P90a_has_lower_value_limit $value .
+    FILTER(datatype(?value) = xsd:string)
 }""" .
   
   <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fupper_value.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fupper_value.trig
@@ -17,6 +17,7 @@
   _:genid-0232cb5b293b423985d1ff0a9a3d8b51-kkeore a <http://spinrdf.org/sp#Query>;
     <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value WHERE {
   $subject crm:P90b_has_upper_value_limit $value . 
+  FILTER(datatype(?value) = xsd:string)
 }""" .
   
   _:genid-0232cb5b293b423985d1ff0a9a3d8b51-zsjdup a <http://spinrdf.org/sp#Query>;
@@ -29,6 +30,7 @@
     $subject crm:P90b_has_upper_value_limit $value .
 }  WHERE {
     $subject crm:P90b_has_upper_value_limit $value .
+    FILTER(datatype(?value) = xsd:string)
 }""" .
   
   <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fvalue.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fvalue.trig
@@ -16,7 +16,8 @@
   
   _:genid-3b60424a898543e3b2ea80eb6a6969e5-q8qauq a <http://spinrdf.org/sp#Query>;
     <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value WHERE {
-  $subject crm:P90_has_value $value . 
+    $subject crm:P90_has_value ?value .
+    FILTER(datatype(?value) = xsd:string)
 }""" .
   
   _:genid-3b60424a898543e3b2ea80eb6a6969e5-q80wtt a <http://spinrdf.org/sp#Query>;
@@ -29,6 +30,7 @@
     $subject crm:P90_has_value $value .
 }  WHERE {
     $subject crm:P90_has_value $value .
+    FILTER(datatype(?value) = xsd:string)
 }""" .
   
   <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fvalue_decimal.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fvalue_decimal.trig
@@ -1,0 +1,38 @@
+
+<http://www.researchspace.org/pattern/system/dimension/value_decimal/context> {
+  <http://www.researchspace.org/pattern/system/dimension/value_decimal> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#decimal>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Value (decimal number)";
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E54_Dimension>;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-0b9c3511161c466eaeb1f370bb9d6e79-kxnjfl;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/dimension>;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-0b9c3511161c466eaeb1f370bb9d6e79-aptg5b;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-0b9c3511161c466eaeb1f370bb9d6e79-8knph;
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-07-04T10:18:19.236+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-0b9c3511161c466eaeb1f370bb9d6e79-8knph a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value WHERE {
+  $subject crm:P90_has_value $value . 
+  FILTER(datatype(?value) = xsd:decimal)
+}""" .
+  
+  _:genid-0b9c3511161c466eaeb1f370bb9d6e79-kxnjfl a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P90_has_value $value . 
+} WHERE {}""" .
+  
+  _:genid-0b9c3511161c466eaeb1f370bb9d6e79-aptg5b a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+    $subject crm:P90_has_value $value .
+}  WHERE {
+    $subject crm:P90_has_value $value .
+    FILTER(datatype(?value) = xsd:decimal)
+}""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/dimension/value_decimal> .
+}

--- a/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fvalue_integer.trig
+++ b/src/main/resources/org/researchspace/apps/default/ldp/system/http%3A%2F%2Fwww.researchspace.org%2Fpattern%2Fsystem%2Fdimension%2Fvalue_integer.trig
@@ -1,0 +1,38 @@
+
+<http://www.researchspace.org/pattern/system/dimension/value_integer/context> {
+  _:genid-4234037abf5d437681edda6a9e9841e0-age4o a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """DELETE {
+    $subject crm:P90_has_value $value .
+}  WHERE {
+    $subject crm:P90_has_value $value .
+    FILTER(datatype(?value) = xsd:integer)
+}""" .
+  
+  <http://www.researchspace.org/pattern/system/dimension/value_integer> a <http://www.researchspace.org/resource/system/fields/Field>,
+      <http://www.w3.org/ns/prov#Entity>, <http://www.w3.org/ns/ldp#Resource>;
+    <http://www.researchspace.org/resource/system/fields/domain> <http://www.cidoc-crm.org/cidoc-crm/E54_Dimension>;
+    <http://www.researchspace.org/resource/system/fields/deletePattern> _:genid-4234037abf5d437681edda6a9e9841e0-age4o;
+    <http://www.researchspace.org/resource/system/fields/minOccurs> "0";
+    <http://www.researchspace.org/resource/system/fields/insertPattern> _:genid-4234037abf5d437681edda6a9e9841e0-rib8q;
+    <http://www.researchspace.org/resource/system/fields/selectPattern> _:genid-4234037abf5d437681edda6a9e9841e0-7pog4m;
+    <http://www.researchspace.org/resource/system/fields/category> <http://www.researchspace.org/resource/system/category/dimension>;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Value (number)";
+    <http://www.researchspace.org/resource/system/fields/xsdDatatype> <http://www.w3.org/2001/XMLSchema#integer>;
+    <http://www.researchspace.org/resource/system/fields/maxOccurs> "1";
+    <http://www.w3.org/ns/prov#wasAttributedTo> <http://www.researchspace.org/resource/user/admin>;
+    <http://www.w3.org/ns/prov#generatedAtTime> "2025-07-04T10:17:27.545+01:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+  
+  _:genid-4234037abf5d437681edda6a9e9841e0-7pog4m a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """SELECT DISTINCT ?value WHERE {
+  $subject crm:P90_has_value $value . 
+  FILTER(datatype(?value) = xsd:integer)
+}""" .
+  
+  _:genid-4234037abf5d437681edda6a9e9841e0-rib8q a <http://spinrdf.org/sp#Query>;
+    <http://spinrdf.org/sp#text> """INSERT { 
+  $subject crm:P90_has_value $value . 
+} WHERE {}""" .
+  
+  <http://www.researchspace.org/resource/system/fieldDefinitionContainer> <http://www.w3.org/ns/ldp#contains>
+      <http://www.researchspace.org/pattern/system/dimension/value_integer> .
+}


### PR DESCRIPTION
# Why
KP dimension_value="http://www.researchspace.org/pattern/system/dimension/value" must be restricted to select only values of datatype string.
The ability to record a dimension value as integer or decimal has been requested in projects, especially in scientific dataset contexts.

# What
- Fix on dimension_value (xsd:string) KP
- Added Dimension value as integer and decimal value in Dimension and Monetary amount forms

