### PR TITLE
SelectInput - new prop updateListOnOpen

### DIFF
--- a/src/main/web/components/forms/forms.scss
+++ b/src/main/web/components/forms/forms.scss
@@ -346,7 +346,7 @@ fieldset[disabled] .form-control {
   &__group-instance > &__remove-value {
     position: absolute;
     right: 0;
-    top: 0;
+    top: -1px;
     padding: 0 9px;
     display: flex;
     align-items: center;
@@ -354,7 +354,7 @@ fieldset[disabled] .form-control {
 
     background-color: transparent;
     border-right: none;
-    border-top: none;
+  //  border-top: none;
     height: 38px;
     width: 38px;
 
@@ -1755,14 +1755,14 @@ fieldset[disabled] .form-control {
   cursor: pointer;
   
   padding: 0 9px;
-  border-right: none;
-  border-top: none;
+//  border-right: none;
+//  border-top: none;
   background-color: transparent;
 
   display: flex;
   align-items: center;
   position: absolute;
-  top: 0;
+  top: -1px;
   right: 37px;
 
   i {

--- a/src/main/web/components/forms/inputs/SelectInput.tsx
+++ b/src/main/web/components/forms/inputs/SelectInput.tsx
@@ -109,6 +109,12 @@ export interface SelectInputProps extends AtomicValueInputProps {
    */
   showDropdownFilter?: boolean;
 
+  /**
+   * If set to true, re-initiates the value set each time the dropdown is opened
+   * @default false
+   */
+  updateListOnOpen?: boolean;
+
 }
 
 interface State {
@@ -371,6 +377,7 @@ export class SelectInput extends AtomicValueInput<SelectInputProps, State> {
           value={selectedValue}
           optionRenderer={this.optionRenderer}
           valueRenderer={this.valueRenderer}
+          onOpen={() => {this.props.updateListOnOpen && this.initValueSet()}}
         />
         <ValidationMessages errors={FieldValue.getErrors(this.props.value)} />
         { showCreateNewButton && (

--- a/src/main/web/styling/_utilities.scss
+++ b/src/main/web/styling/_utilities.scss
@@ -184,6 +184,10 @@
   overflow-y: auto;
 }
 
+.overflow-y-hidden {
+  overflow-y: hidden !important;
+}
+
 .object-fit-cover {
   object-fit: cover;
 }


### PR DESCRIPTION
# Why

The Select Input doesn't update the list of results each time the dropdown is opened, but this is needed when specific workflows are happening on multiple frames. 

# What

Added new prop `update-list-on-open` that re-initiates the value set each time the dropdown is opened. The prop is false by default.

# How To Test

Example in semantic form:

`<semantic-form-select-input 
for='sampling_site_image_annotation' 
label="Sampling site - image annotation"
placeholder="Select image annotation representing the sampling site"  
update-list-on-open="true">
</semantic-form-select-input>`