### PR TITLE
Add blazegraph war to the source tree.

### DIFF
--- a/blazegraph-vocabularies/build.gradle
+++ b/blazegraph-vocabularies/build.gradle
@@ -23,11 +23,11 @@ targetCompatibility = JavaVersion.VERSION_1_8
 repositories {
     // Use jcenter for resolving dependencies.
     jcenter()
-
-    // for blazegraph war
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 dependencies {
-    compileOnly 'com.blazegraph:bigdata-core:2.2.0-20160908.002748-7'
+    // Add the JAR files from the local blazegraph WAR
+    compileOnly zipTree('../libs/blazegraph-2.2.0.war').matching {
+        include 'WEB-INF/lib/**/*.jar'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ java {
 farms {
     farm 'researchspace', {
         // setup blazegraph for local development
-        webapp 'com.blazegraph:blazegraph-war:2.2.0-20160908.003514-6',
+        webapp file('libs/blazegraph-2.2.0.war'),
             contextPath: '/blazegraph',
             overlays: [':blazegraph-vocabularies']
 
@@ -271,9 +271,9 @@ project.afterEvaluate {
 
 
     // for some reason overlay explode task that is needed for farm overlays is not added as a dependency
-    tasks.farmRunresearchspace.dependsOn tasks['farmOverlayArchiveresearchspaceblazegraph-war-2.2.0-20160908.003514-6.war']
-    tasks.farmRunDebugresearchspace.dependsOn tasks['farmOverlayArchiveresearchspaceblazegraph-war-2.2.0-20160908.003514-6.war']
-    tasks.buildProductresearchspace.dependsOn tasks['farmOverlayArchiveresearchspaceblazegraph-war-2.2.0-20160908.003514-6.war']
+    tasks.farmRunresearchspace.dependsOn tasks['farmOverlayArchiveresearchspaceblazegraph-2.2.0.war']
+    tasks.farmRunDebugresearchspace.dependsOn tasks['farmOverlayArchiveresearchspaceblazegraph-2.2.0.war']
+    tasks.buildProductresearchspace.dependsOn tasks['farmOverlayArchiveresearchspaceblazegraph-2.2.0.war']
 
     // connect our custom tasks with tasks from gretty
     tasks.debugAll.dependsOn tasks.farmRunDebugresearchspace
@@ -302,9 +302,6 @@ task runWiremock(type: JavaExec) {
 
 repositories {
     mavenCentral()
-
-    // for blazegraph war
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 
     // for digilib war
     maven { url 'https://robcast.github.io/digilib-repo/maven-repo' }


### PR DESCRIPTION
Add blazegraph war to the source tree. Fixes #415.

# Why

Sonatype repository reached end of life, see https://central.sonatype.org/news/20250326_ossrh_sunset/

# What

Added dependency directly to the source tree.

# How To Test

```
./gradlew runAll
```