### PR TITLE
Don't try to generate link for null IRIs.

### DIFF
--- a/src/main/web/api/navigation/components/ResourceLink.ts
+++ b/src/main/web/api/navigation/components/ResourceLink.ts
@@ -60,20 +60,17 @@ interface State {
 export class ResourceLink extends Component<ResourceLinkProps, State> {
   constructor(props: ResourceLinkProps, context: any) {
     super(props, context);
-    if (this.props.resource && this.props.resource.value) {
-      this.state = {
-        url: construcUrlForResourceSync(
-          this.props.resource,
-          this.props.params,
-          this.getRepository(),
-          this.props.fragment
-        ),
-      };
-    } else {
-      this.state = {
-        url: undefined
-      };
-    }
+    this.state = {
+      url:
+        this.props.resource && this.props.resource.value
+          ? construcUrlForResourceSync(
+              this.props.resource,
+              this.props.params,
+              this.getRepository(),
+              this.props.fragment
+            )
+          : undefined,
+    };
   }
 
   static defaultProps = {
@@ -148,9 +145,6 @@ export class ResourceLink extends Component<ResourceLinkProps, State> {
 
   private isLinkActive = () => {
     const { resource, params } = this.props;
-    if (!resource || !resource.value) {
-      return false;
-    }
     const urlParams = assign({}, params);
     if (!_.isUndefined(this.props.action)) {
       urlParams['action'] = ResourceLinkAction[this.props.action];

--- a/src/main/web/components/forms/inputs/Decorations.tsx
+++ b/src/main/web/components/forms/inputs/Decorations.tsx
@@ -87,19 +87,12 @@ export class InputDecorator extends Component<MultipleValuesProps, {}> {
     return (
       <div className={`${DECORATOR_CLASS}__header`}>
         {(definition.label && definition.label.length) || label ? (
-          definition.iri ? (
-            <ResourceLink resource={Rdf.iri(definition.iri)} draggable={false} target='_blank'>
-              <span className={`${DECORATOR_CLASS}__label`}>
-                {label ? label : getPreferredLabel(definition.label)}
-                {isRequired ? <span className={`${DECORATOR_CLASS}__label-required`} title="Required field" />: null}
-              </span>
-            </ResourceLink>
-          ) : (
+          <ResourceLink resource={definition.iri ? Rdf.iri(definition.iri) : undefined} draggable={false} target='_blank'>
             <span className={`${DECORATOR_CLASS}__label`}>
               {label ? label : getPreferredLabel(definition.label)}
               {isRequired ? <span className={`${DECORATOR_CLASS}__label-required`} title="Required field" />: null}
             </span>
-          )
+          </ResourceLink>
         ) : null}
         {/* {definition.description ? (
           <OverlayTrigger


### PR DESCRIPTION
# Why

Because of bugs, as we had in Decorator, sometime we try to render semantic-link for "null" IRI, obviously it doesn't make sense. This PR changes ResourceLink to not crash when that happens.
# How To Test

http://localhost:10214/resource/rsp:OntologyPropertiesSearch should now work