### PR TITLE
bugfix: prevent constant template re-renderings

### DIFF
--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FImageAnnotationWorkspace.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FImageAnnotationWorkspace.html
@@ -294,7 +294,7 @@ new:
           Iterate over all query result bindings that represent image regions.
           --]]
                                               {{#each bindings}}
-                                                <mp-event-trigger id='focus-event-trigger' type='IIIFViewer.HighlightRegion' targets='["image-editor"]'
+                                                <mp-event-trigger id='focus-event-trigger-{{region.value}}' type='IIIFViewer.HighlightRegion' targets='["image-editor"]'
                                                                   data='{"imageIri": "{{image.value}}","regionIri": "{{region.value}}"}' on='["hover"]'
                                                 >
                                                 <div class="imageAnnotationWorkspace__item">
@@ -387,7 +387,7 @@ new:
                                               <h2>Features</h2>
                                               <div class="imageAnnotationWorkspace__item_container">
                                               {{#each bindings}}
-                                                <mp-event-trigger id='focus-event-trigger' type='IIIFViewer.HighlightRegion' targets='["image-editor"]'
+                                                <mp-event-trigger id='focus-event-trigger-{{feature.value}}' type='IIIFViewer.HighlightRegion' targets='["image-editor"]'
                                                                   data='{"imageIri": "{{image.value}}","regionIri": "{{region.value}}"}' on='["hover"]'
                                                 >
 

--- a/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FSystemAssetsFrame.html
+++ b/src/main/resources/org/researchspace/apps/default/data/templates/http%3A%2F%2Fwww.researchspace.org%2Fresource%2FSystemAssetsFrame.html
@@ -54,7 +54,7 @@
                                       id="upload-type-selection"
                   >
                     {{#each bindings}}
-                      <mp-event-trigger id='upload-pdf' 
+                      <mp-event-trigger id='upload-asset-{{@index}}' 
                                         type='Component.TemplateUpdate' 
                                         data='{"assetTypeIndex": "{{@index}}"}' 
                                         targets='["asset-upload-form-area"]'>

--- a/src/main/web/api/module-loader/Registry.ts
+++ b/src/main/web/api/module-loader/Registry.ts
@@ -266,7 +266,11 @@ function processStyle(node: Node, children: Array<React.ReactNode>): Promise<Rea
   return Promise.resolve(styleNode);
 }
 
-function processReactComponent(node: Node, children: Array<ReactNode>): Promise<React.ReactElement<any>> {
+function processReactComponent(
+  node: Node,
+  children: Array<ReactNode>,
+  index?: number
+): Promise<React.ReactElement<any>> {
   let attributes;
   try {
     attributes = htmlAttributesToReactProps(node.attribs);
@@ -276,13 +280,16 @@ function processReactComponent(node: Node, children: Array<ReactNode>): Promise<
     throw new Error(msg);
   }
 
-  // was previously {key: `component-${index}-${level}`},
+  // stable key (id-based, else position) so re-parsing an equivalent template
+  // updates components in place instead of remounting, as a random key did
   const computedKey =
     attributes['key'] && !attributes['fixedKey']
       ? attributes['key']
       : attributes['fixedKey']
       ? attributes['fixedKey']
-      : Math.random().toString(36).slice(2);
+      : typeof attributes['id'] === 'string' && attributes['id'] !== ''
+      ? `component-${node.name}-id-${attributes['id']}`
+      : `component-${node.name}-${index ?? 0}`;
 
   // we propagate attributes as-is, but also put them into special config field
   let props = assign({ key: computedKey }, attributes);

--- a/src/main/web/api/navigation/components/ResourceLinkComponent.ts
+++ b/src/main/web/api/navigation/components/ResourceLinkComponent.ts
@@ -143,26 +143,36 @@ export class ResourceLinkComponent extends Component<ResourceLinkProps, State> {
   };
 
   public componentDidMount() {
-    const iri = this.getIri();
-
-    if (!iri) {
-      return;
-    }
-
-    this.getRepository().onValue((repository) => {
-      this.fetchLabel(Rdf.iri(iri), this.props.children, repository).onValue((label) =>
-        this.setState({
-          label: maybe.Just(label),
-          repository: maybe.Just(repository),
-        })
-      );
-    });
+    this.loadLabel(this.props);
   }
 
   public componentWillReceiveProps(nextProps: ResourceLinkProps) {
     if (this.props.uri !== nextProps.uri) {
       this.checkDeprecated(nextProps);
     }
+    const nextIri = nextProps.iri || nextProps.uri;
+    if (nextIri !== this.getIri()) {
+      this.setState({ label: maybe.Nothing<string>() });
+      this.loadLabel(nextProps);
+    }
+  }
+
+  private loadLabel(props: ResourceLinkProps) {
+    const iri = props.iri || props.uri;
+    if (!iri) {
+      return;
+    }
+
+    this.getRepository().onValue((repository) => {
+      this.fetchLabel(Rdf.iri(iri), props.children, repository).onValue((label) => {
+        if (this.getIri() === iri) {
+          this.setState({
+            label: maybe.Just(label),
+            repository: maybe.Just(repository),
+          });
+        }
+      });
+    });
   }
 
   public componentWillUnmount() {

--- a/src/main/web/components/dashboard/DashboardComponent.tsx
+++ b/src/main/web/components/dashboard/DashboardComponent.tsx
@@ -218,7 +218,7 @@ export class DashboardComponent extends Component<Props, State> {
     this.itemLabelCount = this.itemLabelCount + 1;
 
     const displayLabel = label ?? 'Homepage';
-    const displayCustomLabel = this.props.initialView?.data["customLabel"] && (this.state.items.length == 0) ?this.props.initialView.data["customLabel"]:displayLabel;
+    const displayCustomLabel = this.props.initialView?.data?.["customLabel"] && (this.state.items.length == 0) ?this.props.initialView.data["customLabel"]:displayLabel;
 
     return { 
       // id: uniqueId(displayLabel.replace(/\s/g, '')),

--- a/src/main/web/components/events/EventProxy.ts
+++ b/src/main/web/components/events/EventProxy.ts
@@ -18,7 +18,7 @@
  */
 
 import { Component } from 'react';
-import { isMatch } from 'lodash';
+import { isEqual, isMatch } from 'lodash';
 
 import { Cancellation } from 'platform/api/async';
 import { Event, listen, trigger } from 'platform/api/events';
@@ -95,6 +95,23 @@ export class EventProxy extends Component<EventProxyProps, void> {
   private cancelation = new Cancellation();
 
   componentDidMount() {
+    this.subscribe();
+  }
+
+  componentDidUpdate(prevProps: EventProxyProps) {
+    if (
+      prevProps.onEventType !== this.props.onEventType ||
+      !isEqual(prevProps.onEventTypes, this.props.onEventTypes) ||
+      prevProps.onEventSource !== this.props.onEventSource ||
+      prevProps.onEventTarget !== this.props.onEventTarget
+    ) {
+      this.cancelation.cancelAll();
+      this.cancelation = new Cancellation();
+      this.subscribe();
+    }
+  }
+
+  private subscribe() {
     if (this.props.onEventTypes) {
       this.props.onEventTypes.forEach(
         eventType => {

--- a/src/main/web/components/events/EventTargetRefresh.ts
+++ b/src/main/web/components/events/EventTargetRefresh.ts
@@ -79,6 +79,18 @@ export class EventTargetRefresh extends Component<EventTargetRefreshProps, Event
   }
 
   componentDidMount() {
+    this.subscribe();
+  }
+
+  componentDidUpdate(prevProps: EventTargetRefreshProps) {
+    if (prevProps.id !== this.props.id || prevProps.refreshInterval !== this.props.refreshInterval) {
+      this.unsubscribe();
+      this.cancelation = new Cancellation();
+      this.subscribe();
+    }
+  }
+
+  private subscribe() {
     this.cancelation
       .map(
         listen({
@@ -93,13 +105,17 @@ export class EventTargetRefresh extends Component<EventTargetRefreshProps, Event
     }
   }
 
-  componentWillUnmount() {
+  private unsubscribe() {
     this.cancelation.cancelAll();
     // cleanup the timer
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
     }
+  }
+
+  componentWillUnmount() {
+    this.unsubscribe();
   }
 
   render() {

--- a/src/main/web/components/events/EventTargetTemplateRender.tsx
+++ b/src/main/web/components/events/EventTargetTemplateRender.tsx
@@ -61,7 +61,7 @@ export interface State {
  * </mp-event-target-template-render>
  */
 export class EventTargetTemplateRender extends Component<Props, State> {
-  private readonly cancellation = new Cancellation();
+  private cancellation = new Cancellation();
 
   constructor(props: Props, context: any) {
     super(props, context);
@@ -72,6 +72,18 @@ export class EventTargetTemplateRender extends Component<Props, State> {
   }
 
   componentDidMount() {
+    this.subscribe();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.id !== this.props.id) {
+      this.cancellation.cancelAll();
+      this.cancellation = new Cancellation();
+      this.subscribe();
+    }
+  }
+
+  private subscribe() {
     this.cancellation
       .map(
         listen({

--- a/src/main/web/components/iiif/ImageRegionEditor.ts
+++ b/src/main/web/components/iiif/ImageRegionEditor.ts
@@ -130,6 +130,27 @@ export class ImageRegionEditorComponentMirador extends Component<ImageRegionEdit
     this.queryAllImagesInfo();
   }
 
+  componentDidUpdate(prevProps: ImageRegionEditorProps) {
+    if (
+      !isEqual(prevProps.imageOrRegion, this.props.imageOrRegion) ||
+      prevProps.imageIdPattern !== this.props.imageIdPattern ||
+      prevProps.iiifServerUrl !== this.props.iiifServerUrl
+    ) {
+      removeMirador(this.miradorInstance, this.miradorElement);
+      this.miradorInstance = undefined;
+      this.setState(
+        {
+          loading: true,
+          allImages: this.normalizeImageProps(this.props),
+          info: undefined,
+          iiifImageId: undefined,
+          errorMessage: undefined,
+        },
+        () => this.queryAllImagesInfo()
+      );
+    }
+  }
+
   private triggerManifestUpdatedEvent = (resources: IiifManifestResource[]) => {
     trigger({
       eventType: ManifestUpdatedEvent,
@@ -158,11 +179,20 @@ export class ImageRegionEditorComponentMirador extends Component<ImageRegionEdit
   }
 
   private queryAllImagesInfo() {
-    this.queryImagesInfo(this.state.allImages).observe({
+    const { allImages } = this.state;
+    this.queryImagesInfo(allImages).observe({
       value: ({ info, iiifImageId }) => {
+        if (this.state.allImages !== allImages) {
+          return;
+        }
         this.setState({ loading: false, iiifImageId, info });
       },
-      error: (error) => this.setState({ loading: false, errorMessage: error }),
+      error: (error) => {
+        if (this.state.allImages !== allImages) {
+          return;
+        }
+        this.setState({ loading: false, errorMessage: error });
+      },
     });
   }
 

--- a/src/main/web/components/security/HasPermission.tsx
+++ b/src/main/web/components/security/HasPermission.tsx
@@ -39,7 +39,7 @@ interface State {
  * <mp-has-permission permission='delete:all:data'></mp-has-permission>
  */
 export class HasPermission extends Component<HasPermisssionProps, State> {
-  private readonly cancellation = new Cancellation();
+  private cancellation = new Cancellation();
 
   constructor(props: HasPermisssionProps) {
     super(props);
@@ -47,9 +47,26 @@ export class HasPermission extends Component<HasPermisssionProps, State> {
   }
 
   componentWillMount() {
+    this.checkPermission(this.props);
+  }
+
+  componentWillReceiveProps(props: HasPermisssionProps) {
+    if (props.permission !== this.props.permission) {
+      this.cancellation.cancelAll();
+      this.cancellation = new Cancellation();
+      this.setState({ allowedToSee: false });
+      this.checkPermission(props);
+    }
+  }
+
+  private checkPermission(props: HasPermisssionProps) {
     this.cancellation
-      .map(Security.isPermitted(this.props.permission))
+      .map(Security.isPermitted(props.permission))
       .onValue((allowedToSee) => this.setState({ allowedToSee }));
+  }
+
+  componentWillUnmount() {
+    this.cancellation.cancelAll();
   }
 
   render() {

--- a/src/main/web/components/semantic/conditional/SemanticIf.tsx
+++ b/src/main/web/components/semantic/conditional/SemanticIf.tsx
@@ -67,9 +67,20 @@ export class SemanticIf extends Component<SemanticIfProps, State> {
   }
 
   componentDidMount() {
+    this.evaluateQuery(this.props);
+  }
+
+  componentWillReceiveProps(nextProps: SemanticIfProps) {
+    if (nextProps.query !== this.props.query) {
+      this.setState({ loading: true, error: undefined, askResult: undefined });
+      this.evaluateQuery(nextProps);
+    }
+  }
+
+  private evaluateQuery(props: SemanticIfProps) {
     let askQuery: SparqlJs.AskQuery;
     try {
-      askQuery = parseAskQuery(this.props.query);
+      askQuery = parseAskQuery(props.query);
     } catch (error) {
       this.setState({ loading: false, error });
       return;
@@ -77,8 +88,16 @@ export class SemanticIf extends Component<SemanticIfProps, State> {
 
     const { semanticContext } = this.context;
     this.cancellation.map(SparqlClient.ask(askQuery, { context: semanticContext })).observe({
-      value: (askResult) => this.setState({ loading: false, askResult }),
-      error: (error) => this.setState({ loading: false, error }),
+      value: (askResult) => {
+        if (this.props.query === props.query) {
+          this.setState({ loading: false, askResult });
+        }
+      },
+      error: (error) => {
+        if (this.props.query === props.query) {
+          this.setState({ loading: false, error });
+        }
+      },
     });
   }
 

--- a/src/main/web/components/semantic/conditional/SemanticSwitch.tsx
+++ b/src/main/web/components/semantic/conditional/SemanticSwitch.tsx
@@ -75,9 +75,20 @@ export class SemanticSwitch extends Component<SemanticSwitchProps, State> {
   }
 
   componentDidMount() {
+    this.evaluateQuery(this.props);
+  }
+
+  componentWillReceiveProps(nextProps: SemanticSwitchProps) {
+    if (nextProps.query !== this.props.query) {
+      this.setState({ loading: true, error: undefined, selectedCase: undefined });
+      this.evaluateQuery(nextProps);
+    }
+  }
+
+  private evaluateQuery(props: SemanticSwitchProps) {
     let switchQuery: SparqlJs.SelectQuery;
     try {
-      switchQuery = parseSwitchSelectQuery(this.props.query);
+      switchQuery = parseSwitchSelectQuery(props.query);
     } catch (error) {
       this.setState({ loading: false, error });
       return;
@@ -85,8 +96,16 @@ export class SemanticSwitch extends Component<SemanticSwitchProps, State> {
 
     const { semanticContext } = this.context;
     this.cancellation.map(SparqlClient.select(switchQuery, { context: semanticContext })).observe({
-      value: (result) => this.setResultCase(result),
-      error: (error) => this.setState({ loading: false, error }),
+      value: (result) => {
+        if (this.props.query === props.query) {
+          this.setResultCase(result);
+        }
+      },
+      error: (error) => {
+        if (this.props.query === props.query) {
+          this.setState({ loading: false, error });
+        }
+      },
     });
   }
 

--- a/src/main/web/components/semantic/graph/api/CytoscapeExtension.ts
+++ b/src/main/web/components/semantic/graph/api/CytoscapeExtension.ts
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { assign } from 'lodash';
+import { assign, isEqual } from 'lodash';
 import { Component, ComponentClass } from 'react';
 import * as maybe from 'data.maybe';
 
@@ -79,7 +79,18 @@ export function registerCytoscapeExtension<Options>({
       this.registerExtension(this.props, this.context.cytoscapeApi);
     }
 
+    componentDidUpdate(prevProps: Options) {
+      if (!isEqual(prevProps, this.props)) {
+        this.destroyInstance();
+        this.registerExtension(this.props, this.context.cytoscapeApi);
+      }
+    }
+
     componentWillUnmount() {
+      this.destroyInstance();
+    }
+
+    private destroyInstance() {
       this.state.instance.map((instance) => {
         // for layouts, instance can be actual cytoscape instance
         // we shouldn't destroy it here

--- a/src/main/web/components/text-annotation/components/TextAnnotationWorkspace.tsx
+++ b/src/main/web/components/text-annotation/components/TextAnnotationWorkspace.tsx
@@ -119,6 +119,7 @@ export class TextAnnotationWorkspace extends Component<TextAnnotationWorkspacePr
   };
 
   private readonly cancellation = new Cancellation();
+  private loadingCancellation = this.cancellation.derive();
   private persistingAnnotation = new Cancellation();
 
   private handlers: WorkspaceHandlers;
@@ -165,13 +166,34 @@ export class TextAnnotationWorkspace extends Component<TextAnnotationWorkspacePr
         });
     }
 
+    this.loadDocument();
+  }
+
+  componentDidUpdate(prevProps: TextAnnotationWorkspaceProps) {
+    if (this.props.documentIri !== prevProps.documentIri) {
+      this.loadingCancellation = this.cancellation.deriveAndCancel(this.loadingCancellation);
+      this.setState(
+        {
+          loadingDocument: true,
+          loadingError: undefined,
+          editorState: undefined,
+          highlightedAnnotations: new Set<string>(),
+          focusedAnnotation: undefined,
+          editedAnnotation: undefined,
+        },
+        () => this.loadDocument()
+      );
+    }
+  }
+
+  private loadDocument() {
     const annotationTypes = extractAnnotationTypes(this.props.children);
     const customTabs = this.parseSidebarTabs();
     this.setState({ annotationTypes, customTabs });
 
     const documentIri = Rdf.iri(this.props.documentIri);
 
-    this.cancellation
+    this.loadingCancellation
       .map(
         Kefir.combine({
           document: this.fetchDocument(documentIri),

--- a/src/main/web/components/text-editor/TextEditor.tsx
+++ b/src/main/web/components/text-editor/TextEditor.tsx
@@ -139,6 +139,7 @@ export class TextEditor extends Component<TextEditorProps, TextEditorState> {
   private editorRef: React.RefObject<Editor>;
   private readonly cancellation = new Cancellation();
   private templateSelection = this.cancellation.derive();
+  private documentLoading = this.cancellation.derive();
 
   static defaultProps: Partial<TextEditorProps> = {
     resourceTemplates: [],
@@ -369,10 +370,14 @@ export class TextEditor extends Component<TextEditorProps, TextEditorState> {
   } 
 
   componentDidMount() {
+    this.loadDocument();
+  }
+
+  private loadDocument() {
     if (this.props.documentIri) {
       const documentIri = Rdf.iri(this.props.documentIri);
-      this.cancellation.map(
-        this.fetchDocument(documentIri)        
+      this.documentLoading.map(
+        this.fetchDocument(documentIri)
       ).observe({
         value: this.onDocumentLoad,
         error: error => console.error(error)
@@ -380,7 +385,19 @@ export class TextEditor extends Component<TextEditorProps, TextEditorState> {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: TextEditorProps) {
+    if (this.props.documentIri !== prevProps.documentIri) {
+      this.documentLoading = this.cancellation.deriveAndCancel(this.documentLoading);
+      this.setState(
+        {
+          documentIri: this.props.documentIri,
+          loading: !!this.props.documentIri,
+        },
+        () => this.loadDocument()
+      );
+      return;
+    }
+
     // when slate Value is rendered we need to find top most block for sidebar positioning
 
     const { value, anchorBlock } = this.state;

--- a/src/main/web/components/ui/entity-view/EntityViewSearchResults.tsx
+++ b/src/main/web/components/ui/entity-view/EntityViewSearchResults.tsx
@@ -51,6 +51,23 @@ export class EntityViewSearchResults extends Component<Props, State> {
     }
 
     componentDidMount() {
+        this.buildQueries();
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (
+            this.props.entityIri !== prevProps.entityIri ||
+            this.props.entityViewConfigIri !== prevProps.entityViewConfigIri ||
+            this.props.navigationEntryIri !== prevProps.navigationEntryIri
+        ) {
+            this.setState(
+                { tableQuery: undefined, searchQuery: undefined, entityDomain: undefined, searchConfig: undefined, viewes: undefined },
+                () => this.buildQueries()
+            );
+        }
+    }
+
+    private buildQueries() {
         const entityConfig = entityConfigs[this.props.entityViewConfigIri];
         // table query
 
@@ -160,7 +177,11 @@ export class EntityViewSearchResults extends Component<Props, State> {
 
         new VariableRenameBinder('value', 'subject').query(tableQuery);
 
+      const requestedProps = this.props;
       generateSearchConfigForFields(relatedEntityConfig.facetKps).onValue(res => {
+        if (this.props !== requestedProps) {
+          return;
+        }
         this.setState({
           tableQuery: SparqlUtil.serializeQuery(tableQuery as any),
           searchQuery: SparqlUtil.serializeQuery(tableQuery),

--- a/src/main/web/components/ui/json/json-renderer.tsx
+++ b/src/main/web/components/ui/json/json-renderer.tsx
@@ -66,6 +66,7 @@ interface Props {
  */
 export class GenericJsonRenderer<T> extends Component<Props, State> {
   private readonly cancellation = new Cancellation();
+  private fetching = this.cancellation.derive();
 
   constructor(props: Props, state: State) {
     super(props, state);
@@ -106,8 +107,19 @@ export class GenericJsonRenderer<T> extends Component<Props, State> {
   }
 
   public componentDidMount() {
+    this.fetchData();
+  }
+
+  public componentDidUpdate(prevProps: Props) {
+    if (this.props.getUrl !== prevProps.getUrl) {
+      this.fetching = this.cancellation.deriveAndCancel(this.fetching);
+      this.setState({ isLoading: true, data: undefined, loadingError: undefined }, () => this.fetchData());
+    }
+  }
+
+  private fetchData() {
     const { getUrl } = this.props;
-    this.cancellation.map(GenericRestService.getJson<T[] | T>(getUrl)).observe({
+    this.fetching.map(GenericRestService.getJson<T[] | T>(getUrl)).observe({
       value: (value) => {
         this.setState({
           isLoading: false,

--- a/src/main/web/components/ui/overlay/OverlayDialog.ts
+++ b/src/main/web/components/ui/overlay/OverlayDialog.ts
@@ -155,6 +155,16 @@ export class OverlayComponent extends Component<OverlayComponentProps> {
     }
   }
 
+  componentDidUpdate(prevProps: OverlayComponentProps) {
+    if (this.props.show !== prevProps.show) {
+      if (this.props.show) {
+        this.showDialog();
+      } else {
+        this.onHide();
+      }
+    }
+  }
+
   componentWillUnmount() {
     super.componentWillUnmount();
     this.onHide();

--- a/src/main/web/components/ui/selection/SelectionToggleComponent.tsx
+++ b/src/main/web/components/ui/selection/SelectionToggleComponent.tsx
@@ -54,6 +54,7 @@ interface State {
  */
 class SelectionToggleComponent extends Component<Props, State> {
   private cancellation = new Cancellation();
+  private suppressToggleEvent = false;
 
   static contextTypes = SelectionGroupContextTypes;
   context: SelectionGroupContext;
@@ -71,8 +72,19 @@ class SelectionToggleComponent extends Component<Props, State> {
     }
   }
 
+  componentWillReceiveProps(nextProps: Props) {
+    if (nextProps.tag !== this.props.tag) {
+      this.suppressToggleEvent = true;
+      this.setState({
+        value: this.context.getSelectionValue ? this.context.getSelectionValue(nextProps.tag) : false,
+      });
+    }
+  }
+
   componentDidUpdate(prevProps: Props, prevState: State) {
-    if (this.state.value !== prevState.value) {
+    const suppressed = this.suppressToggleEvent;
+    this.suppressToggleEvent = false;
+    if (this.state.value !== prevState.value && !suppressed) {
       trigger({
         eventType: SelectionEvents.Toggle,
         source: 'SelectionToggle',

--- a/src/main/web/components/ui/template/TemplateItem.ts
+++ b/src/main/web/components/ui/template/TemplateItem.ts
@@ -57,6 +57,8 @@ export class TemplateItem extends Component<TemplateItemProps, State> {
     template: undefined,
   };
 
+  private compileVersion = 0;
+
   constructor(props: TemplateItemProps, context: any) {
     super(props, context);
     this.state = {
@@ -78,9 +80,11 @@ export class TemplateItem extends Component<TemplateItemProps, State> {
     this.compileTemplate(this.props);
   }
 
-  componentWillReceiveProps(props) {
+  componentWillReceiveProps(props, nextContext) {
     if (!templateEqual(props.template, this.props.template)) {
-      this.compileTemplate(props);
+      // use nextContext: this.context still holds the previous captured
+      // context, but the new source may reference the incoming one's keys
+      this.compileTemplate(props, nextContext);
     }
   }
 
@@ -146,21 +150,37 @@ export class TemplateItem extends Component<TemplateItemProps, State> {
     }
   }
 
-  private compileTemplate(props) {
-    const { templateDataContext } = this.context;
+  componentWillUnmount() {
+    super.componentWillUnmount();
+    // prevent setState from compilations resolving after unmount
+    this.compileVersion++;
+  }
+
+  private compileTemplate(props: TemplateItemProps, context: TemplateContext = this.context) {
+    const { templateDataContext } = context;
+    const version = ++this.compileVersion;
 
     const capturer = CapturedContext.inheritAndCapture(templateDataContext);
     this.appliedTemplateScope
       .compile(props.template.source)
-      // parse to react, but do not omit whitespaces
       .then((template) => {
         const renderedHtml = template(props.template.options, { capturer, parentContext: templateDataContext });
-        return ModuleRegistry.parseHtmlToReact(renderedHtml);
-      })
-      .then((parsedTemplate) => {
-        this.setState({ parsedTemplate, capturedContext: capturer.getResult() });
+        if (version !== this.compileVersion) {
+          // a newer compilation has been started in the meantime
+          return;
+        }
+        // parse to react, but do not omit whitespaces
+        return ModuleRegistry.parseHtmlToReact(renderedHtml).then((parsedTemplate) => {
+          if (version !== this.compileVersion) {
+            return;
+          }
+          this.setState({ parsedTemplate, capturedContext: capturer.getResult(), error: undefined });
+        });
       })
       .catch((error) => {
+        if (version !== this.compileVersion) {
+          return;
+        }
         console.error(error);
         this.setState({ error });
       });


### PR DESCRIPTION
# Why

We had a lot of problems with constant re-renderings here and there, especially it was visible in KMs. That is kind of a platform wide fix.

# What

We no generate stable react keys for the whole template sub-trees. 

# Meta

It can have some united consequences and kind of uncover hidden bugs that previously were not visible because something was just always re-rendered, most possible issues is where component doesn't have proper mechanism to react to updated props. I've tried to went with AI over all components to find such cases and there were only a few.