### PR TITLE
mp-draggable: drag-image-selector prop and pointer event handling

### DIFF
--- a/src/main/web/components/dnd/DraggableComponent.ts
+++ b/src/main/web/components/dnd/DraggableComponent.ts
@@ -30,6 +30,11 @@ export interface DraggableProps {
    */
   iri: string;
   /**
+   * CSS selector of an ancestor to use as the drag preview instead of the
+   * element itself (e.g. the whole card when dragging by an inner handle).
+   */
+  dragImageSelector?: string;
+  /**
    * Styles that are added to the component, if it dragged.
    */
   dragStyles?: CSSProperties;
@@ -99,6 +104,15 @@ export class Draggable extends Component<DraggableProps, State> {
     // One can drop into draft-js contenteditable only if some known to browser mime-type is set
     e.dataTransfer.setData(DRAG_AND_DROP_FORMAT_IE, this.props.iri);
 
+    const { dragImageSelector } = this.props;
+    if (dragImageSelector && e.dataTransfer.setDragImage) {
+      const preview = this.source.closest(dragImageSelector);
+      if (preview) {
+        const rect = preview.getBoundingClientRect();
+        e.dataTransfer.setDragImage(preview, e.clientX - rect.left, e.clientY - rect.top);
+      }
+    }
+
     this.setState({ isDragged: true });
     if (this.props.onDragStart) {
       this.props.onDragStart(this.props.iri);
@@ -137,6 +151,8 @@ export class Draggable extends Component<DraggableProps, State> {
       style: style,
       draggable: true,
       onMouseDown: (e) => e.stopPropagation(),
+      // stop pointerdown too, or pointer-event canvases pan instead of dragging
+      onPointerDown: (e) => e.stopPropagation(),
     });
   }
 }


### PR DESCRIPTION
Adds an optional drag-image-selector attribute that shows the closest matching ancestor (e.g. the whole card) as the drag preview when dragging by a handle inside it, and stops pointerdown alongside mousedown so containers driven by pointer events cannot hijack the native drag.

# Why

So we can custom drag image, e.g. in the KM there is drag handle to drag-and-drop cards into Clipboard, with this change when you drag handle you see the whole card as dragged.

# How To Test

Check how it works in the `reactodia-update-clean` in KMs.